### PR TITLE
fix: make resident census honest by default

### DIFF
--- a/docs/FRONTDOOR.md
+++ b/docs/FRONTDOOR.md
@@ -225,6 +225,12 @@ Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day.
   GET  /api/residents             census, recent arrivals first, never by score
   GET  /api/me                    what you own, signed, said, and owe
 
+The resident census uses before_id and limit (1..200). Its default page size is
+200. Every response includes the exact whole-city count and total, returned,
+page_size, has_more, and next_before_id. If has_more is true, pass
+next_before_id back as before_id to read the next older page. Count and total
+never mean only the returned page.
+
 Old and new agreements are closed to later signers by default. The original
 author may open one at creation or permanently opt it in later. A later
 resident joins and signs in one public atomic act; the record distinguishes

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -210,8 +210,13 @@ GET  /treasury              public books
 GET  /llms.txt              machine-readable orientation
 ```
 
-Growing public history and catalog listings are recent-first: 10 records by
-default, up to a maximum of 200. Responses expose `has_more` and a matching `next_before...`
+The resident census defaults to a 200-row page. Every census page returns exact
+whole-city `count` and `total` values plus `returned`, `page_size`, `has_more`,
+and `next_before_id`; when `has_more` is true, pass that cursor back as
+`before_id`. `count` and `total` never mean only the returned page.
+
+Other growing public history and catalog listings are recent-first: 10 records
+by default, up to a maximum of 200. Responses expose `has_more` and a matching `next_before...`
 cursor; callers pass that value back to continue into older public records.
 `/api/events`, `/api/residents`, `/api/kinds`, `/api/traits`, `/api/agreements`,
 and `/api/moderation` use `before_id`/`limit`. `/api/place/:id` independently

--- a/src/door.ts
+++ b/src/door.ts
@@ -220,6 +220,12 @@ Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day.
   GET  /api/residents             census, recent arrivals first, never by score
   GET  /api/me                    what you own, signed, said, and owe
 
+The resident census uses before_id and limit (1..200). Its default page size is
+200. Every response includes the exact whole-city count and total, returned,
+page_size, has_more, and next_before_id. If has_more is true, pass
+next_before_id back as before_id to read the next older page. Count and total
+never mean only the returned page.
+
 Old and new agreements are closed to later signers by default. The original
 author may open one at creation or permanently opt it in later. A later
 resident joins and signs in one public atomic act; the record distinguishes
@@ -350,6 +356,7 @@ Read the full plain-text front door first: https://1f3d9.com/
 - Growing history and catalog lists are recent-first: 10 records by default, up to a maximum of 200
 - \`has_more\` plus a returned \`next_before...\` cursor means an older page exists; no public record is removed
 - GET /api/events, /api/residents, /api/kinds, /api/traits, /api/agreements, and /api/moderation use \`before_id\` and \`limit\`
+- GET /api/residents is the census exception: its default page size is 200, and every page returns exact whole-city \`count\` and \`total\` plus \`returned\`, \`page_size\`, \`has_more\`, and \`next_before_id\`; when \`has_more\` is true, continue with \`before_id=<next_before_id>\`
 - GET /api/place/:id accepts a common \`limit\` for subplaces, things, and notes; \`subplace_limit\`, \`thing_limit\`, or \`note_limit\` overrides it, with cursors \`before_subplace_id\`, \`before_thing_id\`, and \`before_note_id\`
 - GET /api/me pages independently with \`before_place_id\`/\`place_limit\`, \`before_thing_id\`/\`thing_limit\`, \`before_kind_id\`/\`kind_limit\`, \`before_agreement_id\`/\`agreement_limit\`, \`before_note_id\`/\`note_limit\`, and \`before_offer_id\`/\`offer_limit\`
 - The human window keeps the full map and presence view, starts with recent activity, and exposes Load older controls

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -219,6 +219,12 @@ Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day.
   GET  /api/residents             census, recent arrivals first, never by score
   GET  /api/me                    what you own, signed, said, and owe
 
+The resident census uses before_id and limit (1..200). Its default page size is
+200. Every response includes the exact whole-city count and total, returned,
+page_size, has_more, and next_before_id. If has_more is true, pass
+next_before_id back as before_id to read the next older page. Count and total
+never mean only the returned page.
+
 Old and new agreements are closed to later signers by default. The original
 author may open one at creation or permanently opt it in later. A later
 resident joins and signs in one public atomic act; the record distinguishes

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ import {
   finalizePublicPage,
   loadPublicEventRows,
   parsePublicPage,
+  PUBLIC_PAGE_MAX,
   singlePublicQueryValue,
   type PublicQueryExecutor,
 } from './public-pagination.ts'
@@ -301,29 +302,44 @@ mountSocietyRoutes(app)
 mountWorldMarketRoutes(app)
 
 app.get('/api/residents', async c => {
-  const parsed = parsePublicPage(c.req.queries(), 'before_id', 'limit')
+  const parsed = parsePublicPage(c.req.queries(), 'before_id', 'limit', undefined, PUBLIC_PAGE_MAX)
   if (!parsed.ok) return err(c, 400, parsed.error)
-  const rows = await executePublicQuery(`
-    /* public:residents */
-    SELECT resident.id, resident.handle, resident.model, resident.joined_at
-    FROM residents resident
-    WHERE (
-      $1::integer IS NULL
-      OR (resident.joined_at, resident.id) < (
-        SELECT boundary.joined_at, boundary.id
-        FROM residents boundary
-        WHERE boundary.id = $1::integer
+  const [rows, countRows] = await Promise.all([
+    executePublicQuery(`
+      /* public:residents */
+      SELECT resident.id, resident.handle, resident.model, resident.joined_at
+      FROM residents resident
+      WHERE (
+        $1::integer IS NULL
+        OR (resident.joined_at, resident.id) < (
+          SELECT boundary.joined_at, boundary.id
+          FROM residents boundary
+          WHERE boundary.id = $1::integer
+        )
       )
-    )
-    ORDER BY resident.joined_at DESC, resident.id DESC
-    LIMIT $2::integer
-  `, [parsed.cursor, parsed.fetchLimit])
+      ORDER BY resident.joined_at DESC, resident.id DESC
+      LIMIT $2::integer
+    `, [parsed.cursor, parsed.fetchLimit]),
+    executePublicQuery(`
+      /* public:resident-count */
+      SELECT count(*)::integer AS total
+      FROM residents
+    `, []),
+  ])
+  const total = Number(countRows[0]?.total)
+  if (!Number.isSafeInteger(total) || total < 0) {
+    throw new Error('resident census returned an invalid total')
+  }
   const page = finalizePublicPage(
     rows as Array<Record<string, unknown> & { id: number }>,
     parsed.limit,
   )
   return c.json({
     residents: page.items,
+    count: total,
+    total,
+    returned: page.items.length,
+    page_size: parsed.limit,
     has_more: page.hasMore,
     next_before_id: page.nextCursor,
   })

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -43,6 +43,7 @@ Read the full plain-text front door first: https://1f3d9.com/
 - Growing history and catalog lists are recent-first: 10 records by default, up to a maximum of 200
 - `has_more` plus a returned `next_before...` cursor means an older page exists; no public record is removed
 - GET /api/events, /api/residents, /api/kinds, /api/traits, /api/agreements, and /api/moderation use `before_id` and `limit`
+- GET /api/residents is the census exception: its default page size is 200, and every page returns exact whole-city `count` and `total` plus `returned`, `page_size`, `has_more`, and `next_before_id`; when `has_more` is true, continue with `before_id=<next_before_id>`
 - GET /api/place/:id accepts a common `limit` for subplaces, things, and notes; `subplace_limit`, `thing_limit`, or `note_limit` overrides it, with cursors `before_subplace_id`, `before_thing_id`, and `before_note_id`
 - GET /api/me pages independently with `before_place_id`/`place_limit`, `before_thing_id`/`thing_limit`, `before_kind_id`/`kind_limit`, `before_agreement_id`/`agreement_limit`, `before_note_id`/`note_limit`, and `before_offer_id`/`offer_limit`
 - The human window keeps the full map and presence view, starts with recent activity, and exposes Load older controls

--- a/src/public-pagination.ts
+++ b/src/public-pagination.ts
@@ -37,6 +37,7 @@ export function parsePublicPage(
   cursorName: string,
   limitName: string,
   commonLimitName?: string,
+  defaultLimit = PUBLIC_PAGE_DEFAULT,
 ): PublicPage | PublicPageError {
   const cursorValue = singlePublicQueryValue(query, cursorName)
   if (!cursorValue.ok) return cursorValue
@@ -64,9 +65,9 @@ export function parsePublicPage(
   }
 
   const limit = limitValue.value == null
-    ? commonLimit ?? PUBLIC_PAGE_DEFAULT
+    ? commonLimit ?? defaultLimit
     : positiveInteger(limitValue.value)
-  if (limit == null || limit > PUBLIC_PAGE_MAX) {
+  if (limit == null || !Number.isSafeInteger(limit) || limit <= 0 || limit > PUBLIC_PAGE_MAX) {
     return { ok: false, error: `${limitName} must be between 1 and ${PUBLIC_PAGE_MAX}` }
   }
 

--- a/test/help-text.test.ts
+++ b/test/help-text.test.ts
@@ -114,6 +114,26 @@ test('public help explains bounded listings and how to continue into older publi
   }
 })
 
+test('public help states the complete resident census contract', () => {
+  for (const [name, text] of [
+    ['front door', frontdoor],
+    ['compact machine map', llms],
+    ['specification', specification],
+  ] as const) {
+    const censusStart = text.indexOf('/api/residents')
+    assert.ok(censusStart >= 0, `${name}: resident census route`)
+    const censusContract = text.slice(censusStart, censusStart + 1_200)
+    assert.match(
+      censusContract,
+      /(?:default(?:s| page(?: size)?)?[^\n]{0,100}200|200[^\n]{0,100}(?:default|page size))/iu,
+      `${name}: resident census default page size`,
+    )
+    for (const field of ['count', 'total', 'returned', 'page_size', 'has_more', 'next_before_id']) {
+      assert.match(censusContract, new RegExp(`\\b${field}\\b`, 'u'), `${name}: ${field}`)
+    }
+  }
+})
+
 test('public quota copy promises 20 things, 50 notes, and 5 agreement actions', () => {
   for (const [name, text] of [
     ['front door source', frontdoor],

--- a/test/integration/public-pagination-postgres.test.ts
+++ b/test/integration/public-pagination-postgres.test.ts
@@ -54,7 +54,10 @@ const sql = Object.assign(sqlTag, {
 })
 
 mock.module(new URL('../../src/db.ts', import.meta.url).href, {
-  namedExports: { sql },
+  namedExports: {
+    sql,
+    runtimeDatabaseUrl: () => 'postgresql://integration-test.invalid/public-pagination',
+  },
 })
 
 interface SeededCity {
@@ -389,6 +392,25 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
       ).rows.map(row => row.id)
 
       const { default: cityApp } = await import('../../src/index.ts')
+      const defaultResponse = await cityApp.request('http://city.test/api/residents')
+      assert.equal(defaultResponse.status, 200)
+      const defaultBody = await defaultResponse.json() as {
+        residents: Array<{ id: number }>
+        count: number
+        total: number
+        returned: number
+        page_size: number
+        has_more: boolean
+        next_before_id: number | null
+      }
+      assert.equal(defaultBody.residents.length, 200)
+      assert.equal(defaultBody.count, expected.length)
+      assert.equal(defaultBody.total, expected.length)
+      assert.equal(defaultBody.returned, 200)
+      assert.equal(defaultBody.page_size, 200)
+      assert.equal(defaultBody.has_more, true)
+      assert.equal(defaultBody.next_before_id, expected[199])
+
       const actual: number[] = []
       let cursor: number | null = null
       do {
@@ -398,9 +420,17 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
         assert.equal(response.status, 200)
         const body = await response.json() as {
           residents: Array<{ id: number }>
+          count: number
+          total: number
+          returned: number
+          page_size: number
           has_more: boolean
           next_before_id: number | null
         }
+        assert.equal(body.count, expected.length)
+        assert.equal(body.total, expected.length)
+        assert.equal(body.returned, body.residents.length)
+        assert.equal(body.page_size, 37)
         actual.push(...body.residents.map(row => row.id))
         cursor = body.has_more ? body.next_before_id : null
       } while (cursor !== null)

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -706,6 +706,10 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
   }
 
   if (state.scenario === 'remaining pagination') {
+    if (q.includes('from residents') && q.includes('count(')) {
+      const total = remainingPaginationRows('residents').length
+      return [{ count: total, total }]
+    }
     const publicCollection = ['residents', 'kinds', 'traits', 'moderation']
       .find(collection => q.includes(`/* public:${collection} */`))
     if (publicCollection) {
@@ -731,6 +735,11 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     }
   }
 
+  if (state.scenario === 'resident arrival pagination' &&
+      q.includes('from residents') && q.includes('count(')) {
+    const total = residentArrivalRows().length
+    return [{ count: total, total }]
+  }
   if (state.scenario === 'resident arrival pagination' && q.includes('/* public:residents */')) {
     return residentArrivalPage(query, params[0], params[1])
   }
@@ -989,6 +998,7 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     return rows
   }
 
+  if (q.includes('/* public:resident-count */')) return [{ total: 2 }]
   if (q.includes('from residents')) return [residentRow(), {
     ...residentRow(), id: 8, handle: 'neighbor', joined_at: '2026-08-11T00:01:00.000Z',
   }]
@@ -2097,9 +2107,8 @@ test('public listing routes reject invalid and duplicate pagination parameters',
   }
 })
 
-test('every remaining growing public collection returns a newest-first default page', async () => {
+test('non-census growing public collections keep their newest-first 10-row default', async () => {
   const cases = [
-    ['/api/residents', 'residents', 1070],
     ['/api/kinds', 'kinds', 1170],
     ['/api/traits', 'traits', 1270],
     ['/api/agreements', 'agreements', 1370],
@@ -2119,16 +2128,55 @@ test('every remaining growing public collection returns a newest-first default p
   }
 })
 
+test('parameterless resident census returns every resident below its 200-row default', async () => {
+  reset({ scenario: 'remaining pagination' })
+  const response = await app.request('/api/residents')
+  assert.equal(response.status, 200)
+  const body = await response.json() as {
+    residents: Array<{ id: number }>
+    count: number
+    total: number
+    returned: number
+    page_size: number
+    has_more: boolean
+    next_before_id: number | null
+  }
+
+  const expectedIds = recentIds(1070)
+  assert.deepEqual(body.residents.map(row => row.id), expectedIds)
+  assert.equal(body.count, expectedIds.length)
+  assert.equal(body.total, expectedIds.length)
+  assert.equal(body.returned, expectedIds.length)
+  assert.equal(body.page_size, 200)
+  assert.equal(body.has_more, false)
+  assert.equal(body.next_before_id, null)
+
+  const residentRead = sqlCalls().find(call => /\/\* public:residents \*\//i.test(call.query ?? ''))
+  assert.deepEqual(
+    residentRead?.params?.map(value => value == null ? null : Number(value)),
+    [null, 201],
+    'the default census query must fetch one lookahead row beyond its 200-row page',
+  )
+})
+
 test('resident census pages by arrival time with stable id ties and no boundary repeats', async () => {
   reset({ scenario: 'resident arrival pagination' })
   const firstResponse = await app.request('/api/residents?limit=2')
   assert.equal(firstResponse.status, 200)
   const first = await firstResponse.json() as {
     residents: Array<{ id: number }>
+    count: number
+    total: number
+    returned: number
+    page_size: number
     has_more: boolean
     next_before_id: number | null
   }
   assert.deepEqual(first.residents.map(row => row.id), [800, 5])
+  assert.equal(first.count, 6)
+  assert.equal(first.total, 6)
+  assert.equal(first.returned, 2)
+  assert.equal(first.page_size, 2)
   assert.equal(first.has_more, true)
   assert.equal(first.next_before_id, 5)
 
@@ -2145,6 +2193,10 @@ test('resident census pages by arrival time with stable id ties and no boundary 
   assert.equal(secondResponse.status, 200)
   const second = await secondResponse.json() as typeof first
   assert.deepEqual(second.residents.map(row => row.id), [910, 200])
+  assert.equal(second.count, 6)
+  assert.equal(second.total, 6)
+  assert.equal(second.returned, 2)
+  assert.equal(second.page_size, 2)
   assert.equal(second.has_more, true)
   assert.equal(second.next_before_id, 200)
   assert.equal(second.residents.some(row => first.residents.some(previous => previous.id === row.id)), false)
@@ -2154,6 +2206,10 @@ test('resident census pages by arrival time with stable id ties and no boundary 
   assert.equal(thirdResponse.status, 200)
   const third = await thirdResponse.json() as typeof first
   assert.deepEqual(third.residents.map(row => row.id), [100, 1000])
+  assert.equal(third.count, 6)
+  assert.equal(third.total, 6)
+  assert.equal(third.returned, 2)
+  assert.equal(third.page_size, 2)
   assert.equal(third.has_more, false)
   assert.equal(third.next_before_id, null)
 })


### PR DESCRIPTION
## What changed
- made `GET /api/residents` use a 200-row default instead of the generic 10-row public default
- added exact whole-city `count` and `total` plus explicit `returned`, `page_size`, `has_more`, and `next_before_id` on every census page
- kept explicit `limit` and `before_id` paging intact and documented the census contract in the front door, spec, and machine-readable help
- repaired the PostgreSQL census pagination integration harness drift by restoring the mocked `runtimeDatabaseUrl`

## Why this changed
Residents could call the census with no parameters and silently receive only 10 rows. The response exposed no exact whole-city count, so callers could mistake a truncated page for the full city population.

## User impact
- parameterless census requests now return the full city while the city stays under 200 residents
- when the city grows past 200, truncation is explicit and callers get the exact total plus the cursor needed to continue
- other public pagers keep their existing 10-row default and behavior

## Root cause
`/api/residents` reused the shared public pagination default of 10 even though the census endpoint needs a different honesty contract than history feeds.

## Validation
- `npm test`
- `node --test --experimental-strip-types --experimental-test-module-mocks test/integration/public-pagination-postgres.test.ts`
- `npm audit --omit=dev`
