### PR TITLE
feat: enforce time limits on every migration path

### DIFF
--- a/docs/runbooks/DEPLOYMENT.md
+++ b/docs/runbooks/DEPLOYMENT.md
@@ -25,6 +25,31 @@ Database migrations are separate operations. Run only the explicitly named
 `npm run migrate:*` command appropriate to the migration and environment. A
 deployment must never apply a migration as a side effect.
 
+### When a migration times out
+
+Every migration runs inside one transaction that the runner starts with
+`SET LOCAL lock_timeout = '5s'` and `SET LOCAL statement_timeout = '120s'`
+(a migration file may override either with its own `SET LOCAL`). A timeout
+aborts that whole transaction, so nothing partial commits: the database is
+exactly as it was before the command.
+
+If the command fails with `lock_not_available` (SQLSTATE `55P03`), something
+was holding a lock on a table the migration needs — usually ordinary city
+traffic or another operator session. If it fails with
+`canceling statement due to statement timeout` (SQLSTATE `57014`), one
+statement did more work than expected.
+
+Diagnose before rerunning; do not retry in a loop:
+
+1. In the Neon console, check `pg_stat_activity` for long-running queries and
+   who holds locks on the named table.
+2. For a lock wait, rerun the same named `migrate:*` command once the holder
+   is gone or during a quieter moment.
+3. For a statement timeout, measure the data volume the statement touches. If
+   the work is legitimately heavier than 120 seconds, the migration file
+   itself should set its own explicit `SET LOCAL statement_timeout` with a
+   reviewed justification, rather than the limit being raised globally.
+
 ## Verify production
 
 1. Record the full GitHub `main` SHA:

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -434,7 +434,18 @@ export function splitSqlStatements(ddl: string): string[] {
   return statements
 }
 
-export async function applyMigration(databaseUrl: string, ddl: string): Promise<number> {
+export const MIGRATION_LOCK_TIMEOUT = '5s'
+export const MIGRATION_STATEMENT_TIMEOUT = '120s'
+
+/**
+ * Every migration statement runs inside one transaction whose first commands
+ * enforce short lock and statement time limits, so a bad deploy can neither
+ * wait on nor hold a live lock indefinitely. A migration that needs different
+ * limits sets its own SET LOCAL afterwards, which wins for the rest of its
+ * transaction. A timeout aborts the whole transaction, so nothing partial
+ * ever commits.
+ */
+export function prepareMigrationStatements(ddl: string): string[] {
   const statements = splitSqlStatements(ddl)
   if (statements.length === 0) throw new Error('migration contains no SQL statements')
 
@@ -452,11 +463,20 @@ export async function applyMigration(databaseUrl: string, ddl: string): Promise<
     throw new Error('migration contains an unexpected transaction boundary')
   }
 
+  return [
+    `SET LOCAL lock_timeout = '${MIGRATION_LOCK_TIMEOUT}'`,
+    `SET LOCAL statement_timeout = '${MIGRATION_STATEMENT_TIMEOUT}'`,
+    ...runnableStatements,
+  ]
+}
+
+export async function applyMigration(databaseUrl: string, ddl: string): Promise<number> {
+  const runnableStatements = prepareMigrationStatements(ddl)
   const sql = neon(databaseUrl)
   await sql.transaction(transaction =>
     runnableStatements.map(statement => transaction.query(statement)),
   )
-  return statements.length
+  return runnableStatements.length
 }
 
 async function main(): Promise<void> {

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -1,7 +1,13 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
-import { resolveMigrationRun, splitSqlStatements } from '../scripts/migrate.ts'
+import { readFileSync, readdirSync } from 'node:fs'
+import {
+  MIGRATION_LOCK_TIMEOUT,
+  MIGRATION_STATEMENT_TIMEOUT,
+  prepareMigrationStatements,
+  resolveMigrationRun,
+  splitSqlStatements,
+} from '../scripts/migrate.ts'
 
 const schemaDdl = readFileSync(new URL('../db/schema.sql', import.meta.url), 'utf8')
 
@@ -306,6 +312,41 @@ test('the loopback full schema upgrades a legacy tree before final root indexes'
     schemaDdl,
     /INSERT\s+INTO\s+resident_presence[\s\S]*?ON\s+CONFLICT\s*\(resident_id\)\s+DO\s+UPDATE[\s\S]*?current_place_id\s*=\s*coalesce/i,
   )
+})
+
+test('every migration path runs under enforced lock and statement time limits', () => {
+  const migrationsDirectory = new URL('../db/migrations/', import.meta.url)
+  const migrationFiles = readdirSync(migrationsDirectory).filter(name => name.endsWith('.sql'))
+  assert.ok(migrationFiles.length >= 14)
+
+  for (const file of [...migrationFiles, 'schema.sql']) {
+    const ddl = file === 'schema.sql'
+      ? schemaDdl
+      : readFileSync(new URL(file, migrationsDirectory), 'utf8')
+    const statements = prepareMigrationStatements(ddl)
+    assert.equal(
+      statements[0],
+      `SET LOCAL lock_timeout = '${MIGRATION_LOCK_TIMEOUT}'`,
+      `${file} must start with the enforced lock timeout`,
+    )
+    assert.equal(
+      statements[1],
+      `SET LOCAL statement_timeout = '${MIGRATION_STATEMENT_TIMEOUT}'`,
+      `${file} must enforce the statement timeout`,
+    )
+  }
+})
+
+test('a migration that sets its own limits overrides the enforced defaults', () => {
+  const topology = readFileSync(
+    new URL('../db/migrations/20260814_world_root_topology.sql', import.meta.url),
+    'utf8',
+  )
+
+  const statements = prepareMigrationStatements(topology)
+  const ownLockTimeout = statements.findIndex((statement, index) =>
+    index >= 2 && /SET\s+LOCAL\s+lock_timeout/i.test(statement))
+  assert.ok(ownLockTimeout > 1, 'the file keeps its own lock timeout after the enforced one')
 })
 
 test('world-root topology is one bounded transaction with database backstops', () => {


### PR DESCRIPTION
## Summary

Wave 2, item 15 of the audit outcome plan: time-bounded migrations.

- The migration runner (`prepareMigrationStatements` in `scripts/migrate.ts`) begins every migration transaction with `SET LOCAL lock_timeout = '5s'` and `SET LOCAL statement_timeout = '120s'`, so a bad deploy can neither wait on nor hold a live lock indefinitely. A timeout aborts the whole transaction — nothing partial commits.
- A migration file may override either limit with its own `SET LOCAL` (the two 20260814 world-root migrations already do; the override is covered by a test).
- A repo-wide test now proves the enforced limits on every file in `db/migrations/` plus the full `db/schema.sql` install — previously only one file was checked and all six wave-1 migrations shipped without limits.
- `docs/runbooks/DEPLOYMENT.md` explains how to diagnose `55P03` (lock wait) and `57014` (statement work) timeouts without blind retries.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 560/560
- [x] Release gate (`deploy.sh --prepare`) exit 0 on the pushed commit
- [x] Adversarial review: zero findings (including verification that `SET LOCAL` applies across the driver's single-transaction batch)
- [ ] Vercel preview healthy (no runtime code changes — scripts, tests, docs only)