### PR TITLE
docs: record the passed production backup acceptance gate

### DIFF
--- a/docs/AUDIT_OUTCOME_PLAN_2026-08-15.md
+++ b/docs/AUDIT_OUTCOME_PLAN_2026-08-15.md
@@ -195,11 +195,13 @@ pull requests #31–#35; production verified healthy after each deploy.
   branches, temp diagnostics, dead container) was inventoried and resolved as
   part of this record.
 
-**Open operator actions (not code):** run one real production backup and
-restore drill (item 5 acceptance gate, `docs/runbooks/BACKUP_RESTORE.md`), and
-run `migrate:preview:signin-retention` then
-`migrate:production:signin-retention` (item 16 indexes; pruning is correct
-without them, they only make the scans cheap).
+**Operator actions — completed 2026-08-18.** The production backup and
+isolated restore drill ran and passed (evidence in
+`docs/runbooks/BACKUP_RESTORE.md`), closing item 5. The
+`signin-retention` migration was applied to production after its verified
+pre-snapshot `snap-falling-feather-avmgu9mn` (no preview branch existed to
+rehearse on; the change was three additive indexes under enforced time
+limits). Wave 2 is closed in full.
 
 ## Wave 3 — make the public and agent contract truthful
 

--- a/docs/runbooks/BACKUP_RESTORE.md
+++ b/docs/runbooks/BACKUP_RESTORE.md
@@ -204,13 +204,31 @@ trigger, count, and write checks and removed their exact containers. The
 temporary local archive was deleted after the test, so this is reproducible
 engineering verification, not a retained recovery artifact.
 
-## Production acceptance gate — not run
+## Production acceptance gate — passed 2026-08-18
 
-Wave 2 item 5 remains open until an authorized operator creates one production
-archive and restores that exact archive locally. The evidence record must include
-the date, safe project and branch IDs, archive SHA-256, elapsed time, exact table
-count, zero-invalid constraint/index result, and confirmed container cleanup. It
-must not include URLs, credentials, archive contents, or private row values.
+An authorized operator created one production archive and restored that exact
+archive locally, closing Wave 2 item 5.
+
+- Target: project `bold-union-44728141`, branch `br-lively-sunset-avksnwos`,
+  database `neondb`, endpoint proven against the Neon API before dumping.
+- Archive: `1f3d9-production-neondb-2026-08-18T13-44-43Z.dump`, 3,688,280
+  bytes, SHA-256
+  `1aa25dfa06f5450244ec0a78f70275266932b48d66cd8ed25d1d75b344003c98`, stored
+  with its manifest in the owner-private backup directory. Backup completed in
+  about three minutes; the drill in about one.
+- Drill result: 43 public tables restored, 0 unvalidated constraints, 0
+  invalid indexes, triggers present, rolled-back write check passed. The
+  drill container was removed; zero `com.1f3d9.role=restore-drill` containers
+  remained afterwards.
+- Operator note: run the backup from a shell whose PowerShell module path is
+  the Windows default. A PowerShell 7 parent used to break the directory
+  ACL probe; the script now strips the inherited module path itself.
+
+Future archives repeat this procedure; the record must always include the
+date, safe project and branch IDs, archive SHA-256, elapsed time, exact table
+count, zero-invalid constraint/index result, and confirmed container cleanup,
+and must never include URLs, credentials, archive contents, or private row
+values.
 
 The implementation follows the official PostgreSQL guidance for
 [`pg_dump`](https://www.postgresql.org/docs/current/app-pgdump.html) and

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -324,12 +324,16 @@ function parseWindowsAclEvidence(value: unknown): WindowsAclEvidence {
 }
 
 async function inspectWindowsAcl(directory: string): Promise<WindowsAclEvidence> {
+  // A PowerShell 7 parent exports its own PSModulePath, which breaks module
+  // autoloading (Get-Acl) inside the Windows PowerShell 5.1 child. Let the
+  // child rebuild its default module path instead of inheriting a wrong one.
+  const { PSModulePath: _ignoredModulePath, ...inheritedEnvironment } = process.env
   const result = await runCommand('powershell.exe', [
     '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', WINDOWS_ACL_SCRIPT,
   ], {
     maxOutput: 64 * 1024,
     environment: {
-      ...process.env,
+      ...inheritedEnvironment,
       ONEF3D9_BACKUP_DIRECTORY: directory,
     },
   })


### PR DESCRIPTION
Records the item-5 production acceptance gate as passed on 2026-08-18 (archive SHA-256, table and constraint results, container cleanup — no secrets), marks the wave-2 operator actions complete in the plan, and fixes the one real defect found while running it: the backup tool's Windows ACL probe failed under a PowerShell 7 parent because the child Windows PowerShell 5.1 inherited the wrong PSModulePath. The probe now strips the inherited module path; verified against the live repro from both shells.

## Test plan
- [x] typecheck clean, 583/583 unit tests
- [x] assertPrivateBackupDirectory verified OK from both bash and pwsh parents after the fix (failed from pwsh before)