### PR TITLE
fix: repair Wave 1 identity and payment flows

### DIFF
--- a/db/migrations/20260816_payment_response_replay.sql
+++ b/db/migrations/20260816_payment_response_replay.sql
@@ -1,0 +1,116 @@
+-- Once captured, the facilitator response cannot be replaced or removed.
+CREATE OR REPLACE FUNCTION protect_payment_attempt_history() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'payment attempt history cannot be deleted' USING ERRCODE = '55000';
+  END IF;
+
+  IF ROW(
+    NEW.public_id, NEW.actor_id, NEW.counterparty_id, NEW.operation,
+    NEW.target_key, NEW.offer_id, NEW.asset_type, NEW.asset_id,
+    NEW.request_hash, NEW.request_json, NEW.method, NEW.network, NEW.token,
+    NEW.payer_wallet, NEW.payee_wallet, NEW.amount_units, NEW.x402_nonce,
+    NEW.x402_payload_digest, NEW.x402_valid_after, NEW.x402_valid_before,
+    NEW.start_block, NEW.start_time, NEW.end_time, NEW.created_at
+  ) IS DISTINCT FROM ROW(
+    OLD.public_id, OLD.actor_id, OLD.counterparty_id, OLD.operation,
+    OLD.target_key, OLD.offer_id, OLD.asset_type, OLD.asset_id,
+    OLD.request_hash, OLD.request_json, OLD.method, OLD.network, OLD.token,
+    OLD.payer_wallet, OLD.payee_wallet, OLD.amount_units, OLD.x402_nonce,
+    OLD.x402_payload_digest, OLD.x402_valid_after, OLD.x402_valid_before,
+    OLD.start_block, OLD.start_time, OLD.end_time, OLD.created_at
+  ) THEN
+    RAISE EXCEPTION 'payment attempt terms are immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.tx_hash IS NOT NULL AND NEW.tx_hash IS DISTINCT FROM OLD.tx_hash THEN
+    RAISE EXCEPTION 'payment attempt transaction is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.finalized_block_number IS NOT NULL AND ROW(
+    NEW.finalized_block_number, NEW.finalized_block_hash,
+    NEW.finalized_block_time, NEW.finalized_at
+  ) IS DISTINCT FROM ROW(
+    OLD.finalized_block_number, OLD.finalized_block_hash,
+    OLD.finalized_block_time, OLD.finalized_at
+  ) THEN
+    RAISE EXCEPTION 'payment attempt finality is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' IS NOT NULL
+    AND NEW.response_json #>> '{__1f3d9_x402_response_v1,header}' IS DISTINCT FROM
+      OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' THEN
+    RAISE EXCEPTION 'payment facilitator response is immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status IN ('completed', 'invalid', 'expired', 'legacy_completed')
+    AND NEW IS DISTINCT FROM OLD THEN
+    RAISE EXCEPTION 'terminal payment attempt is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF NOT (
+    (OLD.status = 'settling' AND NEW.status IN (
+      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review'
+    ))
+    OR (OLD.status = 'payment_pending' AND NEW.status IN (
+      'payment_pending', 'completed', 'invalid', 'needs_review'
+    ))
+    OR (OLD.status = 'needs_review' AND NEW.status IN (
+      'needs_review', 'payment_pending', 'completed', 'invalid'
+    ))
+    OR (OLD.status = NEW.status)
+  ) THEN
+    RAISE EXCEPTION 'invalid payment attempt transition' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.updated_at < OLD.updated_at THEN
+    RAISE EXCEPTION 'payment attempt update time cannot move backward' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END
+$$;
+
+-- Preserve the exact X-PAYMENT-RESPONSE bytes already held in response_json
+-- when an existing durable payment attempt becomes complete.
+CREATE OR REPLACE FUNCTION complete_payment_attempt(
+  attempt_id TEXT,
+  expected_lease_owner TEXT,
+  completion_result JSONB,
+  completion_response_status SMALLINT,
+  completion_response JSONB
+) RETURNS payment_attempts LANGUAGE plpgsql AS $$
+DECLARE
+  completed payment_attempts%ROWTYPE;
+BEGIN
+  UPDATE payment_attempts
+  SET status = 'completed',
+    result_json = completion_result,
+    response_status = completion_response_status,
+    response_json = CASE
+      WHEN response_json #>> '{__1f3d9_x402_response_v1,header}' IS NULL
+        THEN completion_response
+      ELSE jsonb_build_object(
+        '__1f3d9_x402_response_v1',
+        jsonb_build_object(
+          'header', response_json #>> '{__1f3d9_x402_response_v1,header}',
+          'body', completion_response
+        )
+      )
+    END,
+    completed_at = clock_timestamp(),
+    lease_owner = NULL,
+    lease_expires_at = NULL,
+    updated_at = clock_timestamp()
+  WHERE public_id = attempt_id
+    AND lease_owner = expected_lease_owner
+    AND status = 'payment_pending'
+    AND tx_hash IS NOT NULL
+    AND finalized_block_number IS NOT NULL
+    AND finalized_block_hash IS NOT NULL
+    AND finalized_block_time IS NOT NULL
+    AND finalized_at IS NOT NULL
+    AND jsonb_typeof(completion_response) = 'object'
+  RETURNING * INTO completed;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'finalized payment attempt is not owned by this completion'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN completed;
+END
+$$;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1791,6 +1791,11 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'payment attempt finality is immutable' USING ERRCODE = '55000';
   END IF;
+  IF OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' IS NOT NULL
+    AND NEW.response_json #>> '{__1f3d9_x402_response_v1,header}' IS DISTINCT FROM
+      OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' THEN
+    RAISE EXCEPTION 'payment facilitator response is immutable' USING ERRCODE = '55000';
+  END IF;
 
   IF OLD.status IN ('completed', 'invalid', 'expired', 'legacy_completed')
     AND NEW IS DISTINCT FROM OLD THEN
@@ -1834,7 +1839,17 @@ BEGIN
   SET status = 'completed',
     result_json = completion_result,
     response_status = completion_response_status,
-    response_json = completion_response,
+    response_json = CASE
+      WHEN response_json #>> '{__1f3d9_x402_response_v1,header}' IS NULL
+        THEN completion_response
+      ELSE jsonb_build_object(
+        '__1f3d9_x402_response_v1',
+        jsonb_build_object(
+          'header', response_json #>> '{__1f3d9_x402_response_v1,header}',
+          'body', completion_response
+        )
+      )
+    END,
     completed_at = clock_timestamp(),
     lease_owner = NULL,
     lease_expires_at = NULL,
@@ -1847,6 +1862,7 @@ BEGIN
     AND finalized_block_hash IS NOT NULL
     AND finalized_block_time IS NOT NULL
     AND finalized_at IS NOT NULL
+    AND jsonb_typeof(completion_response) = 'object'
   RETURNING * INTO completed;
   IF NOT FOUND THEN
     RAISE EXCEPTION 'finalized payment attempt is not owned by this completion'

--- a/e2e/oauth-signin.spec.ts
+++ b/e2e/oauth-signin.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
 const existingResidentKey = `1f3d9_sk_${'ab'.repeat(24)}`
+const recoveryResidentKey = `1f3d9_sk_${'cd'.repeat(24)}`
 const challenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
 const state = 'browser-client-state'
 const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
@@ -103,6 +104,24 @@ async function callMeTool(page: Page, endpoint: '/mcp' | '/mcp/connect', accessT
   })
 }
 
