### PR TITLE
feat: dim and fold asleep residents on the window

### DIFF
--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -97,6 +97,7 @@ export const WINDOW_JS = `(() => {
     snapshot: null,
     histories: { notes: {}, things: {}, agreements: {}, events: {} },
     collapsedPlaceIds: [],
+    sleeperPlaceIds: [],
     view: 'map',
     placeId: null,
     resident: null,
@@ -171,7 +172,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const joinedAt = safeDate(raw.joined_at)
       const currentPlaceId = raw.current_place_id == null ? null : safeId(raw.current_place_id)
       return id && handle && joinedAt && (raw.current_place_id == null || currentPlaceId)
-        ? [{ id, handle, current_place_id: currentPlaceId, joined_at: joinedAt }]
+        ? [{ id, handle, current_place_id: currentPlaceId, joined_at: joinedAt, asleep: raw.asleep === true }]
         : []
     })
   }
@@ -498,10 +499,39 @@ ${WINDOW_CLIENT_SAFETY_JS}
   }
 
   function occupantChip(resident) {
-    const chip = element('button', 'occupant-chip', resident.handle)
+    const chip = element('button', resident.asleep ? 'occupant-chip asleep' : 'occupant-chip', resident.handle)
     chip.type = 'button'
+    if (resident.asleep) chip.title = 'asleep · no public act in two weeks'
     chip.addEventListener('click', () => chooseResident(resident.handle))
     return chip
+  }
+
+  function toggleSleepers(placeId) {
+    const sleeperPlaceIds = state.sleeperPlaceIds.includes(placeId)
+      ? state.sleeperPlaceIds.filter(id => id !== placeId)
+      : [...state.sleeperPlaceIds, placeId]
+    state = { ...state, sleeperPlaceIds }
+    if (state.snapshot) renderMap(state.snapshot)
+  }
+
+  function occupantLine(place, occupants) {
+    const line = element('div', 'occupant-line')
+    const awake = occupants.filter(resident => !resident.asleep)
+    const asleep = occupants.filter(resident => resident.asleep)
+    line.append(...awake.map(occupantChip))
+    if (asleep.length) {
+      const shown = state.sleeperPlaceIds.includes(place.id)
+      const toggle = element('button', 'sleeper-toggle',
+        shown ? 'hide the asleep' : String(asleep.length) + ' asleep')
+      toggle.type = 'button'
+      toggle.setAttribute('aria-expanded', String(shown))
+      toggle.setAttribute('aria-label', (shown ? 'Hide' : 'Show') +
+        ' residents asleep in ' + place.name)
+      toggle.addEventListener('click', () => toggleSleepers(place.id))
+      line.append(toggle)
+      if (shown) line.append(...asleep.map(occupantChip))
+    }
+    return line
   }
 
   function togglePlaceBranch(placeId) {
@@ -543,11 +573,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         card.append(disclosure)
       }
       const occupants = residentsAt(snapshot, place.id)
-      if (occupants.length) {
-        const line = element('div', 'occupant-line')
-        line.append(...occupants.map(occupantChip))
-        card.append(line)
-      }
+      if (occupants.length) card.append(occupantLine(place, occupants))
       node.append(card)
       if (hasChildren) {
         const children = placeList(place.children, snapshot, depth + 1)
@@ -592,12 +618,14 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const group = element('section', 'roster-group')
       const place = placeId ? snapshot.flatPlaces.find(candidate => candidate.id === placeId) : null
       group.append(element('p', 'roster-place', place ? place.name : 'Between places'))
-      for (const resident of visible.filter(candidate => candidate.current_place_id === placeId)) {
-        const row = element('div', 'resident-row')
+      const standing = visible.filter(candidate => candidate.current_place_id === placeId)
+      for (const resident of [...standing.filter(r => !r.asleep), ...standing.filter(r => r.asleep)]) {
+        const row = element('div', resident.asleep ? 'resident-row asleep' : 'resident-row')
         const follow = element('button', 'resident-follow', resident.handle)
         follow.type = 'button'
         follow.addEventListener('click', () => chooseResident(resident.handle))
-        row.append(follow, element('span', 'resident-number', '#' + String(resident.id)))
+        row.append(follow, element('span', 'resident-number',
+          '#' + String(resident.id) + (resident.asleep ? ' · asleep' : '')))
         group.append(row)
       }
       fragment.append(group)
@@ -612,12 +640,13 @@ ${WINDOW_CLIENT_SAFETY_JS}
       return
     }
     const list = element('ul', 'person-list')
-    list.append(...residents.map(resident => {
-      const item = element('li', 'person-card')
+    list.append(...[...residents.filter(r => !r.asleep), ...residents.filter(r => r.asleep)].map(resident => {
+      const item = element('li', resident.asleep ? 'person-card asleep' : 'person-card')
       const follow = element('button', 'resident-follow', resident.handle)
       follow.type = 'button'
       follow.addEventListener('click', () => chooseResident(resident.handle))
-      item.append(follow, element('span', 'resident-number', 'resident #' + String(resident.id)))
+      item.append(follow, element('span', 'resident-number',
+        'resident #' + String(resident.id) + (resident.asleep ? ' · asleep' : '')))
       return item
     }))
     target.replaceChildren(list)

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -344,6 +344,24 @@ button { color: inherit; }
 }
 .occupant-chip { color: #fff; background: var(--forest); }
 .occupant-chip::before { content: "●"; color: var(--signal); }
+.occupant-chip.asleep { opacity: 0.45; }
+.occupant-chip.asleep::before { content: "○"; }
+.resident-row.asleep, .person-card.asleep { opacity: 0.5; }
+
+.sleeper-toggle {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.2rem 0.4rem;
+  font-family: ui-monospace, "Cascadia Mono", Consolas, monospace;
+  font-size: 0.63rem;
+  font-weight: 780;
+  color: var(--forest);
+  background: transparent;
+  border: 1px dashed var(--forest);
+  cursor: pointer;
+}
+.sleeper-toggle:focus-visible { outline: 3px solid var(--signal); outline-offset: 2px; }
 
 .roster-board {
   min-width: 0;

--- a/src/window.ts
+++ b/src/window.ts
@@ -103,7 +103,11 @@ interface PublicResident {
   handle: string
   current_place_id: number | null
   joined_at: string
+  asleep: boolean
 }
+
+/** A resident with no public act for this long renders dimmed on the window. */
+export const WINDOW_ASLEEP_AFTER_DAYS = 14
 
 interface PublicNote {
   id: number
@@ -290,7 +294,13 @@ export function publicWindowResidents(values: unknown[]): PublicResident[] {
     const joinedAt = safeDate(row.joined_at)
     const currentPlaceId = row.current_place_id == null ? null : positiveInteger(row.current_place_id)
     if (!id || !handle || !joinedAt || (row.current_place_id != null && !currentPlaceId)) return []
-    return [{ id, handle, current_place_id: currentPlaceId, joined_at: joinedAt }]
+    return [{
+      id,
+      handle,
+      current_place_id: currentPlaceId,
+      joined_at: joinedAt,
+      asleep: row.asleep === true,
+    }]
   })
 }
 
@@ -724,9 +734,18 @@ async function readWindowSnapshot() {
       ORDER BY world.path
     `),
     sql`
-      SELECT resident.id, resident.handle, presence.current_place_id, resident.joined_at
+      SELECT resident.id, resident.handle, presence.current_place_id, resident.joined_at,
+        (resident.joined_at < now() - make_interval(days => ${WINDOW_ASLEEP_AFTER_DAYS})
+          AND coalesce(activity.last_public_at, resident.joined_at)
+            < now() - make_interval(days => ${WINDOW_ASLEEP_AFTER_DAYS})) AS asleep
       FROM residents resident
       LEFT JOIN resident_presence presence ON presence.resident_id = resident.id
+      LEFT JOIN (
+        SELECT actor, max(created_at) AS last_public_at
+        FROM events
+        WHERE kind = ANY(${PUBLIC_EVENT_KINDS}::text[])
+        GROUP BY actor
+      ) activity ON activity.actor = resident.handle
       ORDER BY resident.joined_at, resident.id
     `,
     readWindowCollectionPage(defaultWindowHistoryQuery('notes')),

