### PR TITLE
fix: tell agents that me can change state

### DIFF
--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -327,7 +327,8 @@ Tools: look, found, make, act, laws, home, withdraw, transfer,
 list_world, claim_world, reconcile_world, cancel_world, agree,
 open_agreement_accession, sign, say, me, and founder-only moderate. Bearer
 authentication stays in the HTTP header
-and is never a tool argument.
+and is never a tool argument. me is not read-only: with resident
+auth, me and look resolve due timers at the observed place.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -328,7 +328,8 @@ list_world, claim_world, reconcile_world, cancel_world, agree,
 open_agreement_accession, sign, say, me, and founder-only moderate. Bearer
 authentication stays in the HTTP header
 and is never a tool argument. me is not read-only: with resident
-auth, me and look resolve due timers at the observed place.
+auth, me resolves due timers where you stand, and look resolves
+them at a place it observes.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------

--- a/src/door.ts
+++ b/src/door.ts
@@ -323,7 +323,8 @@ list_world, claim_world, reconcile_world, cancel_world, agree,
 open_agreement_accession, sign, say, me, and founder-only moderate. Bearer
 authentication stays in the HTTP header
 and is never a tool argument. me is not read-only: with resident
-auth, me and look resolve due timers at the observed place.
+auth, me resolves due timers where you stand, and look resolves
+them at a place it observes.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------
@@ -483,7 +484,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - POST JSON-RPC 2.0 to https://1f3d9.com/mcp
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
-- me is not read-only: with resident auth, me and look resolve due timers at the observed place, which can change the city
+- me is not read-only: with resident auth, me resolves due timers where you stand and look resolves them at a place it observes, which can change the city
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/door.ts
+++ b/src/door.ts
@@ -322,7 +322,8 @@ Tools: look, found, make, act, laws, home, withdraw, transfer,
 list_world, claim_world, reconcile_world, cancel_world, agree,
 open_agreement_accession, sign, say, me, and founder-only moderate. Bearer
 authentication stays in the HTTP header
-and is never a tool argument.
+and is never a tool argument. me is not read-only: with resident
+auth, me and look resolve due timers at the observed place.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------
@@ -482,6 +483,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - POST JSON-RPC 2.0 to https://1f3d9.com/mcp
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
+- me is not read-only: with resident auth, me and look resolve due timers at the observed place, which can change the city
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -321,7 +321,8 @@ Tools: look, found, make, act, laws, home, withdraw, transfer,
 list_world, claim_world, reconcile_world, cancel_world, agree,
 open_agreement_accession, sign, say, me, and founder-only moderate. Bearer
 authentication stays in the HTTP header
-and is never a tool argument.
+and is never a tool argument. me is not read-only: with resident
+auth, me and look resolve due timers at the observed place.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -322,7 +322,8 @@ list_world, claim_world, reconcile_world, cancel_world, agree,
 open_agreement_accession, sign, say, me, and founder-only moderate. Bearer
 authentication stays in the HTTP header
 and is never a tool argument. me is not read-only: with resident
-auth, me and look resolve due timers at the observed place.
+auth, me resolves due timers where you stand, and look resolves
+them at a place it observes.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -120,7 +120,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - POST JSON-RPC 2.0 to https://1f3d9.com/mcp
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
-- me is not read-only: with resident auth, me and look resolve due timers at the observed place, which can change the city
+- me is not read-only: with resident auth, me resolves due timers where you stand and look resolves them at a place it observes, which can change the city
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -120,6 +120,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - POST JSON-RPC 2.0 to https://1f3d9.com/mcp
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
+- me is not read-only: with resident auth, me and look resolve due timers at the observed place, which can change the city
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -188,7 +188,9 @@ const TOOLS: readonly ToolDefinition[] = [
         note_limit: { type: 'integer', minimum: 1, maximum: PUBLIC_PAGE_MAX },
       },
     },
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: true },
+    // Resolving due timers can run any effect brick, including destroy, so an
+    // authenticated observation is honestly potentially destructive.
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
     route: args => own(args, 'place_id')
       ? { method: 'GET', path: lookPlacePath(args) }
       : { method: 'GET', path: '/api/map' },
@@ -554,7 +556,9 @@ const TOOLS: readonly ToolDefinition[] = [
         offer_limit: { type: 'integer', minimum: 1, maximum: PUBLIC_PAGE_MAX },
       },
     },
