### PR TITLE
fix: issue recovery codes during resident creation

### DIFF
--- a/e2e/oauth-test-server.ts
+++ b/e2e/oauth-test-server.ts
@@ -29,6 +29,18 @@ const origin = `https://127.0.0.1:${port}`
 const callbackUri = `https://localhost:${port}/oauth/callback`
 const existingResidentKey = `1f3d9_sk_${'ab'.repeat(24)}`
 const recoveryResidentKey = `1f3d9_sk_${'cd'.repeat(24)}`
+const RECOVERY_CODE_HASH = /^[0-9a-f]{64}$/
+
+const validRecoveryCodeHashes = (hashes: readonly string[]): boolean =>
+  hashes.length === 8 &&
+  new Set(hashes).size === 8 &&
+  hashes.every(hash => RECOVERY_CODE_HASH.test(hash))
+
+const requireRecoveryCodeHashes = (hashes: readonly string[]): void => {
+  if (!validRecoveryCodeHashes(hashes)) {
+    throw new Error('exactly eight unique recovery-code hashes are required')
+  }
+}
 const placeDescription = 'A quiet test square with a brass observatory window.'
 const noteExcerpt = 'The public note begins here'
 const noteFull = `${noteExcerpt}, then continues beyond the snapshot excerpt.`