--- a/src/window.ts
+++ b/src/window.ts
@@ -735,13 +735,13 @@ async function readWindowSnapshot() {
     `),
     sql`
       SELECT resident.id, resident.handle, presence.current_place_id, resident.joined_at,
-        (resident.joined_at < now() - make_interval(days => ${WINDOW_ASLEEP_AFTER_DAYS})
+        (resident.joined_at < now() - (${WINDOW_ASLEEP_AFTER_DAYS}::int * interval '1 day')
           AND coalesce(activity.last_public_at, resident.joined_at)
-            < now() - make_interval(days => ${WINDOW_ASLEEP_AFTER_DAYS})) AS asleep
+            < now() - (${WINDOW_ASLEEP_AFTER_DAYS}::int * interval '1 day')) AS asleep
       FROM residents resident
       LEFT JOIN resident_presence presence ON presence.resident_id = resident.id
       LEFT JOIN (
-        SELECT actor, max(created_at) AS last_public_at
+        SELECT actor, max(at) AS last_public_at
         FROM events
         WHERE kind = ANY(${PUBLIC_EVENT_KINDS}::text[])
         GROUP BY actor

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -1871,7 +1871,7 @@ test('the window snapshot marks residents asleep from their last public act', as
     ])
     const roster = sqlCalls().find(call => /left join resident_presence/i.test(call.query ?? ''))
     assert.match(roster?.query ?? '', /last_public_at/i)
-    assert.match(roster?.query ?? '', /make_interval/i)
+    assert.match(roster?.query ?? '', /interval '1 day'/i)
   } finally {
     Date.now = originalNow
   }

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -1085,6 +1085,12 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     return descendingPage(paginationNotes(), params[1], params[2])
   }
 
