### PR TITLE
docs: define shared preview database lifecycle

### DIFF
--- a/docs/HOSTED_CHAT_SIGNIN.md
+++ b/docs/HOSTED_CHAT_SIGNIN.md
@@ -158,6 +158,12 @@ of whether hosted-chat sign-in is enabled and even when a general `DATABASE_URL`
 exists. Scope `DATABASE_URL` to Production only. Production and development always
 ignore the preview-only override.
 
+The shared Neon branch `preview/shared-vercel-testing` intentionally has no
+expiration so multi-week work and future preview testing are not interrupted. Keep it
+while Preview remains an ongoing test environment. If Preview database access is no
+longer needed, remove `HOSTED_CHAT_PREVIEW_DATABASE_URL` from Vercel Preview first,
+then delete the Neon branch. Never replace it with the production database URL.
+
 ### Guarded migration commands
 
 Preview migration requires the exact acknowledgement


### PR DESCRIPTION
## What changed

- Documents `preview/shared-vercel-testing` as the shared non-production database for Vercel Preview.
- Records that the branch intentionally has no expiration while Preview remains an ongoing test environment.
- Defines safe cleanup order: remove the Vercel Preview variable first, then delete the Neon branch; never substitute the production database.

## Why

Wave 1 payment work will run longer than seven days, and future preview testing may continue indefinitely. The shared preview database must not disappear mid-work.

## Live provider state

- Neon branch `br-square-violet-avqgjmfj` is non-primary, parented to production `main`, named `preview/shared-vercel-testing`, and has no expiration.
- Vercel's sensitive `HOSTED_CHAT_PREVIEW_DATABASE_URL` Preview variable has been refreshed from that branch's pooled URL.

## Checks

- `node --test --experimental-strip-types test/runtime-db-url.test.ts` — 4/4 passed
- `npm run typecheck` — passed
- ECC pre-push gate — 390/390 tests passed