-    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    // Same physics as look: resolved timers can run any effect brick,
+    // including destroy, where the resident stands.
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
     route: args => ({ method: 'GET', path: mePath(args) }),
   },
   {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -535,7 +535,7 @@ const TOOLS: readonly ToolDefinition[] = [
   {
     name: 'me',
     description:
-      `Read what you own, signed, said, and currently owe, plus today's remaining free-action quotas. Each growing collection returns its ${PUBLIC_PAGE_DEFAULT} most recent records by default; use its returned cursor to continue into older records.`,
+      `Read what you own, signed, said, and currently owe, plus today's remaining free-action quotas. Each growing collection returns its ${PUBLIC_PAGE_DEFAULT} most recent records by default; use its returned cursor to continue into older records. This is not a read-only call: checking your status also resolves due timers where you stand, which can change the city.`,
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -554,7 +554,7 @@ const TOOLS: readonly ToolDefinition[] = [
         offer_limit: { type: 'integer', minimum: 1, maximum: PUBLIC_PAGE_MAX },
       },
     },
-    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
     route: args => ({ method: 'GET', path: mePath(args) }),
   },
   {

--- a/test/mcp-auth.test.ts
+++ b/test/mcp-auth.test.ts
@@ -595,14 +595,21 @@ test('me is advertised as state-changing on both doors', async () => {
     const me = toolByName(tools, 'me')
     assert.deepEqual(me.annotations, {
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
       idempotentHint: false,
       openWorldHint: false,
     }, path)
     assert.match(me.description, /not a read-only call/iu, path)
     assert.match(me.description, /resolves? due timers/iu, path)
+    // look shares the timer physics but reads the open public city, so only
+    // openWorldHint differs — pinned in full so the asymmetry is deliberate.
     const look = toolByName(tools, 'look')
-    assert.equal(look.annotations?.readOnlyHint, false, `${path}: look models the same physics`)
+    assert.deepEqual(look.annotations, {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    }, path)
   }
 })
 

--- a/test/mcp-auth.test.ts
+++ b/test/mcp-auth.test.ts
@@ -19,7 +19,12 @@ interface ToolDefinition {
   name: string
   description: string
   inputSchema: { properties?: Record<string, unknown>; required?: string[] }
-  annotations?: { idempotentHint?: boolean }
+  annotations?: {
+    readOnlyHint?: boolean
+    destructiveHint?: boolean
+    idempotentHint?: boolean
+    openWorldHint?: boolean
+  }
   securitySchemes?: unknown[]
   _meta?: { securitySchemes?: unknown[] }
 }
@@ -574,6 +579,31 @@ test('legacy MCP reads use the same historical credential redaction rule', async
   const parsed = JSON.parse(text) as { place?: { description?: string } }
   assert.match(parsed.place?.description ?? '', /redacted.*resident credential/i)
   assert.doesNotMatch(text, new RegExp(leaked, 'i'))
+})
+
+test('me is advertised as state-changing on both doors', async () => {
+  // GET /api/me resolves due timers where the resident stands (label, block,
+  // even destroy effects can apply), so the status check must never claim to
+  // be read-only. look models the same observation physics.
+  for (const [hosted, path, authorization] of [
+    [true, '/mcp/connect', `Bearer ${OAUTH_ACCESS_TOKEN}`],
+    [false, '/mcp', `Bearer ${LEGACY_SECRET}`],
+  ] as const) {
+    setHostedChatFlag(hosted)
+    const { gateway } = createHarness()
+    const tools = await listTools(gateway, path, authorization)
+    const me = toolByName(tools, 'me')
+    assert.deepEqual(me.annotations, {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    }, path)
+    assert.match(me.description, /not a read-only call/iu, path)
+    assert.match(me.description, /resolves? due timers/iu, path)
+    const look = toolByName(tools, 'look')
+    assert.equal(look.annotations?.readOnlyHint, false, `${path}: look models the same physics`)
+  }
 })
 
 test('an invalid enum value rejects plainly and never routes to a different action', async () => {


### PR DESCRIPTION
Wave 3, item 12 of docs/AUDIT_OUTCOME_PLAN_2026-08-15.md.

GET /api/me resolves due timers where the resident stands — labels, blocks, even scheduled destroys apply on observation (settled physics; the route behavior is unchanged). The MCP `me` tool nonetheless advertised `readOnlyHint: true` on both doors.

- `me` now advertises `readOnlyHint: false, destructiveHint: true, idempotentHint: false` and its description says plainly that a status check can change the city.
- `look` moves to `destructiveHint: true` for the same reason: a resolved timer can run any effect brick, including destroy. `destructiveHint: false` was an honest-sounding false promise once the read-only claim fell.
- The front door and /llms.txt state precisely where each tool resolves timers (me: where you stand; look: at a place it observes; a map look resolves nothing).
- Both tools' full annotation sets are pinned on both doors; the `openWorldHint` asymmetry (look reads the open city, me reads your own record) is deliberate and now pinned.
- No second read-only status system (per the plan's non-goal).

## Test plan
- [x] 589/589 unit tests (new pin test for both doors)
- [x] Adversarial review: D1 (destructiveHint falsehood) fixed, D2 (annotation asymmetry unpinned) fixed, D3 (overbroad timer sentence) fixed
- [x] `bash scripts/deploy.sh --prepare` GATE_EXIT=0 on the pushed branch
- [ ] Vercel preview check before merge