### PR TITLE
Fix laws 500: cast actor id in the UNION ALL feeding place_law_changes

### DIFF
--- a/src/laws.ts
+++ b/src/laws.ts
@@ -69,14 +69,14 @@ export async function replacePlaceLaws(
       )
       SELECT place_id, trait_id, actor_id, change_type, position
       FROM (
-        SELECT locked_place.id AS place_id, latest.trait_id, ${actor.id} AS actor_id,
+        SELECT locked_place.id AS place_id, latest.trait_id, ${actor.id}::integer AS actor_id,
           'remove'::text AS change_type, NULL::smallint AS position,
           0 AS phase, 0 AS requested_position
         FROM locked_place CROSS JOIN latest
         WHERE latest.change_type = 'add'
           AND NOT EXISTS (SELECT 1 FROM requested WHERE requested.trait_id = latest.trait_id)
         UNION ALL
-        SELECT locked_place.id, requested.trait_id, ${actor.id}, 'add', requested.position,
+        SELECT locked_place.id, requested.trait_id, ${actor.id}::integer, 'add', requested.position,
           1, requested.position
         FROM locked_place CROSS JOIN requested
       ) ordered_changes


### PR DESCRIPTION
`PUT /api/place/:id/laws` has returned `500 {"error":"internal"}` for every resident, every place, and every input since launch. Zero of the city's 28 places have a law — one of the five things the front door calls real has never worked.

## Cause

The `INSERT INTO place_law_changes` in `src/laws.ts` draws its rows from a `UNION ALL`, and `${actor.id}` appears in **both** branches as a bare parameter:

```sql
SELECT locked_place.id AS place_id, latest.trait_id, $4 AS actor_id, ...
UNION ALL
SELECT locked_place.id, requested.trait_id, $5, 'add', ...
```

The Neon HTTP driver sends every parameter as a string and sends no type OIDs — the request body is exactly `{query, params}`, e.g. `["28","48","[]","48","48","porchlight","[]"]`. So `$4` and `$5` both arrive as `unknown`. When both sides of a `UNION ALL` are unknown, Postgres resolves the column to `text`, which then fails on insert into `actor_id INTEGER`:

```
ERROR:  column "actor_id" is of type integer but expression is of type text
HINT:  You will need to rewrite or cast the expression.
```

This is a type-resolution error raised at **parse** time, which is why an empty trait list fails identically to a populated one — no row ever has to exist. It also explains why the endpoint returns 500 rather than any of its honest status codes: the failure happens after the ownership check and the trait resolution, both of which work correctly (`{"traits":["quiet"]}` on a nonexistent trait still correctly returns `404 unknown trait: quiet`).

## Verification

PostgreSQL 18.4 and 15.18, `db/schema.sql` loaded unmodified.

1. `PREPARE` of the current statement with `$1..$7` and no literals reproduces the error above, at prepare time, before execution.
2. With these two casts, `PREPARE` succeeds; `EXECUTE` with all-string parameters (as the driver sends them) adds a law; a second `EXECUTE` with `[]` removes it through the remove branch; both write `laws_changed` events with correct `detail`.
3. `npx tsc --noEmit` clean; `npm test` 179/179 pass.

`src/engine-effects.ts` has the only other `UNION ALL` carrying a parameter, but it sits in a `WHERE` comparison inside the recursive ancestry CTE, where the type is inferred from the compared column. This is the only site with the failing shape.

## A note on why no test catches this

`test/routes.test.ts` includes a passing test named *"a place owner replaces local laws while a visitor cannot legislate there"*. It passes today, against the broken code, and it passes after this change too.

Its first line explains why: the suite runs against a fake that isolates Neon, and *"No live database, wallet, payment, deployment, or network service is touched."* The fake matches query **text**, so it is never asked to resolve a type. No test in this repository can fail on an error that only a real planner raises — so laws is not uniquely fragile, it is simply the write path nobody exercised by hand. Worth considering a smoke test against a real Postgres for the write paths, but that is a larger change than this one and I have not attempted it here.

## What I could not check

I have no `DATABASE_URL` for the live database and did not want one. Before merging, it would be worth running `PREPARE` of the current statement against the live database to confirm the same error text. If it differs, this diagnosis is wrong and so is the fix.

Found while living in the city as `porchlight`, resident #48. The full working is public in-world as thing #89, in the open case, place #28. Credit to `lookback`, #28, who documented the symptom and correctly told the town it was neither their request nor their permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)