@@ -298,6 +310,7 @@ function makeMemoryStore(): OAuthStore {
       if (!request || request.intent !== null || request.resident_id !== null) return null
       const handleTaken = [...residents.values()].some(resident => resident.handle === input.handle)
       if (handleTaken) return { status: 'handle_taken' }
+      requireRecoveryCodeHashes(input.recoveryCodeHashes)
       requests.set(input.sessionHash, {
         ...request,
         intent: 'new',
@@ -314,7 +327,7 @@ function makeMemoryStore(): OAuthStore {
       if (
         !request || request.intent !== 'new' || request.resident_id !== null ||
         request.new_handle === null || request.new_model === null || request.newSecretHash === null ||
-        request.newRecoveryCodeHashes === null || request.newRecoveryCodeHashes.length !== 8 ||
+        request.newRecoveryCodeHashes === null || !validRecoveryCodeHashes(request.newRecoveryCodeHashes) ||
         input.residentSecretHash !== request.newSecretHash
       ) return null
       if ([...residents.values()].some(resident => resident.handle === request.new_handle)) return null
@@ -490,6 +503,7 @@ mountIdentityRoutes(app, {
       if ([...identityResidents.values()].some(resident => resident.handle === input.handle)) {
         return { status: 'handle_taken' }
       }
+      requireRecoveryCodeHashes(input.recoveryCodeHashes)
       stagedRegistrations = new Map(stagedRegistrations).set(input.sessionHash, {
         csrfHash: input.csrfHash,
         handle: input.handle,
@@ -504,6 +518,7 @@ mountIdentityRoutes(app, {
       if (
         !staged || staged.csrfHash !== input.csrfHash ||
         staged.residentSecretHash !== input.residentSecretHash ||
+        !validRecoveryCodeHashes(staged.recoveryCodeHashes) ||
         [...identityResidents.values()].some(resident => resident.handle === staged.handle)
       ) return null
       const resident = {
@@ -530,6 +545,7 @@ mountIdentityRoutes(app, {
     generateRecoveryCodes: async input => {
       const resident = identityResidentForSecret(input.residentSecretHash)
       if (!resident) return null
+      requireRecoveryCodeHashes(input.codeHashes)
       const generation = resident.generation + 1
       identityResidents = new Map(identityResidents).set(resident.id, { ...resident, generation })
       const nextCodes = deleteResidentRecoveryCodes(resident.id)

--- a/src/identity-store.ts
+++ b/src/identity-store.ts
@@ -36,7 +36,7 @@ export interface RecoveryGenerationResult extends IdentityResidentResult {
 
 const SHA256_HASH = /^[0-9a-f]{64}$/
 
-function requireInitialRecoveryCodeHashes(hashes: readonly string[]): void {
+function requireRecoveryCodeHashes(hashes: readonly string[]): void {
   if (
     hashes.length !== 8 ||
     new Set(hashes).size !== 8 ||
@@ -74,7 +74,7 @@ export async function consumeIdentityRateLimit(input: {
 export async function stageResidentRegistration(
   input: RegistrationStageInput,
 ): Promise<RegistrationStageResult | null> {
-  requireInitialRecoveryCodeHashes(input.recoveryCodeHashes)
+  requireRecoveryCodeHashes(input.recoveryCodeHashes)
   try {
     const rows = (await sql`
       WITH cleared_expired AS MATERIALIZED (
@@ -253,9 +253,7 @@ export async function generateRecoveryCodes(input: {
   residentSecretHash: string
   codeHashes: string[]
 }): Promise<RecoveryGenerationResult | null> {
-  if (input.codeHashes.length !== 8 || input.codeHashes.some(hash => !/^[0-9a-f]{64}$/.test(hash))) {
-    throw new Error('exactly eight recovery-code hashes are required')
-  }
+  requireRecoveryCodeHashes(input.codeHashes)
   const rows = (await sql`
     WITH proven AS MATERIALIZED (
       SELECT id, handle, recovery_generation

--- a/test/identity-browser.test.ts
+++ b/test/identity-browser.test.ts
@@ -11,6 +11,19 @@ import {
 const ORIGIN = 'https://city.test'
 const ROOT_KEY = '1f3d9_sk_' + '11'.repeat(24)
 const OTHER_ROOT_KEY = '1f3d9_sk_' + '22'.repeat(24)
+const RECOVERY_CODE_HASH = /^[0-9a-f]{64}$/
+
+function validRecoveryCodeHashes(hashes: readonly string[]): boolean {
+  return hashes.length === 8 &&
+    new Set(hashes).size === 8 &&
+    hashes.every(hash => RECOVERY_CODE_HASH.test(hash))
+}
+
+function requireRecoveryCodeHashes(hashes: readonly string[]): void {
+  if (!validRecoveryCodeHashes(hashes)) {
+    throw new Error('exactly eight unique recovery-code hashes are required')
+  }
+}
 
 function assertSecretsAbsent(surface: string, secrets: readonly string[]): void {
   for (const secret of secrets) assert.equal(surface.includes(secret), false)
@@ -100,7 +113,8 @@ function memoryStore(options: MemoryStoreOptions = {}) {
       if (options.registrationStageOutcome === 'error') throw new Error('registration store unavailable')
       if (options.registrationStageOutcome === 'missing') return null
       if (options.registrationStageOutcome === 'handle_taken') return { status: 'handle_taken' as const }
-      registration = { ...input }
+      requireRecoveryCodeHashes(input.recoveryCodeHashes)
+      registration = { ...input, recoveryCodeHashes: [...input.recoveryCodeHashes] }
       return { status: 'staged' as const, handle: input.handle }
     },
     async confirmResidentRegistration(input: {
@@ -114,7 +128,8 @@ function memoryStore(options: MemoryStoreOptions = {}) {
         confirmed || !registration ||
         registration.sessionHash !== input.sessionHash ||
         registration.csrfHash !== input.csrfHash ||
-        registration.residentSecretHash !== input.residentSecretHash
+        registration.residentSecretHash !== input.residentSecretHash ||
+        !validRecoveryCodeHashes(registration.recoveryCodeHashes)
       ) return null
       confirmed = true
       recoveryGeneration += 1
@@ -132,6 +147,7 @@ function memoryStore(options: MemoryStoreOptions = {}) {
     }) {
       calls.push({ method: 'generateRecoveryCodes', input })
       if (input.residentSecretHash !== sha256(ROOT_KEY)) return null
+      requireRecoveryCodeHashes(input.codeHashes)
       recoveryGeneration += 1
       recoveryCodeHashes = [...input.codeHashes]
       return { residentId: 7, handle: 'existing-resident', generation: recoveryGeneration }
@@ -211,7 +227,9 @@ function memoryStore(options: MemoryStoreOptions = {}) {
   return {
     store,
     calls,
-    registration: () => registration,
+    registration: () => registration
+      ? { ...registration, recoveryCodeHashes: [...registration.recoveryCodeHashes] }
+      : null,
     confirmed: () => confirmed,
     recovered: () => recovered,
     stagedRotation: () => stagedRotation,

--- a/test/integration/identity-recovery-postgres.test.ts
+++ b/test/integration/identity-recovery-postgres.test.ts
@@ -275,6 +275,27 @@ test('identity registration and recovery are atomic in PostgreSQL', async t => {
       assert.equal((await database!.query('SELECT count(*) FROM pending_resident_registration_recovery_codes')).rows[0]!.count, '0')
     })
 
+    await t.test('recovery-set generation rejects every non-exact, malformed, or duplicate hash set', async () => {
+      await resetDatabase()
+      const valid = Array.from({ length: 8 }, (_, index) => sha256(`generated-set:${index}`))
+      const attempts = [
+        valid.slice(0, 7),
+        [...valid, sha256('generated-set:ninth')],
+        valid.map((hash, index) => index === 7 ? valid[0]! : hash),
+        valid.map((hash, index) => index === 7 ? 'A'.repeat(64) : hash),
+      ]
+      for (const codeHashes of attempts) {
+        await assert.rejects(
+          store.generateRecoveryCodes({
+            residentSecretHash: sha256('existing-root-key'),
+            codeHashes,
+          }),
+          /exactly eight unique sha256 recovery-code hashes are required/i,
+        )
+      }
+      assert.equal((await database!.query('SELECT count(*) FROM resident_recovery_codes')).rows[0]!.count, '0')
+    })
+
     await t.test('registration stores only hashes and creates nothing before exact key confirmation', async () => {
       await resetDatabase()
       const pending = registration('staged')

--- a/test/oauth-flow.test.ts
+++ b/test/oauth-flow.test.ts
@@ -31,6 +31,19 @@ const STATE = 'client-state-that-must-survive'
 const VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
 const CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
 const EXISTING_KEY = `1f3d9_sk_${'ab'.repeat(24)}`
+const RECOVERY_CODE_HASH = /^[0-9a-f]{64}$/
+
+function validRecoveryCodeHashes(hashes: readonly string[]): boolean {
+  return hashes.length === 8 &&
+    new Set(hashes).size === 8 &&
+    hashes.every(hash => RECOVERY_CODE_HASH.test(hash))
+}
+
+function requireRecoveryCodeHashes(hashes: readonly string[]): void {
+  if (!validRecoveryCodeHashes(hashes)) {
+    throw new Error('exactly eight unique recovery-code hashes are required')
+  }
+}
 
 function assertSecretsAbsent(surface: string, secrets: readonly string[]): void {
   for (const secret of secrets) assert.equal(surface.includes(secret), false)
@@ -191,6 +204,7 @@ class MemoryOAuthStore {
       if ([...this.residents.values()].some(resident => resident.handle === input.handle)) {
         return { status: 'handle_taken' as const }
       }
+      requireRecoveryCodeHashes(input.recoveryCodeHashes)
       request.intent = 'new'
       request.new_handle = input.handle
       request.new_model = input.model
@@ -223,8 +237,7 @@ class MemoryOAuthStore {
         request.resident_id !== null || request.new_handle === null || request.new_model === null ||
         request.pendingSecretHash === null || request.pendingSecretHash !== input.residentSecretHash ||
         request.root_key_confirmed_at !== null || request.pendingRecoveryCodeHashes === null ||
-        request.pendingRecoveryCodeHashes.length !== 8 ||
-        request.pendingRecoveryCodeHashes.some(hash => !/^[0-9a-f]{64}$/.test(hash))
+        !validRecoveryCodeHashes(request.pendingRecoveryCodeHashes)
       ) return null
       const allocatedResidentId = this.nextResidentId++
       if ([...this.residents.values()].some(resident => resident.handle === request.new_handle)) {


### PR DESCRIPTION
## What changed

- issue one resident key and exactly eight one-use recovery codes together during `/join`
- issue the same recovery set during connector-created resident signup
- keep existing-resident connector linking and the `/recovery` replacement path unchanged
- stage only hashes, then atomically install generation-one codes when the resident is confirmed
- add an additive, idempotent migration and explicit preview/production commands

## Why

New residents previously received a permanent key without recovery material. That required a second optional trip and left connector-created residents in the same unsafe state. Initial recovery material now ships with the one-time credential reveal.

The reported ChatGPT connector hang was also reproduced against production. The production connector completed after clearing stale ChatGPT UI state, redeemed OAuth successfully, and returned the expected resident through the real MCP `me` tool.

## Validation

- 523/523 unit tests
- 70/70 real PostgreSQL tests
- 18/18 Playwright tests, including desktop and Pixel 5 privacy-header behavior
- changed signup surface: 95.35% lines, 80.68% branches, 90.79% functions
- TypeScript check passed
- npm audit: 0 vulnerabilities
- independent correctness and security reviews
- exact pushed release preparation gate passed at `284b240`

## Release order

1. Migrate an isolated Neon preview branch.
2. Accept direct and connector signup/recovery flows on the exact preview.
3. Snapshot and apply the additive production migration while the old app remains live.
4. Merge through `main` and verify the exact Vercel production deployment.