+async function withStrippedBrowserHeaders(page: Page, path: string, action: () => Promise<void>) {
+  await page.route(`**${path}`, async route => {
+    if (route.request().method() !== 'POST') {
+      await route.continue()
+      return
+    }
+    const headers = { ...route.request().headers() }
+    delete headers.origin
+    delete headers.referer
+    await route.continue({ headers })
+  })
+  try {
+    await action()
+  } finally {
+    await page.unroute(`**${path}`)
+  }
+}
+
 test('shows a clear consent page without exposing a resident key', async ({ page }) => {
   const response = await page.goto(authorizationPath())
 
@@ -188,9 +207,60 @@ test('shows a new resident key once and waits for saved confirmation', async ({ 
   await expectNoResidentKeyOutsidePage(page, residentKey)
 })
 
-test('rotates a resident key only after the private replacement is re-entered', async ({ page, baseURL }) => {
-  const trustedOrigin = new URL(baseURL!).origin
-  await page.setExtraHTTPHeaders({ origin: trustedOrigin })
+test('joins through the first-party page and the generated root key works', async ({ page }) => {
+  const response = await page.goto('/join')
+  await expect(page.getByRole('heading', { name: 'Move into 1F3D9' })).toBeVisible()
+  expect(response?.headers()['cache-control']).toContain('no-store')
+  expect(response?.headers()['referrer-policy']).toBe('same-origin')
+
+  await page.getByLabel('City name').fill('standalone-browser')
+  await page.getByLabel('Model label (optional)').fill('browser-test-model')
+  await page.getByRole('button', { name: 'Show the new resident key' }).click()
+  await expect(page.getByRole('heading', { name: "Save standalone-browser's resident key" })).toBeVisible()
+  const residentKey = (await page.locator('code').textContent())?.trim() ?? ''
+  expect(/^1f3d9_sk_[0-9a-f]{48}$/.test(residentKey)).toBe(true)
+  await expectNoResidentKeyOutsidePage(page, residentKey)
+
+  await page.getByLabel('Re-enter the saved resident key').fill(residentKey)
+  await page.getByRole('button', { name: 'Create this resident' }).click()
+  await expect(page.getByRole('heading', { name: 'standalone-browser now lives in 1F3D9' })).toBeVisible()
+  expect((await page.content()).includes(residentKey)).toBe(false)
+
+  await page.goto('/rotate')
+  await page.getByLabel('Current resident key').fill(residentKey)
+  await page.getByRole('button', { name: 'Show a replacement key' }).click()
+  await expect(page.getByRole('heading', { name: "Save standalone-browser's replacement key" })).toBeVisible()
+  await page.getByRole('button', { name: 'Cancel and keep the current key' }).click()
+  await expect(page.getByRole('heading', { name: 'Rotation canceled' })).toBeVisible()
+})
+
+test('identity pages still work when mobile browsers strip Origin and Referer on submit', async ({ page }) => {
+  await page.goto('/join')
+  await page.getByLabel('City name').fill('mobile-header-join')
+  await page.getByLabel('Model label (optional)').fill('browser-test-model')
+  await withStrippedBrowserHeaders(page, '/join', async () => {
+    await page.getByRole('button', { name: 'Show the new resident key' }).click()
+  })
+  await expect(page.getByRole('heading', { name: "Save mobile-header-join's resident key" })).toBeVisible()
+  const joinedKey = (await page.locator('code').textContent())?.trim() ?? ''
+  expect(/^1f3d9_sk_[0-9a-f]{48}$/.test(joinedKey)).toBe(true)
+
+  await page.goto('/rotate')
+  await page.getByLabel('Current resident key').fill(existingResidentKey)
+  await withStrippedBrowserHeaders(page, '/rotate', async () => {
+    await page.getByRole('button', { name: 'Show a replacement key' }).click()
+  })
+  await expect(page.getByRole('heading', { name: "Save browser-resident's replacement key" })).toBeVisible()
+
+  await page.goto('/recovery')
+  await page.getByLabel('Current resident key').fill(recoveryResidentKey)
+  await withStrippedBrowserHeaders(page, '/recovery', async () => {
+    await page.getByRole('button', { name: 'Create recovery codes' }).click()
+  })
+  await expect(page.getByRole('heading', { name: "Save recovery-browser's recovery codes" })).toBeVisible()
+})
+
+test('rotates a resident key only after the private replacement is re-entered', async ({ page }) => {
   const response = await page.goto('/rotate')
   await expect(page.getByRole('heading', { name: 'Rotate a resident key' })).toBeVisible()
   expect(response?.headers()['cache-control']).toContain('no-store')
@@ -209,6 +279,46 @@ test('rotates a resident key only after the private replacement is re-entered', 
   await expect(page.getByRole('heading', { name: "browser-resident's key is rotated" })).toBeVisible()
   expect((await page.content()).includes(replacementKey)).toBe(false)
   await expectNoResidentKeyOutsidePage(page, replacementKey)
+})
+
+test('generated recovery codes replace a lost key once and revoke the old key and siblings', async ({ page }) => {
+  const response = await page.goto('/recovery')
+  await expect(page.getByRole('heading', { name: 'Resident-key recovery' })).toBeVisible()
+  expect(response?.headers()['cache-control']).toContain('no-store')
+  expect(response?.headers()['referrer-policy']).toBe('same-origin')
+
+  await page.getByLabel('Current resident key').fill(recoveryResidentKey)
+  await page.getByRole('button', { name: 'Create recovery codes' }).click()
+  await expect(page.getByRole('heading', { name: "Save recovery-browser's recovery codes" })).toBeVisible()
+  const codes = (await page.locator('code').allTextContents()).map(code => code.trim())
+  expect(codes).toHaveLength(8)
+  expect(new Set(codes).size).toBe(8)
+  expect(codes.every(code => /^1f3d9_rc_[0-9a-f]{64}$/.test(code))).toBe(true)
+
+  await page.goto('/recovery')
+  await page.getByLabel('Unused recovery code').fill(codes[0]!)
+  await page.getByRole('button', { name: 'Show a replacement key' }).click()
+  await expect(page.getByRole('heading', { name: "Save recovery-browser's replacement key" })).toBeVisible()
+  const replacementKey = (await page.locator('code').textContent())?.trim() ?? ''
+  expect(/^1f3d9_sk_[0-9a-f]{48}$/.test(replacementKey)).toBe(true)
+  await page.getByLabel('Re-enter the replacement resident key').fill(replacementKey)
+  await page.getByRole('button', { name: 'Replace the lost key' }).click()
+  await expect(page.getByRole('heading', { name: 'recovery-browser is recovered' })).toBeVisible()
+
+  await page.goto('/rotate')
+  await page.getByLabel('Current resident key').fill(recoveryResidentKey)
+  await page.getByRole('button', { name: 'Show a replacement key' }).click()
+  await expect(page.getByRole('heading', { name: 'Request stopped' })).toBeVisible()
+
+  await page.goto('/rotate')
+  await page.getByLabel('Current resident key').fill(replacementKey)
+  await page.getByRole('button', { name: 'Show a replacement key' }).click()
+  await expect(page.getByRole('heading', { name: "Save recovery-browser's replacement key" })).toBeVisible()
+
+  await page.goto('/recovery')
+  await page.getByLabel('Unused recovery code').fill(codes[1]!)
+  await page.getByRole('button', { name: 'Show a replacement key' }).click()
+  await expect(page.getByRole('heading', { name: 'Request stopped' })).toBeVisible()
 })
 
 test('stops a form whose CSRF proof was changed in the browser', async ({ page }) => {

--- a/e2e/oauth-test-server.ts
+++ b/e2e/oauth-test-server.ts
@@ -28,6 +28,7 @@ const port = Number(process.env.E2E_PORT ?? 41_739)
 const origin = `https://127.0.0.1:${port}`
 const callbackUri = `https://localhost:${port}/oauth/callback`
 const existingResidentKey = `1f3d9_sk_${'ab'.repeat(24)}`
+const recoveryResidentKey = `1f3d9_sk_${'cd'.repeat(24)}`
 const placeDescription = 'A quiet test square with a brass observatory window.'
 const noteExcerpt = 'The public note begins here'
 const noteFull = `${noteExcerpt}, then continues beyond the snapshot excerpt.`
@@ -398,6 +399,7 @@ function makeCertificate(): { key: string; cert: string } {
 
 const environment = {
   HOSTED_CHAT_SIGNIN_ENABLED: 'true',
+  IDENTITY_RECOVERY_ENABLED: 'true',
   IDENTITY_ROTATION_ENABLED: 'true',
   PUBLIC_ORIGIN: origin,
   VERCEL: '1',
@@ -413,48 +415,181 @@ process.env.PUBLIC_ORIGIN = origin
 
 const app = new Hono()
 const store = makeMemoryStore()
-let currentIdentitySecretHash = sha256(existingResidentKey)
-let stagedRotation: {
+type TestIdentityResident = Readonly<{
+  id: number
+  handle: string
+  secretHash: string
+  generation: number
+}>
+type StagedIdentityChange = Readonly<{
   readonly sessionHash: string
   readonly csrfHash: string
   readonly replacementSecretHash: string
-} | null = null
+  readonly residentId: number
+}>
+
+let identityResidents = new Map<number, TestIdentityResident>([
+  [49, { id: 49, handle: 'browser-resident', secretHash: sha256(existingResidentKey), generation: 0 }],
+  [50, { id: 50, handle: 'recovery-browser', secretHash: sha256(recoveryResidentKey), generation: 0 }],
+])
+let stagedRegistrations = new Map<string, Readonly<{
+  csrfHash: string
+  handle: string
+  model: string
+  residentSecretHash: string
+}>>()
+let recoveryCodes = new Map<string, Readonly<{
+  residentId: number
+  generation: number
+  used: boolean
+}>>()
+let stagedRecoveries = new Map<string, StagedIdentityChange & Readonly<{ recoveryCodeHash: string }>>()
+let stagedRotations = new Map<string, StagedIdentityChange>()
+let nextIdentityResidentId = 200
+
+const identityResidentForSecret = (secretHash: string): TestIdentityResident | null =>
+  [...identityResidents.values()].find(resident => resident.secretHash === secretHash) ?? null
+
+const deleteMapKey = <K, V>(source: ReadonlyMap<K, V>, key: K): Map<K, V> => {
+  const next = new Map(source)
+  next.delete(key)
+  return next
+}
+
+const deleteResidentRecoveryCodes = (residentId: number): Map<string, Readonly<{
+  residentId: number
+  generation: number
+  used: boolean
+}>> => new Map([...recoveryCodes].filter(([, code]) => code.residentId !== residentId))
+
 mountIdentityRoutes(app, {
   environment,
   store: {
     consumeIdentityRateLimit: async () => true,
-    stageResidentRegistration: async () => null,
-    confirmResidentRegistration: async () => null,
-    cancelResidentRegistration: async () => false,
-    generateRecoveryCodes: async () => null,
-    stageRootRecovery: async () => null,
-    confirmRootRecovery: async () => null,
-    cancelRootRecovery: async () => false,
-    stageRootRotation: async input => {
-      if (input.residentSecretHash !== currentIdentitySecretHash || stagedRotation) return null
-      stagedRotation = {
+    stageResidentRegistration: async input => {
+      if (stagedRegistrations.has(input.sessionHash)) return null
+      if ([...identityResidents.values()].some(resident => resident.handle === input.handle)) {
+        return { status: 'handle_taken' }
+      }
+      stagedRegistrations = new Map(stagedRegistrations).set(input.sessionHash, {
+        csrfHash: input.csrfHash,
+        handle: input.handle,
+        model: input.model,
+        residentSecretHash: input.residentSecretHash,
+      })
+      return { status: 'staged', handle: input.handle }
+    },
+    confirmResidentRegistration: async input => {
+      const staged = stagedRegistrations.get(input.sessionHash)
+      if (
+        !staged || staged.csrfHash !== input.csrfHash ||
+        staged.residentSecretHash !== input.residentSecretHash ||
+        [...identityResidents.values()].some(resident => resident.handle === staged.handle)
+      ) return null
+      const resident = {
+        id: nextIdentityResidentId++,
+        handle: staged.handle,
+        secretHash: input.residentSecretHash,
+        generation: 0,
+      }
+      identityResidents = new Map(identityResidents).set(resident.id, resident)
+      stagedRegistrations = deleteMapKey(stagedRegistrations, input.sessionHash)
+      return { residentId: resident.id, handle: resident.handle }
+    },
+    cancelResidentRegistration: async input => {
+      const staged = stagedRegistrations.get(input.sessionHash)
+      if (!staged || staged.csrfHash !== input.csrfHash) return false
+      stagedRegistrations = deleteMapKey(stagedRegistrations, input.sessionHash)
+      return true
+    },
+    generateRecoveryCodes: async input => {
+      const resident = identityResidentForSecret(input.residentSecretHash)
+      if (!resident) return null
+      const generation = resident.generation + 1
+      identityResidents = new Map(identityResidents).set(resident.id, { ...resident, generation })
+      const nextCodes = deleteResidentRecoveryCodes(resident.id)
+      for (const codeHash of input.codeHashes) {
+        nextCodes.set(codeHash, { residentId: resident.id, generation, used: false })
+      }
+      recoveryCodes = nextCodes
+      return { residentId: resident.id, handle: resident.handle, generation }
+    },
+    stageRootRecovery: async input => {
+      const code = recoveryCodes.get(input.recoveryCodeHash)
+      const resident = code ? identityResidents.get(code.residentId) : null
+      if (
+        !code || code.used || !resident || code.generation !== resident.generation ||
+        stagedRecoveries.has(input.sessionHash)
+      ) return null
+      stagedRecoveries = new Map(stagedRecoveries).set(input.sessionHash, {
         sessionHash: input.sessionHash,
         csrfHash: input.csrfHash,
         replacementSecretHash: input.replacementSecretHash,
-      }
-      return { residentId: 49, handle: 'browser-resident' }
+        residentId: resident.id,
+        recoveryCodeHash: input.recoveryCodeHash,
+      })
+      return { residentId: resident.id, handle: resident.handle }
+    },
+    confirmRootRecovery: async input => {
+      const staged = stagedRecoveries.get(input.sessionHash)
+      const resident = staged ? identityResidents.get(staged.residentId) : null
+      const code = staged ? recoveryCodes.get(staged.recoveryCodeHash) : null
+      if (
+        !staged || !resident || !code || code.used ||
+        staged.csrfHash !== input.csrfHash ||
+        staged.replacementSecretHash !== input.replacementSecretHash ||
+        code.generation !== resident.generation
+      ) return null
+      identityResidents = new Map(identityResidents).set(resident.id, {
+        ...resident,
+        secretHash: input.replacementSecretHash,
+        generation: resident.generation + 1,
+      })
+      recoveryCodes = deleteResidentRecoveryCodes(resident.id)
+      stagedRecoveries = deleteMapKey(stagedRecoveries, input.sessionHash)
+      return { residentId: resident.id, handle: resident.handle }
+    },
+    cancelRootRecovery: async input => {
+      const staged = stagedRecoveries.get(input.sessionHash)
+      if (!staged || staged.csrfHash !== input.csrfHash) return false
+      stagedRecoveries = deleteMapKey(stagedRecoveries, input.sessionHash)
+      return true
+    },
+    stageRootRotation: async input => {
+      const resident = identityResidentForSecret(input.residentSecretHash)
+      if (!resident || stagedRotations.has(input.sessionHash)) return null
+      stagedRotations = new Map(stagedRotations).set(input.sessionHash, {
+        sessionHash: input.sessionHash,
+        csrfHash: input.csrfHash,
+        replacementSecretHash: input.replacementSecretHash,
+        residentId: resident.id,
+      })
+      return { residentId: resident.id, handle: resident.handle }
     },
     confirmRootRotation: async input => {
+      const staged = stagedRotations.get(input.sessionHash)
+      const resident = staged ? identityResidents.get(staged.residentId) : null
       if (
-        !stagedRotation || stagedRotation.sessionHash !== input.sessionHash ||
-        stagedRotation.csrfHash !== input.csrfHash ||
-        stagedRotation.replacementSecretHash !== input.replacementSecretHash
+        !staged || !resident || staged.sessionHash !== input.sessionHash ||
+        staged.csrfHash !== input.csrfHash ||
+        staged.replacementSecretHash !== input.replacementSecretHash
       ) return null
-      currentIdentitySecretHash = input.replacementSecretHash
-      stagedRotation = null
-      return { status: 'rotated', residentId: 49, handle: 'browser-resident' }
+      identityResidents = new Map(identityResidents).set(resident.id, {
+        ...resident,
+        secretHash: input.replacementSecretHash,
+        generation: resident.generation + 1,
+      })
+      recoveryCodes = deleteResidentRecoveryCodes(resident.id)
+      stagedRotations = deleteMapKey(stagedRotations, input.sessionHash)
+      return { status: 'rotated', residentId: resident.id, handle: resident.handle }
     },
     cancelRootRotation: async input => {
+      const staged = stagedRotations.get(input.sessionHash)
       if (
-        !stagedRotation || stagedRotation.sessionHash !== input.sessionHash ||
-        stagedRotation.csrfHash !== input.csrfHash
+        !staged || staged.sessionHash !== input.sessionHash ||
+        staged.csrfHash !== input.csrfHash
       ) return false
-      stagedRotation = null
+      stagedRotations = deleteMapKey(stagedRotations, input.sessionHash)
       return true
     },
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "migrate:preview:agreement-accession": "node --experimental-strip-types scripts/migrate.ts --target preview --migration agreement-accession",
     "migrate:preview:open-to-use": "node --experimental-strip-types scripts/migrate.ts --target preview --migration open-to-use",
     "migrate:preview:payment-attempts": "node --experimental-strip-types scripts/migrate.ts --target preview --migration payment-attempts",
+    "migrate:preview:payment-response-replay": "node --experimental-strip-types scripts/migrate.ts --target preview --migration payment-response-replay",
     "migrate:preview:identity-recovery": "node --experimental-strip-types scripts/migrate.ts --target preview --migration identity-recovery",
     "migrate:preview:identity-rotation": "node --experimental-strip-types scripts/migrate.ts --target preview --migration identity-rotation",
     "migrate:production:world-root-expand": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-expand",
@@ -32,6 +33,7 @@
     "migrate:production:agreement-accession": "node --experimental-strip-types scripts/migrate.ts --target production --migration agreement-accession",
     "migrate:production:open-to-use": "node --experimental-strip-types scripts/migrate.ts --target production --migration open-to-use",
     "migrate:production:payment-attempts": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-attempts",
+    "migrate:production:payment-response-replay": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-response-replay",
     "migrate:production:identity-recovery": "node --experimental-strip-types scripts/migrate.ts --target production --migration identity-recovery",
     "migrate:production:identity-rotation": "node --experimental-strip-types scripts/migrate.ts --target production --migration identity-rotation"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from '@playwright/test'
 
 const port = Number(process.env.E2E_PORT ?? 41_739)
 const baseURL = `https://127.0.0.1:${port}`
+const mobile = process.env.E2E_MOBILE === 'true'
 
 export default defineConfig({
   testDir: './e2e',
@@ -20,7 +21,10 @@ export default defineConfig({
     screenshot: 'off',
     video: 'off',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [{
+    name: mobile ? 'mobile-chromium' : 'chromium',
+    use: { ...devices[mobile ? 'Pixel 5' : 'Desktop Chrome'] },
+  }],
   webServer: {
     command: 'node --experimental-strip-types e2e/oauth-test-server.ts',
     url: `${baseURL}/__e2e/health`,

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -14,6 +14,7 @@ type RemoteMigration =
   | 'agreement-accession'
   | 'open-to-use'
   | 'payment-attempts'
+  | 'payment-response-replay'
   | 'identity-recovery'
   | 'identity-rotation'
 
@@ -26,6 +27,7 @@ type MigrationFile =
   | 'db/migrations/20260814_agreement_accession.sql'
   | 'db/migrations/20260815_open_to_use.sql'
   | 'db/migrations/20260816_payment_attempts.sql'
+  | 'db/migrations/20260816_payment_response_replay.sql'
   | 'db/migrations/20260816_identity_recovery.sql'
   | 'db/migrations/20260816_identity_rotation.sql'
 
@@ -61,6 +63,7 @@ const REMOTE_MIGRATIONS: Readonly<Record<RemoteMigration, MigrationFile>> = {
   'agreement-accession': 'db/migrations/20260814_agreement_accession.sql',
   'open-to-use': 'db/migrations/20260815_open_to_use.sql',
   'payment-attempts': 'db/migrations/20260816_payment_attempts.sql',
+  'payment-response-replay': 'db/migrations/20260816_payment_response_replay.sql',
   'identity-recovery': 'db/migrations/20260816_identity_recovery.sql',
   'identity-rotation': 'db/migrations/20260816_identity_rotation.sql',
 }
@@ -78,7 +81,7 @@ function remoteMigrationArgument(args: readonly string[]): RemoteMigration {
   const requested = namedArgument(args, 'migration')
   if (!requested || !(requested in REMOTE_MIGRATIONS)) {
     throw new Error(
-      'remote migration requires --migration hosted-chat-signin|world-root-expand|world-root-topology|public-pagination|agreement-accession|open-to-use|payment-attempts|identity-recovery|identity-rotation',
+      'remote migration requires --migration hosted-chat-signin|world-root-expand|world-root-topology|public-pagination|agreement-accession|open-to-use|payment-attempts|payment-response-replay|identity-recovery|identity-rotation',
     )
   }
   return requested as RemoteMigration

--- a/src/browser-form.ts
+++ b/src/browser-form.ts
@@ -1,0 +1,20 @@
+import type { Context } from 'hono'
+
+export function trustedBrowserForm(c: Context, publicOrigin: string): boolean {
+  const requestOrigin = c.req.header('origin')
+  if (requestOrigin && requestOrigin !== 'null') return requestOrigin === publicOrigin
+
+  const referer = c.req.header('referer')
+  if (!referer) return trustedFetchMetadata(c)
+  try {
+    return new URL(referer).origin === publicOrigin
+  } catch {
+    return false
+  }
+}
+
+function trustedFetchMetadata(c: Context): boolean {
+  return c.req.header('sec-fetch-site') === 'same-origin'
+    && c.req.header('sec-fetch-mode') === 'navigate'
+    && c.req.header('sec-fetch-dest') === 'document'
+}

--- a/src/identity-browser.ts
+++ b/src/identity-browser.ts
@@ -1,8 +1,10 @@
 import { randomBytes } from 'node:crypto'
 import type { Context, Hono } from 'hono'
+import { trustedBrowserForm } from './browser-form.ts'
 import { HANDLE_RE, newSecret, sha256 } from './core.ts'
 import { publicText } from './input.ts'
 import { postgresIdentityStore, type IdentityStore } from './identity-store.ts'
+import { publicOrigin as configuredPublicOrigin } from './oauth-config.ts'
 
 export const RECOVERY_CODE_PREFIX = '1f3d9_rc_'
 
@@ -46,7 +48,7 @@ function page(title: string, body: string): string {
 function privateHeaders(c: Context): void {
   c.header('Cache-Control', 'no-store')
   c.header('Pragma', 'no-cache')
-  c.header('Referrer-Policy', 'no-referrer')
+  c.header('Referrer-Policy', 'same-origin')
   c.header('X-Content-Type-Options', 'nosniff')
   c.header('X-Frame-Options', 'DENY')
   c.header(
@@ -69,15 +71,6 @@ function browserError(c: Context, status: 400 | 403 | 409 | 429, message: string
     'Request stopped',
     `<h1>Request stopped</h1><p>${escapeHtml(message)}</p><p class="muted">No identity change was made.</p>`,
   )
-}
-
-function origin(environment: IdentityEnvironment): string {
-  const value = environment.PUBLIC_ORIGIN ?? 'https://1f3d9.com'
-  try {
-    return new URL(value).origin
-  } catch {
-    return 'https://1f3d9.com'
-  }
 }
 
 function clientAddress(c: Context, environment: IdentityEnvironment): string {
@@ -214,7 +207,7 @@ function rotationKey(handle: string, residentKey: string, csrf: string): string 
 export function mountIdentityRoutes(app: Hono, options: IdentityRouteOptions = {}): void {
   const environment = options.environment ?? process.env
   const store = options.store ?? postgresIdentityStore
-  const publicOrigin = origin(environment)
+  const publicOrigin = configuredPublicOrigin(environment)
 
   app.post('/api/register', c => c.json({
     error: `registration moved to the private browser flow at ${publicOrigin}/join`,
@@ -228,7 +221,7 @@ export function mountIdentityRoutes(app: Hono, options: IdentityRouteOptions = {
   })
 
   app.post('/join', async c => {
-    if (c.req.header('origin') !== publicOrigin) return browserError(c, 403, 'This form did not come from 1F3D9.')
+    if (!trustedBrowserForm(c, publicOrigin)) return browserError(c, 403, 'This form did not come from 1F3D9.')
     const values = await form(c)
     const session = cookie(c, JOIN_COOKIE)
     const action = values ? one(values, 'action', 20) : null
@@ -300,7 +293,7 @@ export function mountIdentityRoutes(app: Hono, options: IdentityRouteOptions = {
     })
 
     app.post('/rotate', async c => {
-      if (c.req.header('origin') !== publicOrigin) return browserError(c, 403, 'This form did not come from 1F3D9.')
+      if (!trustedBrowserForm(c, publicOrigin)) return browserError(c, 403, 'This form did not come from 1F3D9.')
       const values = await form(c)
       const session = cookie(c, ROTATION_COOKIE)
       const action = values ? one(values, 'action', 20) : null
@@ -376,7 +369,7 @@ export function mountIdentityRoutes(app: Hono, options: IdentityRouteOptions = {
   })
 
   app.post('/recovery', async c => {
-    if (c.req.header('origin') !== publicOrigin) return browserError(c, 403, 'This form did not come from 1F3D9.')
+    if (!trustedBrowserForm(c, publicOrigin)) return browserError(c, 403, 'This form did not come from 1F3D9.')
     const values = await form(c)
     const session = cookie(c, RECOVERY_COOKIE)
     const action = values ? one(values, 'action', 20) : null

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { mountWorldRoutes } from './world.ts'
 import { mountWorldMarketRoutes } from './world-market.ts'
 import { mountActionRoutes } from './actions.ts'
 import { mountIdentityRoutes } from './identity-browser.ts'
+import { publicOrigin } from './oauth-config.ts'
 import {
   MAX_DUE_EFFECTS_PER_OBSERVATION,
   MAX_PENDING_EFFECTS_PER_ACTOR,
@@ -65,9 +66,27 @@ import {
   type PublicQueryExecutor,
 } from './public-pagination.ts'
 
-const DOMAIN = process.env.PUBLIC_ORIGIN ?? 'https://1f3d9.com'
-const IDENTITY_RECOVERY_ENABLED = process.env.IDENTITY_RECOVERY_ENABLED === 'true'
-const IDENTITY_ROTATION_ENABLED = process.env.IDENTITY_ROTATION_ENABLED === 'true'
+interface DomainConfiguration {
+  readonly domain: string
+  readonly identityBrowserReady: boolean
+}
+
+function configuredDomain(): DomainConfiguration {
+  try {
+    return { domain: publicOrigin(), identityBrowserReady: true }
+  } catch {
+    console.error('identity browser routes are unavailable because PUBLIC_ORIGIN is invalid')
+    return { domain: 'https://1f3d9.com', identityBrowserReady: false }
+  }
+}
+
+const domainConfiguration = configuredDomain()
+const DOMAIN = domainConfiguration.domain
+const IDENTITY_BROWSER_READY = domainConfiguration.identityBrowserReady
+const IDENTITY_RECOVERY_ENABLED = IDENTITY_BROWSER_READY
+  && process.env.IDENTITY_RECOVERY_ENABLED === 'true'
+const IDENTITY_ROTATION_ENABLED = IDENTITY_BROWSER_READY
+  && process.env.IDENTITY_ROTATION_ENABLED === 'true'
 const ANONYMOUS_FLAGS_PER_IP_HOUR = 5
 
 const executePublicQuery: PublicQueryExecutor = async (text, params) =>
@@ -187,9 +206,25 @@ if (requestedHostedChatSignin.ready) {
   }
 }
 
-mountIdentityRoutes(app)
+if (IDENTITY_BROWSER_READY) {
+  mountIdentityRoutes(app, {
+    environment: { ...process.env, PUBLIC_ORIGIN: DOMAIN },
+  })
+} else {
+  const unavailableIdentity = (c: Context) => {
+    c.header('Cache-Control', 'no-store')
+    return c.json({ error: 'identity browser routes are unavailable' }, 503)
+  }
+  app.all('/join', unavailableIdentity)
+  app.all('/rotate', unavailableIdentity)
+  app.all('/recovery', unavailableIdentity)
+  app.post('/api/register', unavailableIdentity)
+}
 
 app.post('/api/rotate', async c => {
+  if (!IDENTITY_BROWSER_READY) {
+    return c.json({ error: 'identity browser routes are unavailable' }, 503)
+  }
   return c.json({
     error: `root-key rotation moved to the private browser flow at ${DOMAIN}/rotate`,
   }, 410)
@@ -396,7 +431,7 @@ app.get('/api/official', c => c.json({
   market: process.env.MARKET_ORIGIN ?? 'https://1f3ea.com',
   city_skill: 'https://github.com/onetapstudiogames/1f3d9-citylife',
   identity: {
-    join: `${DOMAIN}/join`,
+    join: IDENTITY_BROWSER_READY ? `${DOMAIN}/join` : null,
     recovery: IDENTITY_RECOVERY_ENABLED ? `${DOMAIN}/recovery` : null,
     recovery_enabled: IDENTITY_RECOVERY_ENABLED,
     rotate: IDENTITY_ROTATION_ENABLED ? `${DOMAIN}/rotate` : null,

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'node:crypto'
 import type { Context, Hono } from 'hono'
+import { trustedBrowserForm } from './browser-form.ts'
 import {
   HANDLE_RE,
   newSecret,
@@ -425,7 +426,7 @@ export function mountOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}): vo
   })
 
   app.post('/oauth/authorize', async c => {
-    if (c.req.header('origin') !== oauth.origin) {
+    if (!trustedBrowserForm(c, oauth.origin)) {
       return browserError(c, 403, 'This approval did not come from the 1F3D9 sign-in page.')
     }
     const values = await form(c)

--- a/src/payment-attempts.ts
+++ b/src/payment-attempts.ts
@@ -5,6 +5,10 @@ const HASH_RE = /^0x[0-9a-f]{64}$/u
 const SHA256_RE = /^[0-9a-f]{64}$/u
 const TOKEN_RE = /^0x[0-9a-f]{40}$/u
 const PUBLIC_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]+$/u
+const PAYMENT_RESPONSE_HEADER_RE = /^[A-Za-z0-9+/]+={0,2}$/u
+const MAX_FACILITATOR_RESPONSE_BYTES = 65_536
+const MAX_PAYMENT_RESPONSE_HEADER_LENGTH = 4 * Math.ceil(MAX_FACILITATOR_RESPONSE_BYTES / 3)
+const DURABLE_X402_RESPONSE_KEY = '__1f3d9_x402_response_v1'
 
 export type PaymentAttemptStatus =
   | 'settling'
@@ -50,6 +54,7 @@ export interface PaymentAttemptRecord {
   result: Record<string, unknown> | null
   responseStatus: number | null
   response: Record<string, unknown> | null
+  paymentResponseHeader?: string | null
   createdAt: string
   updatedAt: string
   completedAt: string | null
@@ -219,6 +224,44 @@ function objectValue(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>
 }
 
+function paymentResponseHeaderValue(value: unknown): string | null {
+  if (
+    typeof value !== 'string'
+    || value.length === 0
+    || value.length > MAX_PAYMENT_RESPONSE_HEADER_LENGTH
+    || !PAYMENT_RESPONSE_HEADER_RE.test(value)
+  ) return null
+  try {
+    const decoded = Buffer.from(value, 'base64')
+    if (
+      decoded.byteLength === 0
+      || decoded.byteLength > MAX_FACILITATOR_RESPONSE_BYTES
+      || decoded.toString('base64') !== value
+    ) return null
+    const parsed = JSON.parse(decoded.toString('utf8')) as unknown
+    return parsed != null && typeof parsed === 'object' && !Array.isArray(parsed) ? value : null
+  } catch {
+    return null
+  }
+}
+
+function durablePaymentResponse(value: Record<string, unknown> | null): {
+  header: string
+  body: Record<string, unknown> | null
+} | null {
+  if (!value || Object.keys(value).length !== 1) return null
+  const envelopeValue = value[DURABLE_X402_RESPONSE_KEY]
+  if (!envelopeValue || typeof envelopeValue !== 'object' || Array.isArray(envelopeValue)) return null
+  const envelope = envelopeValue as Record<string, unknown>
+  if (Object.keys(envelope).some(key => key !== 'header' && key !== 'body')) return null
+  const header = paymentResponseHeaderValue(envelope.header)
+  if (!header) return null
+  if (!Object.hasOwn(envelope, 'body')) return { header, body: null }
+  const body = envelope.body
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return null
+  return { header, body: body as Record<string, unknown> }
+}
+
 function textValue(value: unknown): string | null {
   return value == null ? null : String(value)
 }
@@ -237,6 +280,12 @@ function paymentAttemptFromRow(row: Record<string, unknown> | undefined): Paymen
   if (!['settling', 'payment_pending', 'completed', 'invalid', 'expired', 'needs_review', 'legacy_completed'].includes(status)) {
     throw new TypeError('invalid status row')
   }
+  const storedResponse = objectValue(rowValue(row, 'response', 'response_json'))
+  const durableResponse = durablePaymentResponse(storedResponse)
+  const directPaymentResponseHeader = paymentResponseHeaderValue(
+    rowValue(row, 'paymentResponseHeader', 'payment_response_header'),
+  )
+  const paymentResponseHeader = durableResponse?.header ?? directPaymentResponseHeader
   return {
     publicId,
     actorId,
@@ -271,7 +320,8 @@ function paymentAttemptFromRow(row: Record<string, unknown> | undefined): Paymen
     invalidReason: textValue(rowValue(row, 'invalidReason', 'invalid_reason')),
     result: objectValue(rowValue(row, 'result', 'result_json')),
     responseStatus: integer(rowValue(row, 'responseStatus', 'response_status')),
-    response: objectValue(rowValue(row, 'response', 'response_json')),
+    response: durableResponse ? durableResponse.body : storedResponse,
+    ...(paymentResponseHeader ? { paymentResponseHeader } : {}),
     createdAt: isoString(rowValue(row, 'createdAt', 'created_at')) ?? new Date(0).toISOString(),
     updatedAt: isoString(rowValue(row, 'updatedAt', 'updated_at')) ?? new Date(0).toISOString(),
     completedAt: isoString(rowValue(row, 'completedAt', 'completed_at')),
@@ -440,8 +490,15 @@ export async function bindPaymentEvidence(
       blockTime: string
       finalizedAt: string
     }
+    paymentResponseHeader?: string | null
   },
 ): Promise<PaymentAttemptRecord> {
+  const responseHeader = input.paymentResponseHeader == null
+    ? null
+    : paymentResponseHeaderValue(input.paymentResponseHeader)
+  if (input.paymentResponseHeader != null && !responseHeader) {
+    throw new TypeError('invalid payment response header')
+  }
   const updated = paymentAttemptFromRow((await runQuery(database, `
     /* payment-attempts:bind-evidence */
     UPDATE payment_attempts
@@ -451,12 +508,24 @@ export async function bindPaymentEvidence(
       finalized_block_hash = coalesce(finalized_block_hash, lower($5)),
       finalized_block_time = coalesce(finalized_block_time, $6::timestamptz),
       finalized_at = coalesce(finalized_at, $7::timestamptz),
+      response_json = CASE
+        WHEN $8::text IS NULL THEN response_json
+        WHEN response_json IS NULL THEN jsonb_build_object(
+          '${DURABLE_X402_RESPONSE_KEY}', jsonb_build_object('header', $8::text)
+        )
+        ELSE response_json
+      END,
       updated_at = clock_timestamp()
     WHERE public_id = $1
       AND lease_owner = $2
       AND status IN ('settling', 'payment_pending', 'needs_review')
       AND (tx_hash IS NULL OR tx_hash = $3)
       AND ($5::text IS NULL OR finalized_block_hash IS NULL OR finalized_block_hash = $5)
+      AND (
+        $8::text IS NULL
+        OR response_json IS NULL
+        OR response_json #>> '{${DURABLE_X402_RESPONSE_KEY},header}' = $8::text
+      )
     RETURNING *
   `, [
     input.publicId,
@@ -466,6 +535,7 @@ export async function bindPaymentEvidence(
     input.finality?.blockHash ?? null,
     input.finality?.blockTime ?? null,
     input.finality?.finalizedAt ?? null,
+    responseHeader,
   ]))[0] as Record<string, unknown> | undefined)
   if (updated) return updated
   const current = paymentAttemptFromRow((await runQuery(database, `
@@ -477,6 +547,9 @@ export async function bindPaymentEvidence(
   `, [input.publicId]))[0] as Record<string, unknown> | undefined)
   if (!current || (current.txHash != null && current.txHash !== input.txHash.toLowerCase())) {
     conflict('payment evidence conflicts with an existing transaction')
+  }
+  if (responseHeader != null && current.paymentResponseHeader !== responseHeader) {
+    conflict('payment evidence conflicts with an existing facilitator response')
   }
   return current
 }
@@ -521,7 +594,16 @@ export async function completePaymentAttempt(
     SET status = 'completed',
       result_json = $3::jsonb,
       response_status = $4,
-      response_json = $5::jsonb,
+      response_json = CASE
+        WHEN response_json #>> '{${DURABLE_X402_RESPONSE_KEY},header}' IS NULL THEN $5::jsonb
+        ELSE jsonb_build_object(
+          '${DURABLE_X402_RESPONSE_KEY}',
+          jsonb_build_object(
+            'header', response_json #>> '{${DURABLE_X402_RESPONSE_KEY},header}',
+            'body', $5::jsonb
+          )
+        )
+      END,
       completed_at = coalesce(completed_at, clock_timestamp()),
       lease_owner = NULL,
       lease_expires_at = NULL,

--- a/src/payment-flow.ts
+++ b/src/payment-flow.ts
@@ -173,9 +173,12 @@ function completed(attempt: PaymentAttemptRecord): DurableX402Result {
     state: 'completed',
     status: attempt.responseStatus,
     body: attempt.response,
-    paymentResponseHeader: attempt.txHash && attempt.payerWallet
+    // Historical rows completed before receipt persistence cannot recover bytes that
+    // were never stored. Keep their canonical compatibility receipt so paid work is
+    // not stranded; new rows always take the durable header branch.
+    paymentResponseHeader: attempt.paymentResponseHeader ?? (attempt.txHash && attempt.payerWallet
       ? settlementHeader(attempt.txHash, attempt.payerWallet)
-      : null,
+      : null),
   }
 }
 
@@ -338,7 +341,8 @@ export async function resumeDurableX402(
     blockHash: check.blockHash,
     blockTime,
     finalizedAt,
-    paymentResponseHeader: settlementHeader(txHash, attempt.payerWallet),
+    paymentResponseHeader: attempt.paymentResponseHeader
+      ?? settlementHeader(txHash, attempt.payerWallet),
   }
 }
 
@@ -424,6 +428,7 @@ export async function runDurableX402(
   const leaseOwner = leased.leaseOwner
   let txHash = attempt.txHash
   let settlementRaw: Record<string, unknown> | undefined
+  let settledResponseHeader: string | undefined
 
   if (txHash == null && created.disposition === 'existing') {
     txHash = await deps.recoverTransaction(
@@ -465,7 +470,10 @@ export async function runDurableX402(
 
     const settlement = await deps.settle(verified)
     txHash = settlement.transaction
-    if (settlement.state === 'settled') settlementRaw = settlement.response
+    if (settlement.state === 'settled') {
+      settlementRaw = settlement.response
+      settledResponseHeader = settlementHeader(txHash!, parsed.authorization.payer, settlementRaw)
+    }
     if (txHash == null) {
       const review = await deps.needsReview(input.database, {
         publicId: attempt.publicId,
@@ -481,6 +489,7 @@ export async function runDurableX402(
       leaseOwner,
       txHash,
       finality: null,
+      ...(settledResponseHeader ? { paymentResponseHeader: settledResponseHeader } : {}),
     })
   }
 
@@ -543,6 +552,8 @@ export async function runDurableX402(
     blockHash: check.blockHash,
     blockTime,
     finalizedAt,
-    paymentResponseHeader: settlementHeader(txHash, parsed.authorization.payer, settlementRaw),
+    paymentResponseHeader: attempt.paymentResponseHeader
+      ?? settledResponseHeader
+      ?? settlementHeader(txHash, parsed.authorization.payer, settlementRaw),
   }
 }

--- a/test/deploy-safety.test.ts
+++ b/test/deploy-safety.test.ts
@@ -44,6 +44,10 @@ const paymentAttemptsMigrationUrl = new URL(
   '../db/migrations/20260816_payment_attempts.sql',
   import.meta.url,
 )
+const paymentResponseReplayMigrationUrl = new URL(
+  '../db/migrations/20260816_payment_response_replay.sql',
+  import.meta.url,
+)
 const identityRecoveryMigrationUrl = new URL(
   '../db/migrations/20260816_identity_recovery.sql',
   import.meta.url,
@@ -594,7 +598,7 @@ test('migration target must be named explicitly', () => {
 test('remote migration file must be named explicitly', () => {
   assert.throws(
     () => resolveMigrationRun(['--target', 'preview'], {}),
-    /--migration hosted-chat-signin\|world-root-expand\|world-root-topology\|public-pagination\|agreement-accession\|open-to-use\|payment-attempts\|identity-recovery\|identity-rotation/,
+    /--migration hosted-chat-signin\|world-root-expand\|world-root-topology\|public-pagination\|agreement-accession\|open-to-use\|payment-attempts\|payment-response-replay\|identity-recovery\|identity-rotation/,
   )
 })
 
@@ -722,13 +726,16 @@ test('fresh installs contain every reviewed release migration statement', () => 
     [agreementAccessionMigration, 'agreement-accession'],
     [readFileSync(openToUseMigrationUrl, 'utf8'), 'open-to-use'],
     [readFileSync(paymentAttemptsMigrationUrl, 'utf8'), 'payment-attempts'],
+    [readFileSync(paymentResponseReplayMigrationUrl, 'utf8'), 'payment-response-replay'],
     [readFileSync(identityRecoveryMigrationUrl, 'utf8'), 'identity-recovery'],
     [readFileSync(identityRotationMigrationUrl, 'utf8'), 'identity-rotation'],
   ] as const) {
     const statements = label === 'payment-attempts'
-      ? splitSqlStatements(migration).filter(statement =>
-        /^(?:CREATE|COMMENT|DROP\s+TRIGGER|CREATE\s+TRIGGER)/i.test(statement.trim()),
-      )
+      ? splitSqlStatements(migration).filter(statement => {
+        const trimmed = statement.trim()
+        return /^(?:CREATE|COMMENT|DROP\s+TRIGGER|CREATE\s+TRIGGER)/i.test(trimmed)
+          && !/^CREATE\s+OR\s+REPLACE\s+FUNCTION\s+(?:complete_payment_attempt|protect_payment_attempt_history)\s*\(/i.test(trimmed)
+      })
       : label === 'identity-recovery'
         ? splitSqlStatements(migration).filter(statement => {
           const trimmed = statement.trim()
@@ -775,6 +782,8 @@ test('package commands name preview and production migrations explicitly', () =>
   assert.match(packageJson.scripts['migrate:production:open-to-use'] ?? '', /--target production --migration open-to-use$/)
   assert.match(packageJson.scripts['migrate:preview:payment-attempts'] ?? '', /--target preview --migration payment-attempts$/)
   assert.match(packageJson.scripts['migrate:production:payment-attempts'] ?? '', /--target production --migration payment-attempts$/)
+  assert.match(packageJson.scripts['migrate:preview:payment-response-replay'] ?? '', /--target preview --migration payment-response-replay$/)
+  assert.match(packageJson.scripts['migrate:production:payment-response-replay'] ?? '', /--target production --migration payment-response-replay$/)
   assert.match(packageJson.scripts['migrate:preview:identity-recovery'] ?? '', /--target preview --migration identity-recovery$/)
   assert.match(packageJson.scripts['migrate:production:identity-recovery'] ?? '', /--target production --migration identity-recovery$/)
   assert.match(packageJson.scripts['migrate:preview:identity-rotation'] ?? '', /--target preview --migration identity-rotation$/)
@@ -894,6 +903,51 @@ test('payment attempts are an explicitly selected additive release', () => {
     },
   )
   assert.equal(production.migrationFile, 'db/migrations/20260816_payment_attempts.sql')
+})
+
+test('payment response replay is an explicitly selected idempotent function repair', () => {
+  const migration = readFileSync(paymentResponseReplayMigrationUrl, 'utf8')
+  const uncommented = migration.replace(/^\s*--.*$/gm, '')
+  const statements = splitSqlStatements(migration)
+
+  assert.equal(statements.length, 2)
+  assert.match(uncommented, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+complete_payment_attempt/i)
+  assert.match(uncommented, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/i)
+  assert.match(uncommented, /__1f3d9_x402_response_v1/i)
+  assert.doesNotMatch(uncommented, /^\s*(?:DROP\s+TABLE|ALTER\s+TABLE|DELETE|TRUNCATE)\b/im)
+
+  const normalize = (statement: string) => statement
+    .replace(/^\s*--.*$/gm, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  const freshFunctions = new Set(splitSqlStatements(fullSchema).map(normalize))
+  for (const statement of statements) assert.ok(freshFunctions.has(normalize(statement)))
+
+  const preview = resolveMigrationRun(
+    ['--target', 'preview', '--migration', 'payment-response-replay'],
+    {
+      CONFIRM_PREVIEW_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_ISOLATED_PREVIEW',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PREVIEW_BRANCH_ID: 'branch-preview',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PREVIEW_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+    },
+  )
+  assert.equal(preview.migrationFile, 'db/migrations/20260816_payment_response_replay.sql')
+
+  const production = resolveMigrationRun(
+    ['--target', 'production', '--migration', 'payment-response-replay'],
+    {
+      CONFIRM_PRODUCTION_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_PRODUCTION',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PRODUCTION_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+      PRODUCTION_SNAPSHOT_NAME: 'payment-response-replay-release',
+    },
+  )
+  assert.equal(production.migrationFile, 'db/migrations/20260816_payment_response_replay.sql')
 })
 
 test('public pagination indexes are an explicitly selected additive release', () => {

--- a/test/hosted-chat-discovery.test.ts
+++ b/test/hosted-chat-discovery.test.ts
@@ -154,7 +154,7 @@ function startupProbe(overrides: Record<string, string | undefined>) {
     }
     const { default: app } = await import('./src/index.ts')
     const corsHeaders = { origin: 'https://reader.example.test' }
-    const [front, llms, legacy, connector, metadata] = await Promise.all([
+    const [front, llms, legacy, connector, metadata, join, official] = await Promise.all([
       app.request('/', { headers: corsHeaders }),
       app.request('/llms.txt', { headers: corsHeaders }),
       app.request('/mcp', {
@@ -168,7 +168,10 @@ function startupProbe(overrides: Record<string, string | undefined>) {
         body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
       }),
       app.request('/.well-known/oauth-authorization-server'),
+      app.request('/join'),
+      app.request('/api/official'),
     ])
+    const officialBody = await official.json()
     const oauthQueries = globalThis.__queries.filter(query => /oauth_/i.test(query))
     process.stdout.write(JSON.stringify({
       front: front.status,
@@ -180,6 +183,8 @@ function startupProbe(overrides: Record<string, string | undefined>) {
       legacy: legacy.status,
       connector: connector.status,
       metadata: metadata.status,
+      join: join.status,
+      officialJoin: officialBody.identity?.join ?? null,
       oauthQueries: oauthQueries.length,
     }))
   `
@@ -235,6 +240,8 @@ test('bad enabled configuration cannot kill public routes or the legacy MCP door
       legacy: number
       connector: number
       metadata: number
+      join: number
+      officialJoin: string | null
       oauthQueries: number
     }
     assert.equal(probe.front, 200)
@@ -245,6 +252,13 @@ test('bad enabled configuration cannot kill public routes or the legacy MCP door
     assert.equal(probe.connector, 404)
     assert.equal(probe.metadata, 404)
     assert.equal(probe.oauthQueries, 0)
+    if (overrides.PUBLIC_ORIGIN === 'not-an-origin') {
+      assert.equal(probe.join, 503)
+      assert.equal(probe.officialJoin, null)
+    } else {
+      assert.equal(probe.join, 200)
+      assert.equal(probe.officialJoin, `${PREVIEW_ORIGIN}/join`)
+    }
     assert.equal(
       probe.frontText,
       hostedChatDiscovery(FRONTDOOR, { ready: false }, 'frontdoor', false, false),

--- a/test/identity-browser.test.ts
+++ b/test/identity-browser.test.ts
@@ -34,15 +34,20 @@ function postForm(
   path: string,
   cookie: string,
   values: Record<string, string>,
-  origin = ORIGIN,
+  origin: string | null = ORIGIN,
+  referer?: string,
+  extraHeaders: Record<string, string> = {},
 ) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/x-www-form-urlencoded',
+    cookie,
+    ...extraHeaders,
+  }
+  if (origin !== null) headers.origin = origin
+  if (referer !== undefined) headers.referer = referer
   return app.request(path, {
     method: 'POST',
-    headers: {
-      'content-type': 'application/x-www-form-urlencoded',
-      cookie,
-      origin,
-    },
+    headers,
     body: new URLSearchParams(values),
   })
 }
@@ -211,6 +216,23 @@ function appWithMemoryStore(options: MemoryStoreOptions = {}) {
   return { app, memory }
 }
 
+test('identity browser rejects a PUBLIC_ORIGIN that is not one exact HTTPS origin', () => {
+  for (const publicOrigin of [
+    'http://city.test',
+    'https://city.test/path',
+    'https://city.test?query=yes',
+    'not-an-origin',
+  ]) {
+    assert.throws(
+      () => mountIdentityRoutes(new Hono(), {
+        environment: { PUBLIC_ORIGIN: publicOrigin },
+        store: memoryStore().store,
+      }),
+      /PUBLIC_ORIGIN must be an HTTPS origin/,
+    )
+  }
+})
+
 test('the recovery surface is absent unless its deployment switch is explicitly enabled', async () => {
   for (const environment of [
     { PUBLIC_ORIGIN: ORIGIN },
@@ -264,6 +286,7 @@ test('rotation GET is private and uses a separate host-only session cookie', asy
   assert.equal(response.status, 200)
   assert.equal(response.headers.get('cache-control'), 'no-store')
   assert.equal(response.headers.get('pragma'), 'no-cache')
+  assert.equal(response.headers.get('referrer-policy'), 'same-origin')
   assert.equal(response.headers.get('x-frame-options'), 'DENY')
   assert.match(response.headers.get('content-security-policy') ?? '', /frame-ancestors 'none'/)
   assert.equal(response.headers.get('access-control-allow-origin'), null)
@@ -271,6 +294,111 @@ test('rotation GET is private and uses a separate host-only session cookie', asy
   assert.match(setCookie, /^__Host-1f3d9_rotate=/)
   assert.match(setCookie, /; Path=\/; Max-Age=900; Secure; HttpOnly; SameSite=Lax$/)
   assert.doesNotMatch(setCookie, /(?:Domain=|join|recovery)/i)
+})
+
+test('real browser form posts can use a same-origin referrer when Origin is withheld', async () => {
+  const join = appWithMemoryStore()
+  const joinStart = await pageState(await join.app.request('/join'))
+  const joined = await postForm(join.app, '/join', joinStart.cookie, {
+    action: 'stage', csrf: joinStart.csrf, handle: 'mobile-join', model: '',
+  }, null, `${ORIGIN}/join`)
+  assert.equal(joined.status, 200)
+  assert.equal(join.memory.registration()?.handle, 'mobile-join')
+
+  const rotation = appWithMemoryStore()
+  const rotationStart = await pageState(await rotation.app.request('/rotate'))
+  const rotated = await postForm(rotation.app, '/rotate', rotationStart.cookie, {
+    action: 'begin', csrf: rotationStart.csrf, resident_key: ROOT_KEY,
+  }, 'null', `${ORIGIN}/rotate`)
+  assert.equal(rotated.status, 200)
+  assert.ok(rotation.memory.stagedRotation())
+
+  const recovery = appWithMemoryStore()
+  const recoveryStart = await pageState(await recovery.app.request('/recovery'))
+  const generated = await postForm(recovery.app, '/recovery', recoveryStart.cookie, {
+    action: 'generate', csrf: recoveryStart.csrf, resident_key: ROOT_KEY,
+  }, null, `${ORIGIN}/recovery`)
+  assert.equal(generated.status, 200)
+  const recoveryHtml = await generated.text()
+  assert.equal((recoveryHtml.match(/1f3d9_rc_[0-9a-f]{64}/g) ?? []).length, 8)
+})
+
+test('identity forms accept same-origin fetch metadata when privacy browsers omit Origin and Referer', async () => {
+  const fetchMetadata = {
+    'sec-fetch-site': 'same-origin',
+    'sec-fetch-mode': 'navigate',
+    'sec-fetch-dest': 'document',
+  }
+
+  const join = appWithMemoryStore()
+  const joinStart = await pageState(await join.app.request('/join'))
+  const joined = await postForm(join.app, '/join', joinStart.cookie, {
+    action: 'stage', csrf: joinStart.csrf, handle: 'metadata-join', model: '',
+  }, null, undefined, fetchMetadata)
+  assert.equal(joined.status, 200)
+  assert.equal(join.memory.registration()?.handle, 'metadata-join')
+
+  const rotation = appWithMemoryStore()
+  const rotationStart = await pageState(await rotation.app.request('/rotate'))
+  const rotated = await postForm(rotation.app, '/rotate', rotationStart.cookie, {
+    action: 'begin', csrf: rotationStart.csrf, resident_key: ROOT_KEY,
+  }, null, undefined, fetchMetadata)
+  assert.equal(rotated.status, 200)
+  assert.ok(rotation.memory.stagedRotation())
+
+  const recovery = appWithMemoryStore()
+  const recoveryStart = await pageState(await recovery.app.request('/recovery'))
+  const generated = await postForm(recovery.app, '/recovery', recoveryStart.cookie, {
+    action: 'generate', csrf: recoveryStart.csrf, resident_key: ROOT_KEY,
+  }, null, undefined, fetchMetadata)
+  assert.equal(generated.status, 200)
+  const recoveryHtml = await generated.text()
+  assert.equal((recoveryHtml.match(/1f3d9_rc_[0-9a-f]{64}/g) ?? []).length, 8)
+})
+
+test('identity forms still reject absent or conflicting same-site evidence', async () => {
+  const absent = appWithMemoryStore()
+  const absentStart = await pageState(await absent.app.request('/join'))
+  const noEvidence = await postForm(absent.app, '/join', absentStart.cookie, {
+    action: 'stage', csrf: absentStart.csrf, handle: 'no-evidence', model: '',
+  }, null)
+  assert.equal(noEvidence.status, 403)
+  assert.equal(absent.memory.registration(), null)
+
+  const conflicting = appWithMemoryStore()
+  const conflictingStart = await pageState(await conflicting.app.request('/rotate'))
+  const hostileOrigin = await postForm(conflicting.app, '/rotate', conflictingStart.cookie, {
+    action: 'begin', csrf: conflictingStart.csrf, resident_key: ROOT_KEY,
+  }, 'https://attacker.test', `${ORIGIN}/rotate`)
+  assert.equal(hostileOrigin.status, 403)
+  assert.equal(conflicting.memory.stagedRotation(), null)
+
+  const hostileMetadata = appWithMemoryStore()
+  const hostileMetadataStart = await pageState(await hostileMetadata.app.request('/join'))
+  const crossSiteFetch = await postForm(hostileMetadata.app, '/join', hostileMetadataStart.cookie, {
+    action: 'stage', csrf: hostileMetadataStart.csrf, handle: 'hostile-metadata', model: '',
+  }, null, undefined, {
+    'sec-fetch-site': 'cross-site',
+    'sec-fetch-mode': 'navigate',
+    'sec-fetch-dest': 'document',
+  })
+  assert.equal(crossSiteFetch.status, 403)
+  assert.equal(hostileMetadata.memory.registration(), null)
+
+  for (const referer of [
+    'https://attacker.test/recovery',
+    'http://city.test/recovery',
+    'https://city.test:444/recovery',
+    'not-a-url',
+  ]) {
+    const hostileReferrer = appWithMemoryStore()
+    const hostileStart = await pageState(await hostileReferrer.app.request('/recovery'))
+    const missingOrigin = await postForm(hostileReferrer.app, '/recovery', hostileStart.cookie, {
+      action: 'generate', csrf: hostileStart.csrf, resident_key: ROOT_KEY,
+    }, null, referer)
+    assert.equal(missingOrigin.status, 403)
+    assert.equal(hostileReferrer.memory.calls.length, 0)
+  }
 })
 
 test('legacy registration is retired before it can return a resident key', async () => {

--- a/test/integration/payment-postgres.test.ts
+++ b/test/integration/payment-postgres.test.ts
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises'
 import { setTimeout as delay } from 'node:timers/promises'
 import test from 'node:test'
 import { Pool } from 'pg'
+import { bindPaymentEvidence, findPaymentAttempt } from '../../src/payment-attempts.ts'
 
 const POSTGRES_IMAGE = 'postgres@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317'
 const POSTGRES_DATABASE = 'payment_integration'
@@ -13,11 +14,22 @@ const migrationDdl = await readFile(
   new URL('../../db/migrations/20260816_payment_attempts.sql', import.meta.url),
   'utf8',
 )
+const replayMigrationDdl = await readFile(
+  new URL('../../db/migrations/20260816_payment_response_replay.sql', import.meta.url),
+  'utf8',
+)
 
 const BASE_USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
 const SELLER_WALLET = `0x${'1'.repeat(40)}`
 const BUYER_WALLET = `0x${'2'.repeat(40)}`
 const OTHER_WALLET = `0x${'3'.repeat(40)}`
+const FACILITATOR_RESPONSE_HEADER = Buffer.from(JSON.stringify({
+  success: true,
+  transaction: hash('4'),
+  payer: BUYER_WALLET,
+  network: 'base',
+  facilitator: 'https://facilitator.example.test',
+})).toString('base64')
 
 function hash(digit: string): string {
   return `0x${digit.repeat(64)}`
@@ -478,6 +490,80 @@ test('payment custody invariants hold in PostgreSQL', async t => {
         response_status: 201,
         response_json: { ok: true },
       }])
+    })
+
+    await t.test('completion preserves exact facilitator response bytes across a database reload', async () => {
+      await resetFresh(postgres.client)
+      await postgres.client.query(replayMigrationDdl)
+      await postgres.client.query(replayMigrationDdl)
+      const txHash = hash('4')
+      await postgres.client.query(`
+        INSERT INTO payment_attempts (
+          public_id, actor_id, operation, target_key, offer_id, request_hash, request_json,
+          method, network, token, payer_wallet, payee_wallet, amount_units,
+          x402_nonce, x402_payload_digest, x402_valid_after, x402_valid_before,
+          start_block, start_time, end_time, status, lease_owner, lease_expires_at
+        ) VALUES (
+          'attempt_exact_response_01', 2, 'frontier', 'frontier:exact-response', 91,
+          repeat('a', 64), '{}'::jsonb,
+          'x402', 'base', $1, $2, $3, 1000000,
+          $4, repeat('b', 64), 1, 9999999999,
+          10, '2026-08-16T12:00:00Z', '2026-08-16T12:05:00Z',
+          'settling', 'response-lease', clock_timestamp() + interval '1 minute'
+        )
+      `, [BASE_USDC, BUYER_WALLET, SELLER_WALLET, hash('5')])
+      const database = {
+        query: async (text: string, params: readonly unknown[] = []) =>
+          (await postgres.client.query(text, [...params])).rows,
+      }
+
+      const pending = await bindPaymentEvidence(database, {
+        publicId: 'attempt_exact_response_01',
+        leaseOwner: 'response-lease',
+        txHash,
+        finality: {
+          blockNumber: 11n,
+          blockHash: hash('6'),
+          blockTime: '2026-08-16T12:01:00Z',
+          finalizedAt: '2026-08-16T12:02:00Z',
+        },
+        paymentResponseHeader: FACILITATOR_RESPONSE_HEADER,
+      })
+      assert.equal(pending.paymentResponseHeader, FACILITATOR_RESPONSE_HEADER)
+      await rejectsWithCode(postgres.client.query(`
+        UPDATE payment_attempts SET response_json = '{}'::jsonb
+        WHERE public_id = 'attempt_exact_response_01'
+      `), '55000')
+
+      await postgres.client.query(`
+        SELECT complete_payment_attempt(
+          'attempt_exact_response_01',
+          'response-lease',
+          jsonb_build_object('thing_id', 42),
+          201::smallint,
+          jsonb_build_object('ok', true, 'thing', jsonb_build_object('id', 42))
+        )
+      `)
+      const stored = await postgres.client.query(`
+        SELECT response_json FROM payment_attempts
+        WHERE public_id = 'attempt_exact_response_01'
+      `)
+      assert.deepEqual(stored.rows, [{
+        response_json: {
+          __1f3d9_x402_response_v1: {
+            header: FACILITATOR_RESPONSE_HEADER,
+            body: { ok: true, thing: { id: 42 } },
+          },
+        },
+      }])
+
+      const reloaded = await findPaymentAttempt(database, {
+        actorId: 2,
+        operation: 'frontier',
+        offerId: 91,
+      })
+      assert.equal(reloaded?.paymentResponseHeader, FACILITATOR_RESPONSE_HEADER)
+      assert.deepEqual(reloaded?.response, { ok: true, thing: { id: 42 } })
     })
 
     await t.test('upgrade backfills recorded legacy facts and leaves unknown facts null', async () => {

--- a/test/oauth-flow.test.ts
+++ b/test/oauth-flow.test.ts
@@ -467,15 +467,20 @@ async function browserPost(
   app: Hono,
   session: BrowserSession,
   fields: Record<string, string> | URLSearchParams,
-  origin = ORIGIN,
+  origin: string | null = ORIGIN,
+  referer?: string,
+  extraHeaders: Record<string, string> = {},
 ): Promise<Response> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/x-www-form-urlencoded',
+    cookie: session.cookie,
+    ...extraHeaders,
+  }
+  if (origin !== null) headers.origin = origin
+  if (referer !== undefined) headers.referer = referer
   return app.request('/oauth/authorize', {
     method: 'POST',
-    headers: {
-      'content-type': 'application/x-www-form-urlencoded',
-      cookie: session.cookie,
-      origin,
-    },
+    headers,
     body: fields instanceof URLSearchParams ? fields : new URLSearchParams(fields),
   })
 }
@@ -886,6 +891,30 @@ test('browser approval rejects wrong origin and CSRF without reflecting the resi
   })
   assert.equal(wrongCsrf.status, 403)
   assert.doesNotMatch(await wrongCsrf.text(), new RegExp(EXISTING_KEY, 'i'))
+})
+
+test('browser approval accepts a same-origin referrer when Origin is withheld', async () => {
+  const { app } = fixture()
+  const session = await begin(app)
+  const approved = await browserPost(app, session, {
+    action: 'link', csrf: session.csrf, resident_key: EXISTING_KEY,
+  }, 'null', `${ORIGIN}/oauth/authorize`)
+
+  authorizationCode(approved)
+})
+
+test('browser approval accepts same-origin fetch metadata when privacy browsers omit Origin and Referer', async () => {
+  const { app } = fixture()
+  const session = await begin(app)
+  const approved = await browserPost(app, session, {
+    action: 'link', csrf: session.csrf, resident_key: EXISTING_KEY,
+  }, null, undefined, {
+    'sec-fetch-site': 'same-origin',
+    'sec-fetch-mode': 'navigate',
+    'sec-fetch-dest': 'document',
+  })
+
+  authorizationCode(approved)
 })
 
 test('browser approval rejects unknown and duplicate fields instead of guessing intent', async () => {

--- a/test/payment-attempts-schema.test.ts
+++ b/test/payment-attempts-schema.test.ts
@@ -8,6 +8,10 @@ const migrationDdl = readFileSync(
   new URL('../db/migrations/20260816_payment_attempts.sql', import.meta.url),
   'utf8',
 )
+const replayMigrationDdl = readFileSync(
+  new URL('../db/migrations/20260816_payment_response_replay.sql', import.meta.url),
+  'utf8',
+)
 
 function createPaymentAttemptsStatement(ddl: string): string {
   const statement = splitSqlStatements(ddl).find(candidate =>
@@ -30,6 +34,14 @@ function completionFunctionStatement(ddl: string): string {
     /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+complete_payment_attempt\s*\(/iu.test(candidate),
   )
   assert.ok(statement, 'missing atomic payment-attempt completion function')
+  return statement.replace(/^\s*--.*$/gmu, '').replace(/\s+/gu, ' ').trim()
+}
+
+function attemptHistoryFunctionStatement(ddl: string): string {
+  const statement = splitSqlStatements(ddl).find(candidate =>
+    /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history\s*\(\s*\)/iu.test(candidate),
+  )
+  assert.ok(statement, 'missing payment-attempt history function')
   return statement.replace(/^\s*--.*$/gmu, '').replace(/\s+/gu, ' ').trim()
 }
 
@@ -145,9 +157,11 @@ test('terminal results and finality facts are complete, and immutable transition
 
 test('business writes can complete exactly one finalized attempt inside the same SQL statement', () => {
   const fresh = completionFunctionStatement(schemaDdl)
-  const upgrade = completionFunctionStatement(migrationDdl)
+  const initialUpgrade = completionFunctionStatement(migrationDdl)
+  const replayUpgrade = completionFunctionStatement(replayMigrationDdl)
 
-  assert.equal(upgrade, fresh)
+  assert.equal(replayUpgrade, fresh)
+  assert.match(initialUpgrade, /response_json\s*=\s*completion_response/iu)
   assert.match(fresh, /RETURNS\s+payment_attempts/iu)
   assert.match(fresh, /UPDATE\s+payment_attempts/iu)
   assert.match(fresh, /status\s*=\s*'completed'/iu)
@@ -159,7 +173,21 @@ test('business writes can complete exactly one finalized attempt inside the same
   assert.match(fresh, /finalized_block_hash\s+IS\s+NOT\s+NULL/iu)
   assert.match(fresh, /finalized_block_time\s+IS\s+NOT\s+NULL/iu)
   assert.match(fresh, /finalized_at\s+IS\s+NOT\s+NULL/iu)
+  assert.match(fresh, /response_json\s*#>>\s*'\{__1f3d9_x402_response_v1,header\}'/iu)
+  assert.match(fresh, /'body'\s*,\s*completion_response/iu)
   assert.match(fresh, /IF\s+NOT\s+FOUND[\s\S]*RAISE\s+EXCEPTION/iu)
+})
+
+test('a recorded facilitator response header is immutable before and after completion', () => {
+  const fresh = attemptHistoryFunctionStatement(schemaDdl)
+  const replayUpgrade = attemptHistoryFunctionStatement(replayMigrationDdl)
+
+  assert.equal(replayUpgrade, fresh)
+  assert.match(
+    fresh,
+    /OLD\.response_json\s*#>>\s*'\{__1f3d9_x402_response_v1,header\}'\s+IS\s+NOT\s+NULL/iu,
+  )
+  assert.match(fresh, /payment facilitator response is immutable/iu)
 })
 
 test('the global payment-use ledger is owned by one exact attempt and validates effects', () => {

--- a/test/payment-attempts.test.ts
+++ b/test/payment-attempts.test.ts
@@ -26,6 +26,13 @@ const PAYEE = '0x2222222222222222222222222222222222222222'
 const NONCE = `0x${'33'.repeat(32)}`
 const TX = `0x${'44'.repeat(32)}`
 const BLOCK_HASH = `0x${'55'.repeat(32)}`
+const FACILITATOR_RESPONSE_HEADER = Buffer.from(JSON.stringify({
+  success: true,
+  transaction: TX,
+  payer: PAYER,
+  network: 'base',
+  facilitator: 'https://facilitator.example.test',
+})).toString('base64')
 
 class QueuedDatabase implements PaymentAttemptQueryable {
   readonly calls: { text: string; params: readonly unknown[] }[] = []
@@ -300,6 +307,69 @@ test('transaction and finality evidence bind once under the lease', async () => 
   assert.match(database.calls[0]?.text ?? '', /lease_owner\s*=\s*\$\d+/iu)
 })
 
+test('facilitator response bytes survive evidence binding and durable row reload', async () => {
+  const pending = {
+    ...row({
+      status: 'payment_pending',
+      leaseOwner: 'lease_winner',
+      txHash: TX,
+      response: {
+        __1f3d9_x402_response_v1: { header: FACILITATOR_RESPONSE_HEADER },
+      },
+    }),
+  }
+  const database = new QueuedDatabase([pending])
+
+  const rebound = await bindPaymentEvidence(database, {
+    publicId: pending.publicId,
+    leaseOwner: 'lease_winner',
+    txHash: TX,
+    finality: null,
+    paymentResponseHeader: FACILITATOR_RESPONSE_HEADER,
+  })
+
+  assert.equal(database.calls[0]?.params[7], FACILITATOR_RESPONSE_HEADER)
+  assert.equal(rebound.paymentResponseHeader, FACILITATOR_RESPONSE_HEADER)
+  assert.equal(rebound.response, null)
+
+  const completed = {
+    ...pending,
+    status: 'completed' as const,
+    responseStatus: 201,
+    response: {
+      __1f3d9_x402_response_v1: {
+        header: FACILITATOR_RESPONSE_HEADER,
+        body: { ok: true, thing: { id: 42 } },
+      },
+    },
+  }
+  const reloaded = await findPaymentAttempt(new QueuedDatabase([completed]), {
+    actorId: completed.actorId,
+    operation: 'direct_sale',
+    offerId: completed.offerId!,
+  })
+
+  assert.equal(reloaded?.paymentResponseHeader, FACILITATOR_RESPONSE_HEADER)
+  assert.deepEqual(reloaded?.response, { ok: true, thing: { id: 42 } })
+})
+
+test('facilitator response persistence rejects malformed or oversized headers before SQL', async () => {
+  for (const paymentResponseHeader of ['not base64', 'A'.repeat(87_385)]) {
+    const database = new QueuedDatabase()
+    await assert.rejects(
+      bindPaymentEvidence(database, {
+        publicId: row().publicId,
+        leaseOwner: 'lease_winner',
+        txHash: TX,
+        finality: null,
+        paymentResponseHeader,
+      }),
+      (error: unknown) => error instanceof TypeError,
+    )
+    assert.equal(database.calls.length, 0)
+  }
+})
+
 test('evidence cannot overwrite a different transaction', async () => {
   const different = row({ status: 'payment_pending', leaseOwner: 'lease_winner', txHash: `0x${'77'.repeat(32)}` })
   const database = new QueuedDatabase([], [different])
@@ -403,6 +473,7 @@ test('public pending/completed views say not to pay again and omit payment secre
       responseStatus: 200,
       response: { ok: true },
     }),
+    paymentResponseHeader: FACILITATOR_RESPONSE_HEADER,
     request_json: { authorization: { signature: 'secret' } },
     x402_payload_digest: '66'.repeat(32),
   }
@@ -418,6 +489,7 @@ test('public pending/completed views say not to pay again and omit payment secre
     response: { ok: true },
   })
   assert.doesNotMatch(encoded, /authorization|signature|payload_digest|nonce/iu)
+  assert.equal(encoded.includes(FACILITATOR_RESPONSE_HEADER), false)
 
   assert.equal(toPublicPaymentAttempt(row({ status: 'payment_pending' })).do_not_pay_again, true)
   assert.equal(toPublicPaymentAttempt(row({ status: 'expired' })).do_not_pay_again, false)

--- a/test/payment-flow.test.ts
+++ b/test/payment-flow.test.ts
@@ -6,13 +6,21 @@ import {
   runDurableX402,
   type PaymentFlowDependencies,
 } from '../src/payment-flow.ts'
-import type { PaymentAttemptRecord } from '../src/payment-attempts.ts'
+import { findPaymentAttempt, type PaymentAttemptRecord } from '../src/payment-attempts.ts'
 
 const PAYER = '0x1111111111111111111111111111111111111111'
 const PAYEE = '0x2222222222222222222222222222222222222222'
 const TX = `0x${'33'.repeat(32)}`
 const BLOCK_HASH = `0x${'44'.repeat(32)}`
 const NONCE = `0x${'55'.repeat(32)}`
+const FACILITATOR_RESPONSE = {
+  success: true,
+  transaction: TX,
+  payer: PAYER,
+  network: 'base',
+  facilitator: 'https://facilitator.example.test',
+}
+const FACILITATOR_RESPONSE_HEADER = Buffer.from(JSON.stringify(FACILITATOR_RESPONSE)).toString('base64')
 const accepted = requirements(PAYEE, 2, '/api/transfer', 'test sale')
 const paymentHeader = Buffer.from(JSON.stringify({
   x402Version: 1,
@@ -97,7 +105,7 @@ function dependencies(
     verify: async () => { events.push('verify'); return { ...parsed, state: 'verified', verificationPayer: PAYER } },
     settle: async () => {
       events.push('settle')
-      return { state: 'settled', transaction: TX, payer: PAYER, response: { success: true, transaction: TX } }
+      return { state: 'settled', transaction: TX, payer: PAYER, response: FACILITATOR_RESPONSE }
     },
     bindEvidence: async (_database, input) => {
       events.push(input.finality ? 'bind-final' : 'bind-tx')
@@ -229,16 +237,28 @@ test('unfinalized evidence stays pending and releases the worker lease', async (
 
 test('a completed retry returns the stored canonical response without chain or facilitator calls', async () => {
   const events: string[] = []
+  const stored = attempt({
+    status: 'completed', responseStatus: 201,
+    txHash: TX,
+    response: {
+      __1f3d9_x402_response_v1: {
+        header: FACILITATOR_RESPONSE_HEADER,
+        body: { ok: true, thing: { id: 42 } },
+      },
+    },
+  })
+  const persisted = await findPaymentAttempt({ query: async () => [stored] }, {
+    actorId: stored.actorId,
+    operation: 'direct_sale',
+    offerId: stored.offerId!,
+  })
+  assert.ok(persisted)
   const deps = dependencies(events, {
     createOrRead: async () => {
       events.push('create')
       return {
         disposition: 'existing',
-        attempt: attempt({
-          status: 'completed', responseStatus: 201,
-          txHash: TX,
-          response: { ok: true, thing: { id: 42 } },
-        }),
+        attempt: persisted,
       }
     },
   })
@@ -248,13 +268,40 @@ test('a completed retry returns the stored canonical response without chain or f
   if (result.state === 'completed') {
     assert.equal(result.status, 201)
     assert.deepEqual(result.body, { ok: true, thing: { id: 42 } })
-    assert.ok(result.paymentResponseHeader)
+    assert.equal(result.paymentResponseHeader, FACILITATOR_RESPONSE_HEADER)
+    assert.deepEqual(JSON.parse(Buffer.from(result.paymentResponseHeader, 'base64').toString('utf8')), FACILITATOR_RESPONSE)
+  }
+  assert.deepEqual(events, ['block', 'create'])
+})
+
+test('a pre-upgrade completed row uses the compatibility receipt without another settlement', async () => {
+  const events: string[] = []
+  const deps = dependencies(events, {
+    createOrRead: async () => {
+      events.push('create')
+      return {
+        disposition: 'existing',
+        attempt: attempt({
+          status: 'completed',
+          responseStatus: 201,
+          txHash: TX,
+          response: { ok: true, thing: { id: 42 } },
+        }),
+      }
+    },
+  })
+
+  const result = await runDurableX402(input, deps)
+
+  assert.equal(result.state, 'completed')
+  if (result.state === 'completed') {
     assert.deepEqual(
-      JSON.parse(Buffer.from(result.paymentResponseHeader, 'base64').toString('utf8')),
+      JSON.parse(Buffer.from(result.paymentResponseHeader!, 'base64').toString('utf8')),
       { success: true, transaction: TX, payer: PAYER },
     )
   }
   assert.deepEqual(events, ['block', 'create'])
+  assert.equal(events.includes('settle'), false)
 })
 
 test('a finalized transfer outside the conservative window is terminally rejected', async () => {


### PR DESCRIPTION
## What changed\n\n- accept mobile privacy-browser form submissions only with exact same-origin browser evidence across join, rotate, recovery, and OAuth consent\n- fail identity routes closed when PUBLIC_ORIGIN is invalid while keeping public routes available\n- persist the exact successful x402 facilitator response for safe retry/replay without a second settlement\n- add the separate idempotent payment-response-replay migration\n\n## Root cause\n\nThe browser forms required an exact Origin header. Mobile privacy browsers can omit Origin (and sometimes Referer), so valid first-party submissions were rejected before any founder key, resident key, or recovery code was checked.\n\n## Verification\n\n- 494/494 unit tests\n- TypeScript type-check\n- 53/53 real PostgreSQL integration tests\n- 16/16 Chromium E2E tests\n- 16/16 Pixel 5 E2E tests\n- 88.32% line coverage\n- npm audit: 0 vulnerabilities\n- clean pushed-commit release preparation gate\n\n## Release order\n\n1. Verify the isolated Vercel preview.\n2. Apply the named payment-response-replay migration with the guarded Neon target and snapshot checks.\n3. Merge this PR to main; the linked Vercel project deploys that exact commit.\n4. Run live identity, rotation, recovery, connector, and one-payment canaries.\n