### PR TITLE
fix: fail closed for preview database selection

### DIFF
--- a/docs/HOSTED_CHAT_SIGNIN.md
+++ b/docs/HOSTED_CHAT_SIGNIN.md
@@ -151,11 +151,12 @@ Production migration and application deployment are separate commands. The relea
 process must never run an automatic production migration as a side effect of deploying
 the application.
 
-For a Vercel preview, set `HOSTED_CHAT_PREVIEW_DATABASE_URL` as a Preview-only
-sensitive variable pointing to the pooled runtime URL for that isolated branch. An
-enabled Vercel preview refuses database work if this dedicated value is missing, even
-when a general `DATABASE_URL` exists. Production and development always ignore this
-preview-only override.
+For every Vercel preview, set `HOSTED_CHAT_PREVIEW_DATABASE_URL` as a Preview-only
+sensitive variable pointing to the pooled runtime URL for that isolated branch. Every
+preview refuses database work if this dedicated value is missing or blank, regardless
+of whether hosted-chat sign-in is enabled and even when a general `DATABASE_URL`
+exists. Scope `DATABASE_URL` to Production only. Production and development always
+ignore the preview-only override.
 
 ### Guarded migration commands
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -10,9 +10,7 @@ export function runtimeDatabaseUrl(environment: DatabaseEnvironment = process.en
   const previewOverride = environment.HOSTED_CHAT_PREVIEW_DATABASE_URL?.trim()
   if (environment.VERCEL_ENV === 'preview') {
     if (previewOverride) return previewOverride
-    if (environment.HOSTED_CHAT_SIGNIN_ENABLED === 'true') {
-      throw new Error(DATABASE_UNAVAILABLE)
-    }
+    throw new Error(DATABASE_UNAVAILABLE)
   }
   const url = environment.DATABASE_URL?.trim()
   if (!url) throw new Error(DATABASE_UNAVAILABLE)

--- a/test/runtime-db-url.test.ts
+++ b/test/runtime-db-url.test.ts
@@ -4,24 +4,17 @@ import { runtimeDatabaseUrl } from '../src/db.ts'
 
 const live = 'postgresql://live.example.test/city'
 const preview = 'postgresql://preview.example.test/city'
+const previewFeatureStates = [undefined, 'false', 'true'] as const
 
-test('an enabled Vercel preview must use its dedicated isolated database', () => {
-  assert.equal(runtimeDatabaseUrl({
-    VERCEL_ENV: 'preview',
-    HOSTED_CHAT_SIGNIN_ENABLED: 'true',
-    HOSTED_CHAT_PREVIEW_DATABASE_URL: preview,
-    DATABASE_URL: live,
-  }), preview)
-
-  assert.throws(() => runtimeDatabaseUrl({
-    VERCEL_ENV: 'preview',
-    HOSTED_CHAT_SIGNIN_ENABLED: 'true',
-    DATABASE_URL: live,
-  }), (error: unknown) => (
-    error instanceof Error
-    && error.message === 'database is temporarily unavailable'
-    && !/HOSTED_CHAT_PREVIEW_DATABASE_URL|DATABASE_URL/u.test(error.message)
-  ))
+test('every Vercel preview uses its dedicated isolated database', () => {
+  for (const hostedChatSigninEnabled of previewFeatureStates) {
+    assert.equal(runtimeDatabaseUrl({
+      VERCEL_ENV: 'preview',
+      HOSTED_CHAT_SIGNIN_ENABLED: hostedChatSigninEnabled,
+      HOSTED_CHAT_PREVIEW_DATABASE_URL: preview,
+      DATABASE_URL: live,
+    }), preview)
+  }
 })
 
 test('production and development can never select the preview override', () => {
@@ -35,18 +28,21 @@ test('production and development can never select the preview override', () => {
   }
 })
 
-test('an ordinary preview uses the isolated override when present and otherwise keeps legacy behavior', () => {
-  assert.equal(runtimeDatabaseUrl({
-    VERCEL_ENV: 'preview',
-    HOSTED_CHAT_SIGNIN_ENABLED: 'false',
-    HOSTED_CHAT_PREVIEW_DATABASE_URL: preview,
-    DATABASE_URL: live,
-  }), preview)
-  assert.equal(runtimeDatabaseUrl({
-    VERCEL_ENV: 'preview',
-    HOSTED_CHAT_SIGNIN_ENABLED: 'false',
-    DATABASE_URL: live,
-  }), live)
+test('every Vercel preview fails closed without a non-empty dedicated database', () => {
+  for (const hostedChatSigninEnabled of previewFeatureStates) {
+    for (const previewDatabaseUrl of [undefined, '   ']) {
+      assert.throws(() => runtimeDatabaseUrl({
+        VERCEL_ENV: 'preview',
+        HOSTED_CHAT_SIGNIN_ENABLED: hostedChatSigninEnabled,
+        HOSTED_CHAT_PREVIEW_DATABASE_URL: previewDatabaseUrl,
+        DATABASE_URL: live,
+      }), (error: unknown) => (
+        error instanceof Error
+        && error.message === 'database is temporarily unavailable'
+        && !/HOSTED_CHAT_PREVIEW_DATABASE_URL|DATABASE_URL/u.test(error.message)
+      ))
+    }
+  }
 })
 
 test('missing database configuration still fails closed', () => {


### PR DESCRIPTION
## Summary
- fail closed for every Vercel preview without a dedicated preview database URL
- update the runtime DB test to cover all preview feature-flag states
- document the preview-only database requirement in the hosted-chat contract

## Verification
- node --test --experimental-strip-types test/runtime-db-url.test.ts
- scripts/deploy.sh --prepare
