### PR TITLE
feat: retire expired sign-in records after a forensic window

### DIFF
--- a/db/migrations/20260818_signin_retention.sql
+++ b/db/migrations/20260818_signin_retention.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+-- Sign-in data retention (docs/runbooks/SIGNIN_RETENTION.md). Retention
+-- pruning scans expired sign-in rows in every terminal state, which the
+-- existing partial live-row expiry indexes cannot serve. These three additive
+-- indexes keep each bounded retention batch an index scan. The tables are
+-- small, so plain CREATE INDEX inside the timeout-guarded transaction is safe.
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '30s';
+
+CREATE INDEX IF NOT EXISTS oauth_authorization_requests_retention
+  ON oauth_authorization_requests (expires_at, id);
+
+CREATE INDEX IF NOT EXISTS oauth_authorization_codes_retention
+  ON oauth_authorization_codes (expires_at, id);
+
+CREATE INDEX IF NOT EXISTS oauth_token_families_retention
+  ON oauth_token_families (expires_at, id);
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -277,6 +277,10 @@ CREATE INDEX IF NOT EXISTS oauth_authorization_requests_expiry
 CREATE INDEX IF NOT EXISTS oauth_authorization_requests_resident
   ON oauth_authorization_requests (resident_id, created_at DESC)
   WHERE resident_id IS NOT NULL;
