### PR TITLE
fix: keep census page and total in one snapshot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -304,9 +304,14 @@ mountWorldMarketRoutes(app)
 app.get('/api/residents', async c => {
   const parsed = parsePublicPage(c.req.queries(), 'before_id', 'limit', undefined, PUBLIC_PAGE_MAX)
   if (!parsed.ok) return err(c, 400, parsed.error)
-  const [rows, countRows] = await Promise.all([
-    executePublicQuery(`
-      /* public:residents */
+  const censusRows = await executePublicQuery(`
+    /* public:residents */
+    SELECT page.id, page.handle, page.model, page.joined_at, census.total
+    FROM (
+      SELECT count(*)::integer AS total
+      FROM residents
+    ) census
+    LEFT JOIN LATERAL (
       SELECT resident.id, resident.handle, resident.model, resident.joined_at
       FROM residents resident
       WHERE (
@@ -319,17 +324,18 @@ app.get('/api/residents', async c => {
       )
       ORDER BY resident.joined_at DESC, resident.id DESC
       LIMIT $2::integer
-    `, [parsed.cursor, parsed.fetchLimit]),
-    executePublicQuery(`
-      /* public:resident-count */
-      SELECT count(*)::integer AS total
-      FROM residents
-    `, []),
-  ])
-  const total = Number(countRows[0]?.total)
+    ) page ON TRUE
+    ORDER BY page.joined_at DESC NULLS LAST, page.id DESC NULLS LAST
+  `, [parsed.cursor, parsed.fetchLimit])
+  const total = Number(censusRows[0]?.total)
   if (!Number.isSafeInteger(total) || total < 0) {
     throw new Error('resident census returned an invalid total')
   }
+  const rows = censusRows.flatMap(row => {
+    if (row.id == null) return []
+    const { total: _total, ...resident } = row
+    return [resident]
+  })
   const page = finalizePublicPage(
     rows as Array<Record<string, unknown> & { id: number }>,
     parsed.limit,

--- a/test/integration/public-pagination-postgres.test.ts
+++ b/test/integration/public-pagination-postgres.test.ts
@@ -392,8 +392,14 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
       ).rows.map(row => row.id)
 
       const { default: cityApp } = await import('../../src/index.ts')
+      const statementsBeforeDefaultCensus = statementCount
       const defaultResponse = await cityApp.request('http://city.test/api/residents')
       assert.equal(defaultResponse.status, 200)
+      assert.equal(
+        statementCount - statementsBeforeDefaultCensus,
+        1,
+        'the census page and exact total must come from one PostgreSQL statement',
+      )
       const defaultBody = await defaultResponse.json() as {
         residents: Array<{ id: number }>
         count: number
@@ -438,6 +444,19 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
       assert.deepEqual(actual, expected)
       assert.deepEqual(actual.slice(0, 3), [3, 2, 1], 'joined_at wins; id only breaks ties')
       assert.equal(new Set(actual).size, actual.length, 'page boundaries must not repeat residents')
+
+      const exhaustedResponse = await cityApp.request(
+        `http://city.test/api/residents?limit=37&before_id=${expected.at(-1)}`,
+      )
+      assert.equal(exhaustedResponse.status, 200)
+      const exhausted = await exhaustedResponse.json() as typeof defaultBody
+      assert.deepEqual(exhausted.residents, [])
+      assert.equal(exhausted.count, expected.length)
+      assert.equal(exhausted.total, expected.length)
+      assert.equal(exhausted.returned, 0)
+      assert.equal(exhausted.page_size, 37)
+      assert.equal(exhausted.has_more, false)
+      assert.equal(exhausted.next_before_id, null)
     })
 
     await t.test('the window bounds history but keeps the complete map and presence', async () => {

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -706,11 +706,12 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
   }
 
   if (state.scenario === 'remaining pagination') {
-    if (q.includes('from residents') && q.includes('count(')) {
+    if (q.includes('/* public:residents */')) {
       const total = remainingPaginationRows('residents').length
-      return [{ count: total, total }]
+      const page = descendingPage(remainingPaginationRows('residents'), params[0], params[1])
+      return page.length > 0 ? page.map(row => ({ ...row, total })) : [{ total }]
     }
-    const publicCollection = ['residents', 'kinds', 'traits', 'moderation']
+    const publicCollection = ['kinds', 'traits', 'moderation']
       .find(collection => q.includes(`/* public:${collection} */`))
     if (publicCollection) {
       return descendingPage(remainingPaginationRows(publicCollection), params[0], params[1])
@@ -735,13 +736,10 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     }
   }
 
-  if (state.scenario === 'resident arrival pagination' &&
-      q.includes('from residents') && q.includes('count(')) {
-    const total = residentArrivalRows().length
-    return [{ count: total, total }]
-  }
   if (state.scenario === 'resident arrival pagination' && q.includes('/* public:residents */')) {
-    return residentArrivalPage(query, params[0], params[1])
+    const total = residentArrivalRows().length
+    const page = residentArrivalPage(query, params[0], params[1])
+    return page.length > 0 ? page.map(row => ({ ...row, total })) : [{ total }]
   }
 
   if (state.scenario === 'public pagination' && q.includes('from places p') && q.includes('where p.parent_id')) {
@@ -998,7 +996,9 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     return rows
   }
 
-  if (q.includes('/* public:resident-count */')) return [{ total: 2 }]
+  if (q.includes('/* public:residents */')) return [residentRow(), {
+    ...residentRow(), id: 8, handle: 'neighbor', joined_at: '2026-08-11T00:01:00.000Z',
+  }].map(row => ({ ...row, total: 2 }))
   if (q.includes('from residents')) return [residentRow(), {
     ...residentRow(), id: 8, handle: 'neighbor', joined_at: '2026-08-11T00:01:00.000Z',
   }]
@@ -2157,6 +2157,12 @@ test('parameterless resident census returns every resident below its 200-row def
     [null, 201],
     'the default census query must fetch one lookahead row beyond its 200-row page',
   )
+  const censusReads = sqlCalls().filter(call => (
+    /\/\* public:residents \*\//i.test(call.query ?? '')
+      || /\/\* public:resident-count \*\//i.test(call.query ?? '')
+  ))
+  assert.equal(censusReads.length, 1, 'the census page and total must share one database snapshot')
+  assert.match(censusReads[0]?.query ?? '', /count\s*\(\s*\*\s*\)/i)
 })
 
 test('resident census pages by arrival time with stable id ties and no boundary repeats', async () => {
@@ -2212,6 +2218,17 @@ test('resident census pages by arrival time with stable id ties and no boundary 
   assert.equal(third.page_size, 2)
   assert.equal(third.has_more, false)
   assert.equal(third.next_before_id, null)
+
+  const emptyResponse = await app.request('/api/residents?limit=2&before_id=1000')
+  assert.equal(emptyResponse.status, 200)
+  const empty = await emptyResponse.json() as typeof first
+  assert.deepEqual(empty.residents, [])
+  assert.equal(empty.count, 6)
+  assert.equal(empty.total, 6)
+  assert.equal(empty.returned, 0)
+  assert.equal(empty.page_size, 2)
+  assert.equal(empty.has_more, false)
+  assert.equal(empty.next_before_id, null)
 })
 
 test('public collection cursors preserve agreement filters and never repeat the boundary', async () => {


### PR DESCRIPTION
## What changed
- read the resident page and exact city total in one PostgreSQL statement
- keep the bounded keyset page and exact `count`/`total` contract unchanged
- preserve exact totals even when a caller requests a page past the oldest resident

## Why
PR #18 used two concurrent statements, so a registration between them could make one response combine a page from one database snapshot with a total from another.

## Impact
Every census response is now internally consistent while retaining the live 200-row default, explicit pagination metadata, and existing input validation.

## Validation
- 348/348 unit tests pass
- 91.43% line coverage
- real PostgreSQL pagination suite passes, including an exhausted cursor
- typecheck passes
- npm audit reports 0 vulnerabilities
- independent correctness and SQL reviews completed

## Known unrelated harness failure
The full PostgreSQL command still reaches the stale `world-postgres` fixture, which creates an ordinary parentless place and is rejected by the world-root topology. This PR does not touch that fixture.