### PR TITLE
fix: honest collision and uncertain-commit responses

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -9,6 +9,7 @@ import {
   runAction,
   setHome,
   withEngineTransaction,
+  type ActionExecution,
   type Presence,
   type TaggedSql,
   type RuntimeTarget,
@@ -96,6 +97,44 @@ function actionFieldsAllowed(action: BasicAction, body: JsonObject): boolean {
   return hasOnly(body, ACTION_FIELDS)
 }
 
+function expectedPlaceAfterAction(
+  action: BasicAction,
+  result: ActionExecution,
+  before: Presence,
+  destinationPlaceId: number | null,
+): number | null {
+  if (result.httpStatus !== 200) return before.currentPlaceId
+  if (action === 'move') return destinationPlaceId
+  if (action === 'go_home') return before.homePlaceId
+  return before.currentPlaceId
+}
+
+/**
+ * The action outcome is already durably recorded, so observing the city after
+ * it is best-effort: a failed read or due-effect pass must never repaint a
+ * committed action as an error. Deferred effects stay due for the next observer.
+ */
+async function observePlaceAfterAction(
+  residentId: number,
+  action: BasicAction,
+  result: ActionExecution,
+  before: Presence,
+  destinationPlaceId: number | null,
+): Promise<number | null> {
+  let placeId = expectedPlaceAfterAction(action, result, before, destinationPlaceId)
+  try {
+    const after = await residentPresence(residentId)
+    placeId = after.currentPlaceId
+    if (result.httpStatus === 200 && after.currentPlaceId !== null
+      && after.currentPlaceId !== before.currentPlaceId) {
+      await resolveDueEffects(after.currentPlaceId)
+    }
+  } catch (error) {
+    console.error('post-action observation failed', error)
+  }
+  return placeId
+}
+
 async function runResidentAction(
   c: Context,
   resident: Resident,
@@ -146,16 +185,14 @@ async function runResidentAction(
       recipientId: toResidentId,
       payload: {},
     })
-    const after = await residentPresence(resident.id)
-    if (result.httpStatus === 200 && after.currentPlaceId !== null
-      && after.currentPlaceId !== before.currentPlaceId) {
-      await resolveDueEffects(after.currentPlaceId)
-    }
+    const placeId = await observePlaceAfterAction(
+      resident.id, action, result, before, destinationPlaceId,
+    )
     const publicAction = {
       id: result.actionId,
       action,
       status: result.status,
-      place_id: after.currentPlaceId,
+      place_id: placeId,
       effects_applied: result.effectsApplied,
     }
     if (result.error) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -123,6 +123,22 @@ export function postgresErrorMessage(error: unknown, depth = 0): string | null {
   return postgresErrorMessage(candidate.sourceError, depth + 1)
 }
 
+/**
+ * Ordinary write collisions: serialization failure, deadlock, an unavailable
+ * lock, and a unique-key race no named handler claimed. Each one means another
+ * action touched the same records first, so a plain retry is the honest answer.
+ */
+const RETRYABLE_COLLISION_CODES: readonly string[] = Object.freeze([
+  '40001', '40P01', '55P03', '23505',
+])
+
+export const COLLISION_CONFLICT_MESSAGE = 'another action changed the same records; retry'
+
+export function isRetryableCollision(error: unknown): boolean {
+  const code = postgresErrorCode(error)
+  return code !== null && RETRYABLE_COLLISION_CODES.includes(code)
+}
+
 type ErrorStatus = 400 | 401 | 402 | 403 | 404 | 409 | 429 | 500 | 502 | 503
 
 export function err(c: Context, status: ErrorStatus, message: string) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -126,6 +126,8 @@ const MAX_JSON_BYTES = 65_536
 type EngineStatus = 400 | 403 | 404 | 409 | 429 | 500
 export type TargetType = 'resident' | 'place' | 'thing' | 'kind'
 export type ResolutionStatus = 'applied' | 'blocked' | 'noop' | 'failed'
+/** What a caller may see: stored statuses plus the honest not-knowable one. */
+export type ActionOutcomeStatus = ResolutionStatus | 'unconfirmed'
 
 export class EngineError extends Error {
   readonly status: EngineStatus
@@ -190,7 +192,7 @@ export type ActionInput = BaseActionInput & (
 
 export interface ActionExecution {
   readonly actionId: number
-  readonly status: ResolutionStatus
+  readonly status: ActionOutcomeStatus
   readonly httpStatus: number
   readonly error: string | null
   readonly effectsApplied: number
@@ -583,7 +585,7 @@ async function recordActionResolution(
   detail: Readonly<Record<string, unknown>>,
   db: TaggedSql,
 ) {
-  await queryRows(db`
+  const rows = await queryRows(db`
     WITH resolution AS (
       INSERT INTO action_resolutions (action_run_id, status, detail)
       VALUES (${actionId}, ${status}, ${json(detail)}::jsonb)
@@ -594,6 +596,10 @@ async function recordActionResolution(
       ${json({ action_id: actionId, status, ...detail })}::jsonb FROM resolution
     RETURNING id
   `)
+  // The unique action_run_id index makes this insert wait on any in-doubt
+  // transaction for the same run, so losing the conflict proves an earlier
+  // resolution committed and is now visible.
+  return rows.length > 0
 }
 
 export const UNCONFIRMED_ACTION_ERROR =
@@ -652,7 +658,16 @@ async function recordFailedExecution(
   db: TaggedSql,
 ): Promise<ActionExecution> {
   const failure = failureFromError(error)
-  await recordActionResolution(actionId, actorHandle, 'failed', { error: failure.message }, db)
+  const won = await recordActionResolution(
+    actionId, actorHandle, 'failed', { error: failure.message }, db,
+  )
+  if (!won) {
+    // A resolution already committed — possibly the very transaction whose
+    // commit acknowledgement was lost. That stored row is the one canonical
+    // outcome, so it wins over the failure this call meant to record.
+    const committed = await committedResolution(actionId, db)
+    if (committed) return committed
+  }
   return {
     actionId,
     status: 'failed',
@@ -663,10 +678,12 @@ async function recordFailedExecution(
 }
 
 /**
- * The commit outcome is unknown, so the stored record decides: a committed
- * resolution is returned as-is, a missing one proves the rollback and becomes
- * a plain failure, and an unreadable record must never claim failure or invite
- * repeating work that may already have applied.
+ * The commit outcome is unknown, so the database decides. A visible committed
+ * resolution is returned as-is. Otherwise the failure insert settles the race:
+ * its unique index waits out the in-doubt transaction, and losing the conflict
+ * means the action committed after all, so the stored outcome is returned. An
+ * unreadable record must never claim failure or invite repeating work that may
+ * already have applied.
  */
 async function resolveUncertainCommit(
   actionId: number,
@@ -674,20 +691,19 @@ async function resolveUncertainCommit(
   failure: CommitOutcomeUnknownError,
   db: TaggedSql,
 ): Promise<ActionExecution> {
-  let committed: ActionExecution | null
   try {
-    committed = await committedResolution(actionId, db)
+    const committed = await committedResolution(actionId, db)
+    if (committed) return committed
+    return await recordFailedExecution(actionId, actorHandle, failure.sourceError, db)
   } catch {
     return {
       actionId,
-      status: 'failed',
+      status: 'unconfirmed',
       httpStatus: 500,
       error: UNCONFIRMED_ACTION_ERROR,
       effectsApplied: 0,
     }
   }
-  if (committed) return committed
-  return recordFailedExecution(actionId, actorHandle, failure.sourceError, db)
 }
 
 async function sourceReady(input: RequiredActionInput, db: TaggedSql) {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,4 +1,5 @@
 import { Pool, type PoolClient } from '@neondatabase/serverless'
+import { COLLISION_CONFLICT_MESSAGE, isRetryableCollision } from './core.ts'
 import { runtimeDatabaseUrl, sql } from './db.ts'
 import {
   effectsForAction,
@@ -69,6 +70,29 @@ function clientSql(client: PoolClient): TaggedSql {
   return tagged
 }
 
+/**
+ * COMMIT itself failed, so the transaction may or may not have applied.
+ * Callers must resolve the canonical stored outcome instead of assuming either.
+ */
+export class CommitOutcomeUnknownError extends Error {
+  readonly sourceError: unknown
+
+  constructor(sourceError: unknown) {
+    super('transaction commit outcome is unknown')
+    this.name = 'CommitOutcomeUnknownError'
+    this.sourceError = sourceError
+  }
+}
+
+/** The transaction is already doomed; a failed ROLLBACK must not mask the cause. */
+async function rollbackQuietly(client: PoolClient): Promise<void> {
+  try {
+    await client.query('ROLLBACK')
+  } catch {
+    // A dead connection cannot roll back; releasing it discards the transaction.
+  }
+}
+
 /** Production actions use one interactive transaction; tagged fakes stay injectable. */
 export async function withEngineTransaction<T>(
   db: TaggedSql,
@@ -79,12 +103,20 @@ export async function withEngineTransaction<T>(
   const client = await pool().connect()
   try {
     await client.query('BEGIN')
-    const result = await work(clientSql(client), true)
-    await client.query('COMMIT')
+    let result: T
+    try {
+      result = await work(clientSql(client), true)
+    } catch (error) {
+      await rollbackQuietly(client)
+      throw error
+    }
+    try {
+      await client.query('COMMIT')
+    } catch (error) {
+      await rollbackQuietly(client)
+      throw new CommitOutcomeUnknownError(error)
+    }
     return result
-  } catch (error) {
-    await client.query('ROLLBACK')
-    throw error
   } finally {
     client.release()
   }
@@ -564,6 +596,100 @@ async function recordActionResolution(
   `)
 }
 
+export const UNCONFIRMED_ACTION_ERROR =
+  'the action outcome could not be confirmed; re-read your state before repeating it'
+
+function resolutionDetail(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    try {
+      return objectRecord(JSON.parse(value)) ?? {}
+    } catch {
+      return {}
+    }
+  }
+  return objectRecord(value) ?? {}
+}
+
+/** The resolution row commits atomically with the action, so it is the canonical outcome. */
+async function committedResolution(
+  actionId: number,
+  db: TaggedSql,
+): Promise<ActionExecution | null> {
+  const rows = await queryRows<Record<string, unknown>>(db`
+    SELECT status, detail FROM action_resolutions WHERE action_run_id = ${actionId}
+  `)
+  const row = rows[0]
+  if (!row) return null
+  const detail = resolutionDetail(row.detail)
+  if (row.status === 'applied' || row.status === 'noop') {
+    return {
+      actionId,
+      status: row.status,
+      httpStatus: 200,
+      error: null,
+      effectsApplied: integer(detail.effects_applied) ?? 0,
+    }
+  }
+  if (row.status === 'blocked') {
+    const message = typeof detail.error === 'string'
+      ? detail.error
+      : 'action is temporarily blocked'
+    return { actionId, status: 'blocked', httpStatus: 403, error: message, effectsApplied: 0 }
+  }
+  return null
+}
+
+function failureFromError(error: unknown): EngineError {
+  if (error instanceof EngineError) return error
+  if (isRetryableCollision(error)) return new EngineError(409, COLLISION_CONFLICT_MESSAGE)
+  return new EngineError(500, 'effect execution failed')
+}
+
+async function recordFailedExecution(
+  actionId: number,
+  actorHandle: string,
+  error: unknown,
+  db: TaggedSql,
+): Promise<ActionExecution> {
+  const failure = failureFromError(error)
+  await recordActionResolution(actionId, actorHandle, 'failed', { error: failure.message }, db)
+  return {
+    actionId,
+    status: 'failed',
+    httpStatus: failure.status,
+    error: failure.message,
+    effectsApplied: 0,
+  }
+}
+
+/**
+ * The commit outcome is unknown, so the stored record decides: a committed
+ * resolution is returned as-is, a missing one proves the rollback and becomes
+ * a plain failure, and an unreadable record must never claim failure or invite
+ * repeating work that may already have applied.
+ */
+async function resolveUncertainCommit(
+  actionId: number,
+  actorHandle: string,
+  failure: CommitOutcomeUnknownError,
+  db: TaggedSql,
+): Promise<ActionExecution> {
+  let committed: ActionExecution | null
+  try {
+    committed = await committedResolution(actionId, db)
+  } catch {
+    return {
+      actionId,
+      status: 'failed',
+      httpStatus: 500,
+      error: UNCONFIRMED_ACTION_ERROR,
+      effectsApplied: 0,
+    }
+  }
+  if (committed) return committed
+  return recordFailedExecution(actionId, actorHandle, failure.sourceError, db)
+}
+
 async function sourceReady(input: RequiredActionInput, db: TaggedSql) {
   if (input.sourceThingId === null) return null
   const thing = await thingState(input.sourceThingId, db, { forUpdate: true })
@@ -752,11 +878,9 @@ export async function runAction(
       return { actionId, status, httpStatus: 200, error: null, effectsApplied }
     })
   } catch (error) {
-    const failure = error instanceof EngineError ? error : new EngineError(500, 'effect execution failed')
-    await recordActionResolution(actionId, input.actorHandle, 'failed', { error: failure.message }, db)
-    return {
-      actionId, status: 'failed', httpStatus: failure.status,
-      error: failure.message, effectsApplied: 0,
+    if (error instanceof CommitOutcomeUnknownError) {
+      return resolveUncertainCommit(actionId, input.actorHandle, error, db)
     }
+    return recordFailedExecution(actionId, input.actorHandle, error, db)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,9 @@ import { sql } from './db.ts'
 import {
   auth,
   authRootKey,
+  COLLISION_CONFLICT_MESSAGE,
   err,
+  isRetryableCollision,
   QUOTAS,
   sha256,
 } from './core.ts'
@@ -161,6 +163,7 @@ app.use('*', async (c, next) => {
 app.use('*', publicResponseSafety)
 app.onError((error, c) => {
   console.error('request failed', error)
+  if (isRetryableCollision(error)) return err(c, 409, COLLISION_CONFLICT_MESSAGE)
   return c.json({ error: 'internal' }, 500)
 })
 

--- a/test/collision-boundary.test.ts
+++ b/test/collision-boundary.test.ts
@@ -1,0 +1,83 @@
+// The central error boundary: a raw database collision that no named handler
+// claimed answers as a plain retryable conflict, and every other unexpected
+// failure stays a generic internal error that leaks no database detail.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+process.env.DATABASE_URL = 'postgresql://fake:fake@fake-host.example.neon.tech/fakedb'
+process.env.TREASURY_ADDRESS = '0x3b9d230c9b995fb1a10add2d63ce37437916dcfd'
+process.env.PUBLIC_ORIGIN = 'https://1f3d9.com'
+process.env.BASE_RPC_URL = 'https://base-rpc.test'
+process.env.FACILITATOR_URL = 'https://facilitator.test'
+
+let stagedFailure: Error | null = null
+
+function stageFailure(message: string, code?: string): void {
+  stagedFailure = code ? Object.assign(new Error(message), { code }) : new Error(message)
+}
+
+globalThis.fetch = (async (input: unknown) => {
+  const url = String(input)
+  if (url.includes('/sql') && stagedFailure) {
+    const failure = stagedFailure
+    stagedFailure = null
+    throw failure
+  }
+  throw new Error(`unexpected fetch in the collision boundary suite: ${url}`)
+}) as typeof fetch
+
+const { default: app } = await import('../src/index.ts')
+const { COLLISION_CONFLICT_MESSAGE } = await import('../src/core.ts')
+
+async function publicRead(): Promise<{ status: number; body: string }> {
+  const response = await app.request('/api/residents')
+  return { status: response.status, body: await response.text() }
+}
+
+test('a serialization failure reaching the boundary is a plain retryable conflict', async () => {
+  stageFailure('could not serialize access due to concurrent update', '40001')
+  const { status, body } = await publicRead()
+  assert.equal(status, 409)
+  assert.deepEqual(JSON.parse(body), { error: COLLISION_CONFLICT_MESSAGE })
+  assert.doesNotMatch(body, /serialize/)
+})
+
+test('a deadlock reaching the boundary is a plain retryable conflict', async () => {
+  stageFailure('deadlock detected while updating relation "places"', '40P01')
+  const { status, body } = await publicRead()
+  assert.equal(status, 409)
+  assert.deepEqual(JSON.parse(body), { error: COLLISION_CONFLICT_MESSAGE })
+  assert.doesNotMatch(body, /deadlock|relation/)
+})
+
+test('an unavailable lock reaching the boundary is a plain retryable conflict', async () => {
+  stageFailure('could not obtain lock on row in relation "residents"', '55P03')
+  const { status, body } = await publicRead()
+  assert.equal(status, 409)
+  assert.deepEqual(JSON.parse(body), { error: COLLISION_CONFLICT_MESSAGE })
+  assert.doesNotMatch(body, /lock|relation/)
+})
+
+test('a unique-key race no named handler claimed is a conflict, not a server failure', async () => {
+  stageFailure('duplicate key value violates unique constraint "places_name_key"', '23505')
+  const { status, body } = await publicRead()
+  assert.equal(status, 409)
+  assert.deepEqual(JSON.parse(body), { error: COLLISION_CONFLICT_MESSAGE })
+  assert.doesNotMatch(body, /duplicate|constraint|places_name_key/)
+})
+
+test('an ordinary failure stays a generic internal error without database detail', async () => {
+  stageFailure('connection to db.internal.example:5432 refused')
+  const { status, body } = await publicRead()
+  assert.equal(status, 500)
+  assert.deepEqual(JSON.parse(body), { error: 'internal' })
+  assert.doesNotMatch(body, /db\.internal\.example/)
+})
+
+test('a coded failure outside the collision list is not softened into a conflict', async () => {
+  stageFailure('null value in column "handle" violates not-null constraint', '23502')
+  const { status, body } = await publicRead()
+  assert.equal(status, 500)
+  assert.deepEqual(JSON.parse(body), { error: 'internal' })
+  assert.doesNotMatch(body, /handle|not-null/)
+})

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -1399,7 +1399,7 @@ test('an uncertain commit resolves to the recorded outcome instead of a failure'
   assert.equal(failedResolutionWrites(calls).length, 0)
 })
 
-test('an uncertain commit with no stored record is a plain retryable conflict', async () => {
+test('an uncertain commit whose failure record wins is a plain retryable conflict', async () => {
   const { db, calls } = fakeSql(uncertainCommitResponder(() => []))
   setEngineTransactionRunnerForTests(async (database, work) => {
     await work(database, true)
@@ -1418,6 +1418,41 @@ test('an uncertain commit with no stored record is a plain retryable conflict', 
   assert.equal(failedResolutionWrites(calls).length, 1)
 })
 
+test('an uncertain commit that lands after the readback still answers with the committed outcome', async () => {
+  let resolutionReads = 0
+  const { db, calls } = fakeSql(({ text }) => {
+    if (/SELECT status, detail FROM action_resolutions/.test(text)) {
+      resolutionReads += 1
+      // Invisible on the first read; the in-doubt commit lands while the
+      // failure insert waits on the unique index and loses the conflict.
+      return resolutionReads === 1 ? [] : [{ status: 'applied', detail: { effects_applied: 1 } }]
+    }
+    if (/FROM resident_presence/.test(text)) {
+      return [{ resident_id: 7, current_place_id: 2, home_place_id: 3, updated_at: 'now' }]
+    }
+    if (/INSERT INTO action_runs/.test(text)) return [{ id: 240 }]
+    if (/FROM active_blocks/.test(text)) return [{ blocked: false }]
+    if (/INSERT INTO action_resolutions/.test(text)) return []
+    return []
+  })
+  setEngineTransactionRunnerForTests(async (database, work) => {
+    await work(database, true)
+    throw new CommitOutcomeUnknownError(new Error('connection closed before the commit reply'))
+  })
+  try {
+    const result = await runAction(UNCERTAIN_COMMIT_ACTION, db)
+    assert.equal(result.status, 'applied')
+    assert.equal(result.httpStatus, 200)
+    assert.equal(result.error, null)
+    assert.equal(result.effectsApplied, 1)
+  } finally {
+    setEngineTransactionRunnerForTests(null)
+  }
+  assert.equal(resolutionReads, 2)
+  assert.ok(calls.some(call =>
+    /INSERT INTO action_resolutions/.test(call.text) && call.values[1] === 'failed'))
+})
+
 test('an unreadable outcome record never claims failure or invites a retry', async () => {
   const { db, calls } = fakeSql(uncertainCommitResponder(() => {
     throw Object.assign(new Error('the record read failed too'), { code: '57P01' })
@@ -1428,6 +1463,7 @@ test('an unreadable outcome record never claims failure or invites a retry', asy
   })
   try {
     const result = await runAction(UNCERTAIN_COMMIT_ACTION, db)
+    assert.equal(result.status, 'unconfirmed')
     assert.equal(result.httpStatus, 500)
     assert.equal(result.error, UNCONFIRMED_ACTION_ERROR)
     assert.doesNotMatch(result.error ?? '', /retry/)

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2,9 +2,11 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  CommitOutcomeUnknownError,
   EngineError,
   MAX_PENDING_EFFECTS_PER_ACTOR,
   MAX_PENDING_EFFECTS_PER_PLACE,
+  UNCONFIRMED_ACTION_ERROR,
   effectiveLaws,
   ensurePresence,
   isActionBlocked,
@@ -17,6 +19,7 @@ import {
   type ActionInput,
   type TaggedSql,
 } from '../src/engine.ts'
+import { COLLISION_CONFLICT_MESSAGE } from '../src/core.ts'
 
 interface Call {
   text: string
@@ -1347,4 +1350,111 @@ test('generation eight resolves but cannot schedule another repeat', async () =>
   })
   assert.deepEqual(await resolveDueEffects(2, db), { resolved: 1, failed: 0, capped: false })
   assert.equal(calls.some(call => /INSERT INTO pending_effects/.test(call.text)), false)
+})
+
+function uncertainCommitResponder(
+  resolutionRows: () => Record<string, unknown>[],
+): (call: Call) => unknown[] {
+  return ({ text }) => {
+    if (/SELECT status, detail FROM action_resolutions/.test(text)) return resolutionRows()
+    if (/FROM resident_presence/.test(text)) {
+      return [{ resident_id: 7, current_place_id: 2, home_place_id: 3, updated_at: 'now' }]
+    }
+    if (/INSERT INTO action_runs/.test(text)) return [{ id: 240 }]
+    if (/FROM active_blocks/.test(text)) return [{ blocked: false }]
+    if (/INSERT INTO action_resolutions/.test(text)) return [{ id: 340 }]
+    return []
+  }
+}
+
+const UNCERTAIN_COMMIT_ACTION: ActionInput = {
+  actorId: 7,
+  actorHandle: 'tiny-lantern',
+  action: 'use',
+  placeId: 2,
+}
+
+function failedResolutionWrites(calls: Call[]): Call[] {
+  return calls.filter(call =>
+    /INSERT INTO action_resolutions/.test(call.text) && call.values[1] === 'failed')
+}
+
+test('an uncertain commit resolves to the recorded outcome instead of a failure', async () => {
+  const { db, calls } = fakeSql(uncertainCommitResponder(
+    () => [{ status: 'applied', detail: { effects_applied: 2 } }],
+  ))
+  setEngineTransactionRunnerForTests(async (database, work) => {
+    await work(database, true)
+    throw new CommitOutcomeUnknownError(new Error('connection closed before the commit reply'))
+  })
+  try {
+    const result = await runAction(UNCERTAIN_COMMIT_ACTION, db)
+    assert.equal(result.status, 'applied')
+    assert.equal(result.httpStatus, 200)
+    assert.equal(result.error, null)
+    assert.equal(result.effectsApplied, 2)
+  } finally {
+    setEngineTransactionRunnerForTests(null)
+  }
+  assert.equal(failedResolutionWrites(calls).length, 0)
+})
+
+test('an uncertain commit with no stored record is a plain retryable conflict', async () => {
+  const { db, calls } = fakeSql(uncertainCommitResponder(() => []))
+  setEngineTransactionRunnerForTests(async (database, work) => {
+    await work(database, true)
+    throw new CommitOutcomeUnknownError(
+      Object.assign(new Error('deadlock detected'), { code: '40P01' }),
+    )
+  })
+  try {
+    const result = await runAction(UNCERTAIN_COMMIT_ACTION, db)
+    assert.equal(result.status, 'failed')
+    assert.equal(result.httpStatus, 409)
+    assert.equal(result.error, COLLISION_CONFLICT_MESSAGE)
+  } finally {
+    setEngineTransactionRunnerForTests(null)
+  }
+  assert.equal(failedResolutionWrites(calls).length, 1)
+})
+
+test('an unreadable outcome record never claims failure or invites a retry', async () => {
+  const { db, calls } = fakeSql(uncertainCommitResponder(() => {
+    throw Object.assign(new Error('the record read failed too'), { code: '57P01' })
+  }))
+  setEngineTransactionRunnerForTests(async (database, work) => {
+    await work(database, true)
+    throw new CommitOutcomeUnknownError(new Error('connection closed before the commit reply'))
+  })
+  try {
+    const result = await runAction(UNCERTAIN_COMMIT_ACTION, db)
+    assert.equal(result.httpStatus, 500)
+    assert.equal(result.error, UNCONFIRMED_ACTION_ERROR)
+    assert.doesNotMatch(result.error ?? '', /retry/)
+  } finally {
+    setEngineTransactionRunnerForTests(null)
+  }
+  assert.equal(failedResolutionWrites(calls).length, 0)
+})
+
+test('a raw serialization collision inside an action answers as a retryable conflict', async () => {
+  const { db } = fakeSql(({ text }) => {
+    if (/FROM resident_presence/.test(text)) {
+      return [{ resident_id: 7, current_place_id: 2, home_place_id: 3, updated_at: 'now' }]
+    }
+    if (/INSERT INTO action_runs/.test(text)) return [{ id: 243 }]
+    if (/FROM active_blocks/.test(text)) {
+      throw Object.assign(
+        new Error('could not serialize access due to concurrent update'),
+        { code: '40001' },
+      )
+    }
+    if (/INSERT INTO action_resolutions/.test(text)) return [{ id: 343 }]
+    return []
+  })
+  const result = await runAction(UNCERTAIN_COMMIT_ACTION, db)
+  assert.equal(result.status, 'failed')
+  assert.equal(result.httpStatus, 409)
+  assert.equal(result.error, COLLISION_CONFLICT_MESSAGE)
+  assert.doesNotMatch(result.error ?? '', /serialize/)
 })

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -163,6 +163,7 @@ interface FakeState {
   failPaidWriteOnce: boolean
   placeDescription: string
   noteBody: string
+  actionResolved?: boolean
 }
 
 const initialState = (): FakeState => ({
@@ -427,6 +428,15 @@ function recordPayment(query: string, params: unknown[]) {
 function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] {
   const q = query.replace(/\s+/g, ' ').trim().toLowerCase()
   recordPayment(query, params)
+
+  // Once the action resolution committed, every later presence read breaks.
+  if (state.scenario === 'post-action observation failure'
+    && state.actionResolved && q.includes('resident_presence')) {
+    throw Object.assign(
+      new Error('connection reset while re-reading presence'),
+      { code: '57P01' },
+    )
+  }
 
   if (q.includes('/* payment-attempts:find-operation */')) {
     const row = [...state.paymentAttempts.values()].reverse().find(attempt =>
@@ -720,7 +730,10 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
   if (q.includes('as place_pending')) return [{ place_pending: 0, actor_pending: 0 }]
   if (q.includes('pg_advisory_xact_lock')) return []
   if (q.includes('from active_blocks')) return [{ blocked: state.actionBlocked }]
-  if (q.includes('insert into action_resolutions')) return [{ id: 201 }]
+  if (q.includes('insert into action_resolutions')) {
+    state = { ...state, actionResolved: true }
+    return [{ id: 201 }]
+  }
   if (q.includes('with recursive ancestry') && q.includes('update things set withdrawn_at')) {
     const target = Number(params.find(value => [41, 42].includes(Number(value))) ?? 41)
     if (target === 42 && !state.targetThingWithdrawn) {
@@ -3577,6 +3590,18 @@ test('go_home remains available when ordinary movement is actively blocked', asy
   const body = await home.json() as { action: { action: string; place_id: number } }
   assert.equal(body.action.action, 'go_home')
   assert.equal(body.action.place_id, 2)
+})
+
+test('a committed action answers success even when the after-action observation fails', async () => {
+  reset({ scenario: 'post-action observation failure' })
+  const response = await app.request('/api/go-home', { method: 'POST', headers: authHeaders() })
+  assert.equal(response.status, 200)
+  const body = await response.json() as {
+    action: { action: string; status: string; place_id: number | null }
+  }
+  assert.equal(body.action.action, 'go_home')
+  assert.equal(body.action.status, 'applied')
+  assert.equal(body.action.place_id, 3)
 })
 
 test('thing withdrawal is owner-only, one-way, and refused during an open sale', async () => {


### PR DESCRIPTION
## Summary

Wave 2, item 9 of the audit outcome plan: honest collision and ambiguous-result responses.

- Raw concurrent-write collisions (Postgres serialization failure 40001, deadlock 40P01, lock-not-available 55P03, and unique violations no named handler claimed) now answer as a plain retryable 409 — 'another action changed the same records; retry' — instead of a generic 500, both at the app error boundary and inside the action engine's own failure path. No database detail leaks into public bodies.
- Lost commit acknowledgements resolve to the one canonical outcome. The action's resolution row commits atomically with the action; on an uncertain commit the engine reads it back, and the failure-record insert itself settles the race: its unique index waits out the in-doubt transaction, so losing that conflict proves the action committed and the stored outcome is returned (review finding — the first draft treated an absent row as proof of rollback, which a late-landing commit could falsify).
- When even the readback fails, the caller gets the honest structured status 'unconfirmed' with 'the action outcome could not be confirmed; re-read your state before repeating it' — never a definite 'failed', never a retry invitation (review finding).
- Post-action observation (presence re-read, due-effect resolution) is best-effort: a committed action is never converted into an error by a failed read afterwards.
- Deliberately not expanded into the deferred physics races, per the plan's non-goals.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` 583/583 (12 new behavior tests, incl. the late-landing-commit race and the unconfirmed status)
- [x] Release gate (`deploy.sh --prepare`) exit 0 on the exact pushed commit
- [x] Adversarial review: 1 HIGH + 1 MEDIUM confirmed and fixed, re-verified green
- [ ] Vercel preview healthy