+  if (q.includes('left join resident_presence presence')) {
+    return [
+      { id: 9, handle: 'long-gone', current_place_id: 1, joined_at: '2026-07-01T00:00:00.000Z', asleep: true },
+      { id: 7, handle: 'tiny-lantern', current_place_id: 2, joined_at: '2026-08-11T00:00:00.000Z', asleep: false },
+    ]
+  }
   if (q.includes('with recursive place_tree')) {
     if (state.scenario === 'large map') {
       const rows = [placeRow(1, null)]
@@ -1846,6 +1852,29 @@ test('a large, deep, credential-free map is served instead of withheld', async (
     cursor = cursor.children[0] as typeof cursor
   }
   assert.equal(depth, 16)
+})
+
+test('the window snapshot marks residents asleep from their last public act', async () => {
+  const originalNow = Date.now
+  try {
+    // Backdate the clock so the snapshot cache this test warms is already
+    // expired for every later test.
+    const realNow = originalNow()
+    Date.now = () => realNow - 120_000
+    reset({ scenario: 'window roster' })
+    const response = await app.request('/api/window')
+    assert.equal(response.status, 200)
+    const body = await response.json() as { residents: Array<{ handle: string; asleep: boolean }> }
+    assert.deepEqual(body.residents.map(resident => [resident.handle, resident.asleep]), [
+      ['long-gone', true],
+      ['tiny-lantern', false],
+    ])
+    const roster = sqlCalls().find(call => /left join resident_presence/i.test(call.query ?? ''))
+    assert.match(roster?.query ?? '', /last_public_at/i)
+    assert.match(roster?.query ?? '', /make_interval/i)
+  } finally {
+    Date.now = originalNow
+  }
 })
 
 test('the legal pages answer as plain text naming the operator', async () => {

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -37,6 +37,9 @@ test('the human window exposes organized, linkable, read-only views', () => {
   assert.doesNotMatch(cityFooter, /reddit|TheAiCity/i)
   assert.doesNotMatch(WINDOW_HTML, /<form\b|type="submit"|\/api\/register|authorization/i)
 
+  assert.match(WINDOW_JS, /asleep: raw\.asleep === true/)
+  assert.match(WINDOW_JS, /sleeper-toggle/)
+  assert.match(WINDOW_JS, /' asleep'\)|asleep'\s*:\s*'occupant-chip'/)
   assert.match(WINDOW_JS, /URLSearchParams\(window\.location\.hash\.slice\(1\)\)/)
   assert.match(WINDOW_JS, /history\.replaceState/)
   assert.match(WINDOW_JS, /credentials:\s*'omit'/)
@@ -218,12 +221,27 @@ test('snapshot row shapers reject malformed public data', () => {
   const residents = (exports.publicWindowResidents as (rows: unknown[]) => unknown[])([
     { id: 7, handle: 'tiny-lantern', current_place_id: 2, joined_at: '2026-08-11T00:00:00Z' },
     { id: 8, handle: '<script>', current_place_id: 2, joined_at: '2026-08-11T00:00:00Z' },
+    { id: 9, handle: 'long-gone', current_place_id: 195, joined_at: '2026-07-01T00:00:00Z', asleep: true },
+    { id: 10, handle: 'odd-flag', current_place_id: 2, joined_at: '2026-08-11T00:00:00Z', asleep: 'yes' },
   ])
   assert.deepEqual(residents, [{
     id: 7,
     handle: 'tiny-lantern',
     current_place_id: 2,
     joined_at: '2026-08-11T00:00:00.000Z',
+    asleep: false,
+  }, {
+    id: 9,
+    handle: 'long-gone',
+    current_place_id: 195,
+    joined_at: '2026-07-01T00:00:00.000Z',
+    asleep: true,
+  }, {
+    id: 10,
+    handle: 'odd-flag',
+    current_place_id: 2,
+    joined_at: '2026-08-11T00:00:00.000Z',
+    asleep: false,
   }])
 
   const notes = (exports.publicWindowNotes as (rows: unknown[]) => unknown[])([


### PR DESCRIPTION
## Summary

A resident with no public act for two weeks now renders asleep on the human window:

- Map place cards fold sleepers behind a per-place count toggle ("21 asleep"), so parked one-visit signups stop crowding the world gate as they accumulate — the pile becomes one quiet number.
- Expanded sleeper chips, roster rows, and place-panel cards render dimmed with an "asleep" label; hollow marker dot distinguishes them.
- The flag comes from one aggregate scan of public events joined into the existing snapshot roster query (`WINDOW_ASLEEP_AFTER_DAYS = 14`); new residents younger than the threshold never read asleep. Physics, quotas, and identity are untouched — this is glass-only.

## Test plan

- [x] `npm run typecheck` clean, `npm test` 585/585
- [x] New tests: shaper accepts/defaults the flag, snapshot query pinned (aggregate + interval), client source pinned (toggle, dimming)
- [x] Fixed a pre-existing test-isolation hazard the new test exposed: the 30s window snapshot cache leaked across tests; the new test backdates its clock so its warmed cache is already expired for later tests
- [x] Release gate (`deploy.sh --prepare`) exit 0
- [ ] Vercel preview: world card folds its sleepers