+-- Retention pruning scans expired rows in every terminal state, which the
+-- partial live-row index above cannot serve. See docs/runbooks/SIGNIN_RETENTION.md.
+CREATE INDEX IF NOT EXISTS oauth_authorization_requests_retention
+  ON oauth_authorization_requests (expires_at, id);
 
 CREATE TABLE IF NOT EXISTS oauth_authorization_request_recovery_codes (
   request_id BIGINT NOT NULL
@@ -310,6 +314,8 @@ CREATE INDEX IF NOT EXISTS oauth_authorization_codes_expiry
   ON oauth_authorization_codes (expires_at, id) WHERE used_at IS NULL;
 CREATE INDEX IF NOT EXISTS oauth_authorization_codes_resident
   ON oauth_authorization_codes (resident_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS oauth_authorization_codes_retention
+  ON oauth_authorization_codes (expires_at, id);
 
 CREATE TABLE IF NOT EXISTS oauth_token_families (
   id            BIGSERIAL PRIMARY KEY,
@@ -328,6 +334,8 @@ CREATE INDEX IF NOT EXISTS oauth_token_families_resident
   ON oauth_token_families (resident_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS oauth_token_families_active
   ON oauth_token_families (expires_at, id) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS oauth_token_families_retention
+  ON oauth_token_families (expires_at, id);
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   id                    BIGSERIAL PRIMARY KEY,

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,9 @@ Operations:
   production and how to verify or roll it back.
 - [runbooks/BACKUP_RESTORE.md](runbooks/BACKUP_RESTORE.md) covers Neon snapshots, local
   backups, restore drills, and recovery evidence.
+- [runbooks/SIGNIN_RETENTION.md](runbooks/SIGNIN_RETENTION.md) states how long each
+  sign-in record type lives, how pruning rides ordinary OAuth traffic, and how
+  backup rotation bounds what deletion leaves behind.
 - [runbooks/ENVIRONMENT.md](runbooks/ENVIRONMENT.md) records which ignored environment
   files are active, duplicated, or temporary without exposing their values.
 

--- a/docs/runbooks/SIGNIN_RETENTION.md
+++ b/docs/runbooks/SIGNIN_RETENTION.md
@@ -1,0 +1,83 @@
+# Sign-in data retention
+
+Hosted-chat sign-in leaves records behind: authorization requests, authorization
+codes, token families, and token rows. They contain only hashes and OAuth
+metadata, but they still describe who signed in, from which client, and when.
+This runbook states how long each record type lives, why, and how deletion
+actually happens in a city with no cron.
+
+## Retention periods
+
+Every sign-in record type is removed **30 days after the last moment it could
+have authenticated anything** — its own `expires_at`. Thirty days is the
+incident-forensics window: a compromised sign-in reported within a month can
+still be reconstructed from the live database, and after that the record is
+noise with privacy cost. No record is ever deleted while a live grant could
+still need it.
+
+| Record | Live lifetime | Terminal states | Removed from the live database |
+|---|---|---|---|
+| `oauth_authorization_requests` | 15 minutes | used, canceled, expired (secret hashes scrubbed at the terminal state) | 30 days after `expires_at`, and only once no authorization code references the row |
+| `oauth_authorization_request_recovery_codes` | with their request | deleted when the request reaches a terminal state | at the latest with their request (`ON DELETE CASCADE`) |
+| `oauth_authorization_codes` | 5 minutes | used, expired | 30 days after `expires_at` |
+| `oauth_token_families` | up to 30 days | expired, revoked | 30 days after `expires_at`, whether or not the family was revoked earlier |
+| `oauth_tokens` (access and refresh) | 10 minutes / family lifetime | used, revoked, expired | together with their family — 30 days after the family's `expires_at` |
+| `oauth_rate_limits` | 1-hour windows | — | pruned inline once a window is older than 24 hours (pre-existing behavior) |
+
+Why the token rows and families share one clock:
+
+- Refresh-token **reuse detection** matches previously *used* refresh rows and
+  revokes the whole family. Deleting used or revoked token rows before the
+  family would blind that check and erase the evidence it produces.
+- A rotation chain (`rotated_from_token_id`) is only interpretable whole. Rows
+  are removed newest-link-first, and the family row — with its `revoke_reason`,
+  including `refresh token reuse` — is the last thing to go.
+- A family revoked early keeps its **full** window measured from `expires_at`,
+  so revocation evidence always outlives the incident that caused it.
+
+Expired authorization requests and codes keep their metadata (client, redirect
+URI, timestamps) for the same window because that metadata is what reconstructs
+a phishing or client-impersonation attempt. Their secret hashes never wait for
+retention: they are scrubbed the moment the row reaches a terminal state.
+
+## How deletion runs without a cron
+
+The city only advances when someone acts, so there is no scheduled job.
+Retention deletion rides the shared OAuth throttle statement in
+`consumeOAuthRateLimit` (`src/oauth-store.ts`) — the same statement that already
+prunes stale `oauth_rate_limits` windows inline, and one that every `/oauth`
+route passes through. Each pass deletes at most `SIGNIN_RETENTION_BATCH` rows
+per record type, so a single request never does unbounded work and any backlog
+drains across ordinary traffic. Deletes are index scans over the additive
+`*_retention` indexes (`db/migrations/20260818_signin_retention.sql`).
+
+If the sign-in door sees no traffic, nothing is pruned — and nothing new
+accumulates either. The next request picks the backlog up in bounded batches.
+
+## Records this policy does not touch
+
+- **Identity records** are not sign-in records: `residents.secret_hash`,
+  `resident_recovery_codes`, `resident_key_rotations`, and
+  `pending_resident_registrations` keep their existing scrub-at-terminal-state
+  behavior and are out of scope here.
+- **Public city records** (places, things, notes, agreements, events, actions)
+  are the public record and are never deleted.
+
+## Backups do not quietly defeat this policy
+
+Backup layers are documented in [BACKUP_RESTORE.md](BACKUP_RESTORE.md); their
+retention bounds how long a deleted sign-in record can outlive the live delete:
+
+- Neon point-in-time history covers 6 hours; automatic provider snapshots run
+  daily and are retained for 14 days. A pruned sign-in record therefore leaves
+  every provider recovery layer at most 14 days after it leaves the live
+  database (plus the lifetime of any named permanent snapshot, which should be
+  deleted when its release risk has passed).
+- Manual `pg_dump` archives contain the sign-in tables and are exactly as
+  sensitive as the live rows. Keep them in the owner-private directory the
+  backup runbook requires, and delete an archive once it is no longer needed
+  for the incident or release that justified it — an archive kept forever is a
+  retention policy of forever.
+- A restore that resurrects already-pruned sign-in rows is self-healing: the
+  first OAuth request after the restore prunes everything past retention again,
+  in the same bounded batches.

--- a/docs/runbooks/SIGNIN_RETENTION.md
+++ b/docs/runbooks/SIGNIN_RETENTION.md
@@ -17,7 +17,7 @@ still need it.
 
 | Record | Live lifetime | Terminal states | Removed from the live database |
 |---|---|---|---|
-| `oauth_authorization_requests` | 15 minutes | used, canceled, expired (secret hashes scrubbed at the terminal state) | 30 days after `expires_at`, and only once no authorization code references the row |
+| `oauth_authorization_requests` | 15 minutes | used, canceled, expired (staged new-resident secrets scrubbed at the terminal state) | 30 days after `expires_at`, and only once no authorization code references the row |
 | `oauth_authorization_request_recovery_codes` | with their request | deleted when the request reaches a terminal state | at the latest with their request (`ON DELETE CASCADE`) |
 | `oauth_authorization_codes` | 5 minutes | used, expired | 30 days after `expires_at` |
 | `oauth_token_families` | up to 30 days | expired, revoked | 30 days after `expires_at`, whether or not the family was revoked earlier |
@@ -37,8 +37,13 @@ Why the token rows and families share one clock:
 
 Expired authorization requests and codes keep their metadata (client, redirect
 URI, timestamps) for the same window because that metadata is what reconstructs
-a phishing or client-impersonation attempt. Their secret hashes never wait for
-retention: they are scrubbed the moment the row reaches a terminal state.
+a phishing or client-impersonation attempt. Staged new-resident material — the
+proposed key hash and pending recovery-code hashes — is scrubbed when the row
+reaches a terminal state (lazily for expiry, during the next sign-in request).
+The rows' own lookup hashes (`code_hash`, `session_hash`, `csrf_hash`) are
+schema-required and remain until the retention delete; none of them can
+authenticate anything once expired, because every consumption path requires
+`expires_at` to still be in the future.
 
 ## How deletion runs without a cron
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "migrate:preview:identity-recovery": "node --experimental-strip-types scripts/migrate.ts --target preview --migration identity-recovery",
     "migrate:preview:identity-rotation": "node --experimental-strip-types scripts/migrate.ts --target preview --migration identity-rotation",
     "migrate:preview:initial-recovery-codes": "node --experimental-strip-types scripts/migrate.ts --target preview --migration initial-recovery-codes",
+    "migrate:preview:signin-retention": "node --experimental-strip-types scripts/migrate.ts --target preview --migration signin-retention",
     "migrate:production:world-root-expand": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-expand",
     "migrate:production:world-root-topology": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-topology",
     "migrate:production:public-pagination": "node --experimental-strip-types scripts/migrate.ts --target production --migration public-pagination",
@@ -46,7 +47,8 @@
     "migrate:production:payment-response-body-validate": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-response-body-validate",
     "migrate:production:identity-recovery": "node --experimental-strip-types scripts/migrate.ts --target production --migration identity-recovery",
     "migrate:production:identity-rotation": "node --experimental-strip-types scripts/migrate.ts --target production --migration identity-rotation",
-    "migrate:production:initial-recovery-codes": "node --experimental-strip-types scripts/migrate.ts --target production --migration initial-recovery-codes"
+    "migrate:production:initial-recovery-codes": "node --experimental-strip-types scripts/migrate.ts --target production --migration initial-recovery-codes",
+    "migrate:production:signin-retention": "node --experimental-strip-types scripts/migrate.ts --target production --migration signin-retention"
   },
   "dependencies": {
     "@hono/node-server": "^2.1.0",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -29,6 +29,7 @@ type RemoteMigration =
   | 'identity-recovery'
   | 'identity-rotation'
   | 'initial-recovery-codes'
+  | 'signin-retention'
 
 type MigrationFile =
   | 'db/schema.sql'
@@ -46,6 +47,7 @@ type MigrationFile =
   | 'db/migrations/20260816_identity_recovery.sql'
   | 'db/migrations/20260816_identity_rotation.sql'
   | 'db/migrations/20260817_initial_recovery_codes.sql'
+  | 'db/migrations/20260818_signin_retention.sql'
 
 type MigrationEnvironment = Readonly<Record<string, string | undefined>>
 
@@ -85,6 +87,7 @@ const REMOTE_MIGRATIONS: Readonly<Record<RemoteMigration, MigrationFile>> = {
   'identity-recovery': 'db/migrations/20260816_identity_recovery.sql',
   'identity-rotation': 'db/migrations/20260816_identity_rotation.sql',
   'initial-recovery-codes': 'db/migrations/20260817_initial_recovery_codes.sql',
+  'signin-retention': 'db/migrations/20260818_signin_retention.sql',
 }
 
 function namedArgument(args: readonly string[], name: string): string | undefined {
@@ -100,7 +103,7 @@ function remoteMigrationArgument(args: readonly string[]): RemoteMigration {
   const requested = namedArgument(args, 'migration')
   if (!requested || !(requested in REMOTE_MIGRATIONS)) {
     throw new Error(
-      'remote migration requires --migration hosted-chat-signin|world-root-expand|world-root-topology|public-pagination|agreement-accession|open-to-use|payment-attempts|payment-response-replay|payment-response-body-replay|payment-response-body-rollout|payment-response-body-validate|identity-recovery|identity-rotation|initial-recovery-codes',
+      'remote migration requires --migration hosted-chat-signin|world-root-expand|world-root-topology|public-pagination|agreement-accession|open-to-use|payment-attempts|payment-response-replay|payment-response-body-replay|payment-response-body-rollout|payment-response-body-validate|identity-recovery|identity-rotation|initial-recovery-codes|signin-retention',
     )
   }
   return requested as RemoteMigration

--- a/src/oauth-store.ts
+++ b/src/oauth-store.ts
@@ -74,6 +74,16 @@ export type RefreshRotationResult = 'rotated' | 'reused' | 'invalid'
 
 const SHA256_HASH = /^[0-9a-f]{64}$/
 
+// Sign-in records stay readable for incident forensics for this long after the
+// last moment they could have authenticated anything, then leave the live
+// database. Documented in docs/runbooks/SIGNIN_RETENTION.md; the unit tests
+// keep this constant and that document in agreement.
+const SIGNIN_RETENTION_WINDOW = '30 days'
+
+// The city has no cron: retention deletion rides every OAuth throttle check in
+// bounded batches so one request never does unbounded cleanup work.
+const SIGNIN_RETENTION_BATCH = 50
+
 function requireInitialRecoveryCodeHashes(hashes: readonly string[]): void {
   if (
     hashes.length !== 8 ||
@@ -611,12 +621,74 @@ export async function consumeOAuthRateLimit(input: {
   attemptKind: OAuthAttemptKind
   maximum: number
 }): Promise<boolean> {
+  // Every OAuth route passes through this throttle, so sign-in retention rides
+  // the same statement as the existing rate-limit prune. Each record type is
+  // deleted only after SIGNIN_RETENTION_WINDOW past its own expiry, in bounded
+  // batches. Order protects the foreign keys: an authorization code goes before
+  // the request it references, and every token row of a family goes (newest
+  // rotation link first) before the family row itself, which keeps refresh
+  // reuse detection intact for the family's whole forensic window.
   const rows = (await sql`
     WITH current_window AS MATERIALIZED (
       SELECT date_trunc('hour', now(), 'UTC') AS window_start
     ), cleanup AS (
       DELETE FROM oauth_rate_limits
       WHERE window_start < (SELECT window_start FROM current_window) - interval '24 hours'
+    ), retired_codes AS MATERIALIZED (
+      SELECT id
+      FROM oauth_authorization_codes
+      WHERE expires_at <= now() - ${SIGNIN_RETENTION_WINDOW}::interval
+      ORDER BY expires_at, id
+      LIMIT ${SIGNIN_RETENTION_BATCH}
+    ), pruned_codes AS (
+      DELETE FROM oauth_authorization_codes code
+      USING retired_codes retired
+      WHERE code.id = retired.id
+      RETURNING code.id
+    ), retired_requests AS MATERIALIZED (
+      SELECT request.id
+      FROM oauth_authorization_requests request
+      WHERE request.expires_at <= now() - ${SIGNIN_RETENTION_WINDOW}::interval
+        AND NOT EXISTS (
+          SELECT 1 FROM oauth_authorization_codes code
+          WHERE code.request_id = request.id
+            AND code.id NOT IN (SELECT id FROM retired_codes)
+        )
+      ORDER BY request.expires_at, request.id
+      LIMIT ${SIGNIN_RETENTION_BATCH}
+    ), pruned_requests AS (
+      DELETE FROM oauth_authorization_requests request
+      USING retired_requests retired
+      WHERE request.id = retired.id
+      RETURNING request.id
+    ), retired_tokens AS MATERIALIZED (
+      SELECT token.id
+      FROM oauth_tokens token
+      JOIN oauth_token_families family ON family.id = token.family_id
+      WHERE family.expires_at <= now() - ${SIGNIN_RETENTION_WINDOW}::interval
+      ORDER BY token.id DESC
+      LIMIT ${SIGNIN_RETENTION_BATCH}
+    ), pruned_tokens AS (
+      DELETE FROM oauth_tokens token
+      USING retired_tokens retired
+      WHERE token.id = retired.id
+      RETURNING token.id
+    ), retired_families AS MATERIALIZED (
+      SELECT family.id
+      FROM oauth_token_families family
+      WHERE family.expires_at <= now() - ${SIGNIN_RETENTION_WINDOW}::interval
+        AND NOT EXISTS (
+          SELECT 1 FROM oauth_tokens token
+          WHERE token.family_id = family.id
+            AND token.id NOT IN (SELECT id FROM retired_tokens)
+        )
+      ORDER BY family.expires_at, family.id
+      LIMIT ${SIGNIN_RETENTION_BATCH}
+    ), pruned_families AS (
+      DELETE FROM oauth_token_families family
+      USING retired_families retired
+      WHERE family.id = retired.id
+      RETURNING family.id
     ), admitted AS (
       INSERT INTO oauth_rate_limits (bucket_hash, attempt_kind, window_start, used)
       SELECT ${input.bucketHash}, ${input.attemptKind}, window_start, 1

--- a/test/integration/oauth-postgres.test.ts
+++ b/test/integration/oauth-postgres.test.ts
@@ -174,6 +174,57 @@ async function seedAuthorizationCode(
   })
 }
 
+async function ageSignInFlowPastExpiry(
+  sessionHash: string,
+  anchorTokenHash: string,
+  agedInterval: string,
+): Promise<void> {
+  assert.ok(database)
+  await database.query(
+    `UPDATE oauth_authorization_requests
+     SET created_at = now() - $1::interval - interval '15 minutes',
+         expires_at = now() - $1::interval
+     WHERE session_hash = $2`,
+    [agedInterval, sessionHash],
+  )
+  await database.query(
+    `UPDATE oauth_authorization_codes code
+     SET created_at = now() - $1::interval - interval '5 minutes',
+         expires_at = now() - $1::interval
+     FROM oauth_authorization_requests request
+     WHERE request.id = code.request_id AND request.session_hash = $2`,
+    [agedInterval, sessionHash],
+  )
+  await database.query(
+    `UPDATE oauth_token_families family
+     SET created_at = now() - $1::interval - interval '30 days',
+         expires_at = now() - $1::interval
+     FROM oauth_tokens token
+     WHERE token.family_id = family.id AND token.token_hash = $2`,
+    [agedInterval, anchorTokenHash],
+  )
+  await database.query(
+    `UPDATE oauth_tokens token
+     SET created_at = now() - $1::interval - interval '10 minutes',
+         expires_at = now() - $1::interval
+     FROM oauth_tokens anchor
+     WHERE anchor.token_hash = $2 AND token.family_id = anchor.family_id`,
+    [agedInterval, anchorTokenHash],
+  )
+}
+
+async function signInRowCounts(): Promise<Record<string, string>> {
+  assert.ok(database)
+  const state = await database.query<Record<string, string>>(
+    `SELECT
+       (SELECT count(*) FROM oauth_authorization_requests)::text AS requests,
+       (SELECT count(*) FROM oauth_authorization_codes)::text AS codes,
+       (SELECT count(*) FROM oauth_token_families)::text AS families,
+       (SELECT count(*) FROM oauth_tokens)::text AS tokens`,
+  )
+  return state.rows[0]!
+}
+
 async function exchangeExistingResidentCode(store: OAuthStore, label: string) {
   const request = authorizationRequestInput(label)
   const codeHash = sha256(`${label}:authorization-code`)
@@ -1268,6 +1319,100 @@ test('OAuth authorization writes roll back atomically in PostgreSQL', async t =>
         [bucketHash],
       )
       assert.deepEqual(rows.rows[0], { authorize_used: 3, stale_rows: '0' })
+    })
+
+    await t.test('sign-in records survive the forensic window and are pruned only after it', async () => {
+      await resetDatabase()
+      const inside = await exchangeExistingResidentCode(store, 'retention-inside-window')
+      const past = await exchangeExistingResidentCode(store, 'retention-past-window')
+      for (const [flow, label] of [[inside, 'retention-inside-window'], [past, 'retention-past-window']] as const) {
+        assert.equal(await store.rotateRefreshToken({
+          presentedRefreshTokenHash: flow.refreshTokenHash,
+          clientId: flow.request.clientId,
+          resource: flow.request.resource,
+          accessTokenHash: sha256(`${label}:rotated-access`),
+          newRefreshTokenHash: sha256(`${label}:rotated-refresh`),
+        }), 'rotated')
+      }
+      assert.deepEqual(await signInRowCounts(), {
+        requests: '2', codes: '2', families: '2', tokens: '8',
+      })
+
+      await ageSignInFlowPastExpiry(past.request.sessionHash, past.accessTokenHash, '31 days')
+      await ageSignInFlowPastExpiry(inside.request.sessionHash, inside.accessTokenHash, '29 days')
+
+      assert.equal(await store.consumeOAuthRateLimit({
+        bucketHash: sha256('retention-prune-bucket'),
+        attemptKind: 'token',
+        maximum: 10,
+      }), true)
+
+      assert.deepEqual(await signInRowCounts(), {
+        requests: '1', codes: '1', families: '1', tokens: '4',
+      })
+      const survivors = await database!.query<{ sessions: string[]; anchor_tokens: string }>(
+        `SELECT
+           (SELECT array_agg(session_hash) FROM oauth_authorization_requests) AS sessions,
+           (SELECT count(*) FROM oauth_tokens WHERE token_hash = $1)::text AS anchor_tokens`,
+        [inside.refreshTokenHash],
+      )
+      assert.deepEqual(survivors.rows[0], {
+        sessions: [inside.request.sessionHash],
+        anchor_tokens: '1',
+      })
+
+      const replay = {
+        clientId: inside.request.clientId,
+        resource: inside.request.resource,
+        accessTokenHash: sha256('retention-replay-access'),
+        newRefreshTokenHash: sha256('retention-replay-refresh'),
+      }
+      assert.equal(await store.rotateRefreshToken({
+        ...replay,
+        presentedRefreshTokenHash: past.refreshTokenHash,
+      }), 'invalid', 'a fully retired family leaves nothing for reuse detection to revoke')
+      assert.equal(await store.rotateRefreshToken({
+        ...replay,
+        presentedRefreshTokenHash: inside.refreshTokenHash,
+      }), 'reused', 'reuse detection still works on retained rows inside the window')
+
+      assert.equal(await store.consumeOAuthRateLimit({
+        bucketHash: sha256('retention-prune-bucket-second-pass'),
+        attemptKind: 'refresh',
+        maximum: 10,
+      }), true)
+      assert.deepEqual(await signInRowCounts(), {
+        requests: '1', codes: '1', families: '1', tokens: '4',
+      }, 'a revoked family keeps its full window measured from expiry')
+    })
+
+    await t.test('an expired access token in a live family is never deleted before the family', async () => {
+      await resetDatabase()
+      const live = await exchangeExistingResidentCode(store, 'retention-live-family')
+      await database!.query(
+        `UPDATE oauth_tokens
+         SET created_at = now() - interval '31 days' - interval '10 minutes',
+             expires_at = now() - interval '31 days'
+         WHERE token_hash = $1`,
+        [live.accessTokenHash],
+      )
+
+      assert.equal(await store.consumeOAuthRateLimit({
+        bucketHash: sha256('retention-live-family-bucket'),
+        attemptKind: 'refresh',
+        maximum: 10,
+      }), true)
+
+      assert.deepEqual(await signInRowCounts(), {
+        requests: '1', codes: '1', families: '1', tokens: '2',
+      })
+      assert.equal(await store.rotateRefreshToken({
+        presentedRefreshTokenHash: live.refreshTokenHash,
+        clientId: live.request.clientId,
+        resource: live.request.resource,
+        accessTokenHash: sha256('retention-live-family:rotated-access'),
+        newRefreshTokenHash: sha256('retention-live-family:rotated-refresh'),
+      }), 'rotated', 'the live grant must keep working after a retention pass')
     })
   } finally {
     database = null

--- a/test/oauth-retention.test.ts
+++ b/test/oauth-retention.test.ts
@@ -1,0 +1,174 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { splitSqlStatements } from '../scripts/migrate.ts'
+
+const schema = readFileSync(new URL('../db/schema.sql', import.meta.url), 'utf8')
+const oauthStore = readFileSync(new URL('../src/oauth-store.ts', import.meta.url), 'utf8')
+const retentionMigration = readFileSync(
+  new URL('../db/migrations/20260818_signin_retention.sql', import.meta.url),
+  'utf8',
+)
+const retentionRunbook = readFileSync(
+  new URL('../docs/runbooks/SIGNIN_RETENTION.md', import.meta.url),
+  'utf8',
+)
+
+const throttleStart = oauthStore.indexOf('export async function consumeOAuthRateLimit')
+const throttleEnd = oauthStore.indexOf('export const postgresOAuthStore', throttleStart)
+assert.ok(throttleStart >= 0 && throttleEnd > throttleStart, 'missing throttle function boundary')
+const throttleSource = oauthStore.slice(throttleStart, throttleEnd)
+
+function cte(name: string): string {
+  const pattern = new RegExp(`\\)?,?\\s*${name}\\s+AS(?:\\s+MATERIALIZED)?\\s*\\(`, 'i')
+  const start = throttleSource.search(pattern)
+  assert.ok(start >= 0, `missing ${name} CTE in the throttle statement`)
+  const following = throttleSource.slice(start)
+  const nextCte = following.slice(1).search(/\),\s*[a-z_]+\s+AS(?:\s+MATERIALIZED)?\s*\(/i)
+  return nextCte >= 0 ? following.slice(0, nextCte + 2) : following
+}
+
+const retentionWindow = /const SIGNIN_RETENTION_WINDOW = '([^']+)'/.exec(oauthStore)?.[1]
+const retentionBatch = Number(/const SIGNIN_RETENTION_BATCH = (\d+)/.exec(oauthStore)?.[1])
+
+test('every expired sign-in record type is deleted inside the shared OAuth throttle statement', () => {
+  assert.equal(
+    throttleSource.match(/await\s+sql`/g)?.length ?? 0,
+    1,
+    'the throttle must remain one PostgreSQL statement so pruning rides every OAuth request',
+  )
+  for (const table of [
+    'oauth_authorization_codes',
+    'oauth_authorization_requests',
+    'oauth_tokens',
+    'oauth_token_families',
+  ]) {
+    assert.match(
+      throttleSource,
+      new RegExp(`DELETE FROM ${table}\\b`, 'i'),
+      `${table} rows must be pruned on sign-in traffic`,
+    )
+  }
+})
+
+test('retention deletes only rows past the documented forensic window, never merely expired ones', () => {
+  assert.equal(retentionWindow, '30 days')
+  const guards = throttleSource.match(
+    /expires_at <= now\(\) - \$\{SIGNIN_RETENTION_WINDOW\}::interval/g,
+  )
+  assert.equal(guards?.length, 4, 'each record type must wait out the full retention window')
+  assert.doesNotMatch(
+    throttleSource,
+    /expires_at <= now\(\)\s*(?:ORDER|LIMIT|\))/i,
+    'a bare expiry comparison would delete records still inside the forensic window',
+  )
+})
+
+test('retention work is bounded so one request never performs unbounded deletion', () => {
+  assert.ok(Number.isInteger(retentionBatch) && retentionBatch > 0)
+  const bounds = throttleSource.match(/LIMIT \$\{SIGNIN_RETENTION_BATCH\}/g)
+  assert.equal(bounds?.length, 4, 'each retention batch must carry its own LIMIT')
+})
+
+test('token rows are deleted only by their family clock so reuse detection works all window long', () => {
+  const doomedTokens = cte('retired_tokens')
+  assert.match(doomedTokens, /family\.expires_at <= now\(\)/i)
+  assert.doesNotMatch(
+    doomedTokens,
+    /token\.(expires_at|used_at|revoked_at)/i,
+    'an individually expired, used, or revoked token must survive until family retention',
+  )
+
+  const reuseDetection = oauthStore.slice(
+    oauthStore.indexOf('async function revokeReusedRefreshToken'),
+    oauthStore.indexOf('export async function rotateRefreshToken'),
+  )
+  assert.match(
+    reuseDetection,
+    /used_at IS NOT NULL/i,
+    'reuse detection still depends on retained used-token rows',
+  )
+})
+
+test('token deletion removes the newest rotation links first so the refresh chain never dangles', () => {
+  assert.match(cte('retired_tokens'), /ORDER BY token\.id DESC/i)
+})
+
+test('a family row is deleted only after every one of its token rows is gone', () => {
+  const doomedFamilies = cte('retired_families')
+  assert.match(doomedFamilies, /NOT EXISTS\s*\(\s*SELECT 1 FROM oauth_tokens/i)
+  assert.match(doomedFamilies, /token\.id NOT IN \(SELECT id FROM retired_tokens\)/i)
+  assert.ok(
+    throttleSource.indexOf('pruned_tokens') < throttleSource.indexOf('pruned_families'),
+    'tokens must be deleted before their family to satisfy the RESTRICT foreign key',
+  )
+})
+
+test('a request row is deleted only when no authorization code still references it', () => {
+  const doomedRequests = cte('retired_requests')
+  assert.match(doomedRequests, /NOT EXISTS\s*\(\s*SELECT 1 FROM oauth_authorization_codes/i)
+  assert.match(doomedRequests, /code\.id NOT IN \(SELECT id FROM retired_codes\)/i)
+  assert.ok(
+    throttleSource.indexOf('pruned_codes') < throttleSource.indexOf('pruned_requests'),
+    'codes must be deleted before their request to satisfy the RESTRICT foreign key',
+  )
+})
+
+test('identity records stay outside the sign-in retention deletes', () => {
+  for (const identityTable of [
+    'residents',
+    'resident_recovery_codes',
+    'resident_key_rotations',
+    'pending_resident_registrations',
+  ]) {
+    assert.doesNotMatch(
+      throttleSource,
+      new RegExp(`DELETE FROM ${identityTable}\\b`, 'i'),
+      `${identityTable} is identity, not a sign-in record`,
+    )
+  }
+})
+
+test('retention scans are served by additive expiry indexes in both the fresh schema and the release migration', () => {
+  const normalize = (statement: string) =>
+    statement.replace(/^\s*--.*$/gm, '').replace(/\s+/g, ' ').trim()
+  const schemaStatements = new Set(splitSqlStatements(schema).map(normalize))
+  const migrationStatements = splitSqlStatements(retentionMigration).map(normalize)
+
+  for (const index of [
+    'CREATE INDEX IF NOT EXISTS oauth_authorization_requests_retention ON oauth_authorization_requests (expires_at, id)',
+    'CREATE INDEX IF NOT EXISTS oauth_authorization_codes_retention ON oauth_authorization_codes (expires_at, id)',
+    'CREATE INDEX IF NOT EXISTS oauth_token_families_retention ON oauth_token_families (expires_at, id)',
+  ]) {
+    assert.ok(schemaStatements.has(index), `db/schema.sql is missing: ${index}`)
+    assert.ok(migrationStatements.includes(index), `retention migration is missing: ${index}`)
+  }
+})
+
+test('the retention migration is one transaction with enforced wait and work limits', () => {
+  assert.match(retentionMigration, /^\s*BEGIN\s*;/i)
+  assert.match(retentionMigration, /SET\s+LOCAL\s+lock_timeout\s*=/i)
+  assert.match(retentionMigration, /SET\s+LOCAL\s+statement_timeout\s*=/i)
+  assert.match(retentionMigration, /COMMIT\s*;\s*$/i)
+})
+
+test('the retention runbook and the implementation state the same window and mechanism', () => {
+  assert.ok(retentionWindow, 'the store must declare its retention window')
+  assert.match(retentionRunbook, new RegExp(retentionWindow!))
+  for (const table of [
+    'oauth_authorization_requests',
+    'oauth_authorization_codes',
+    'oauth_token_families',
+    'oauth_tokens',
+  ]) {
+    assert.match(retentionRunbook, new RegExp(`\\b${table}\\b`))
+  }
+  assert.match(retentionRunbook, /consumeOAuthRateLimit/)
+  assert.match(retentionRunbook, /BACKUP_RESTORE\.md/)
+
+  const documentationMap = readFileSync(
+    new URL('../docs/README.md', import.meta.url),
+    'utf8',
+  )
+  assert.match(documentationMap, /runbooks\/SIGNIN_RETENTION\.md/)
+})


### PR DESCRIPTION
## Summary

Wave 2, item 16 of the audit outcome plan: sign-in data retention.

- Every sign-in record type now has a documented retention period: 30 days after the record's own expiry — long enough to reconstruct an incident reported within a month, no longer. Policy and reasoning in `docs/runbooks/SIGNIN_RETENTION.md` (linked from docs/README.md).
- Deletion piggybacks on the shared OAuth throttle statement (the city has no background jobs by design), in bounded batches of 50 per record type, with foreign-key-safe ordering: codes before the requests they reference, token rows newest-rotation-link first, a family only when its tokens are gone.
- Refresh-token reuse detection keeps its evidence: token rows share their family's retention clock, and a revoked family keeps its full window so revocation evidence outlives the incident.
- Backup statement: Neon PITR (6h) and snapshots (14 days) mean a pruned record leaves every provider layer within 14 days; manual archives carry a rotate-and-delete instruction.
- Migration `20260818_signin_retention.sql` adds three additive `(expires_at, id)` indexes (starts with the item-15 mandated `SET LOCAL` limits); same indexes idempotent in `db/schema.sql`. **Run `migrate:production:signin-retention` separately after merge** — pruning works correctly without the indexes, they only make the scans cheap.
- Review finding fixed: the retention doc now states exactly which hashes persist until the retention delete (schema-required lookup hashes that cannot authenticate once expired) instead of overpromising scrub-at-terminal-state.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 571/571
- [x] Real-Postgres proof: rows aged 31 days past expiry deleted, 29-day rows survive; retained used refresh token still answers 'reused'; revoked family inside window intact (22/22 in the extended oauth integration suite)
- [x] Release gate (`deploy.sh --prepare`) exit 0
- [x] Adversarial review: 1 MEDIUM (doc accuracy) — fixed
- [ ] Vercel preview healthy
- [ ] After merge: run `migrate:preview:signin-retention` then `migrate:production:signin-retention` in an operator session