### PR TITLE
feat: stable machine-readable MCP error classes

### DIFF
--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -335,8 +335,9 @@ A failed tool call answers JSON with a stable error_class:
 bad_input, auth_required, forbidden, payment_required, conflict,
 rate_limited, city_fault, or unreachable — correct the call, sign
 in, pay, retry after the conflict, wait, or report. The class comes
-only from the HTTP status, never from private detail; the original
-error body is kept beside it with its http_status.
+only from the HTTP status or transport state, never from body
+content; a city error keeps its original fields and http_status
+beside the class.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -331,6 +331,13 @@ and is never a tool argument. me is not read-only: with resident
 auth, me resolves due timers where you stand, and look resolves
 them at a place it observes.
 
+A failed tool call answers JSON with a stable error_class:
+bad_input, auth_required, forbidden, payment_required, conflict,
+rate_limited, city_fault, or unreachable — correct the call, sign
+in, pay, retry after the conflict, wait, or report. The class comes
+only from the HTTP status, never from private detail; the original
+error body is kept beside it with its http_status.
+
 THE 1F3D9 CITYLIFE SKILL
 ------------------------
 The city skill teaches an agent to move in, guard its key, walk, build,

--- a/src/door.ts
+++ b/src/door.ts
@@ -326,6 +326,13 @@ and is never a tool argument. me is not read-only: with resident
 auth, me resolves due timers where you stand, and look resolves
 them at a place it observes.
 
+A failed tool call answers JSON with a stable error_class:
+bad_input, auth_required, forbidden, payment_required, conflict,
+rate_limited, city_fault, or unreachable — correct the call, sign
+in, pay, retry after the conflict, wait, or report. The class comes
+only from the HTTP status, never from private detail; the original
+error body is kept beside it with its http_status.
+
 THE 1F3D9 CITYLIFE SKILL
 ------------------------
 The city skill teaches an agent to move in, guard its key, walk, build,
@@ -485,6 +492,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
 - me is not read-only: with resident auth, me resolves due timers where you stand and look resolves them at a place it observes, which can change the city
+- A failed tool call returns JSON with a stable error_class (bad_input, auth_required, forbidden, payment_required, conflict, rate_limited, city_fault, unreachable) plus http_status and the original error fields; the class derives only from the HTTP status, never from private detail
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/door.ts
+++ b/src/door.ts
@@ -330,8 +330,9 @@ A failed tool call answers JSON with a stable error_class:
 bad_input, auth_required, forbidden, payment_required, conflict,
 rate_limited, city_fault, or unreachable — correct the call, sign
 in, pay, retry after the conflict, wait, or report. The class comes
-only from the HTTP status, never from private detail; the original
-error body is kept beside it with its http_status.
+only from the HTTP status or transport state, never from body
+content; a city error keeps its original fields and http_status
+beside the class.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------
@@ -492,7 +493,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
 - me is not read-only: with resident auth, me resolves due timers where you stand and look resolves them at a place it observes, which can change the city
-- A failed tool call returns JSON with a stable error_class (bad_input, auth_required, forbidden, payment_required, conflict, rate_limited, city_fault, unreachable) plus http_status and the original error fields; the class derives only from the HTTP status, never from private detail
+- A failed tool call returns JSON with a stable error_class (bad_input, auth_required, forbidden, payment_required, conflict, rate_limited, city_fault, unreachable); a city error keeps its original fields and http_status beside the class, which derives only from the HTTP status or transport state, never from body content
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -325,6 +325,13 @@ and is never a tool argument. me is not read-only: with resident
 auth, me resolves due timers where you stand, and look resolves
 them at a place it observes.
 
+A failed tool call answers JSON with a stable error_class:
+bad_input, auth_required, forbidden, payment_required, conflict,
+rate_limited, city_fault, or unreachable — correct the call, sign
+in, pay, retry after the conflict, wait, or report. The class comes
+only from the HTTP status, never from private detail; the original
+error body is kept beside it with its http_status.
+
 THE 1F3D9 CITYLIFE SKILL
 ------------------------
 The city skill teaches an agent to move in, guard its key, walk, build,

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -329,8 +329,9 @@ A failed tool call answers JSON with a stable error_class:
 bad_input, auth_required, forbidden, payment_required, conflict,
 rate_limited, city_fault, or unreachable — correct the call, sign
 in, pay, retry after the conflict, wait, or report. The class comes
-only from the HTTP status, never from private detail; the original
-error body is kept beside it with its http_status.
+only from the HTTP status or transport state, never from body
+content; a city error keeps its original fields and http_status
+beside the class.
 
 THE 1F3D9 CITYLIFE SKILL
 ------------------------

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -121,6 +121,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
 - me is not read-only: with resident auth, me resolves due timers where you stand and look resolves them at a place it observes, which can change the city
+- A failed tool call returns JSON with a stable error_class (bad_input, auth_required, forbidden, payment_required, conflict, rate_limited, city_fault, unreachable) plus http_status and the original error fields; the class derives only from the HTTP status, never from private detail
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -121,7 +121,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Pass the bearer secret only in the HTTP Authorization header, never in tool arguments
 - Tools: look, found, make, act, laws, home, withdraw, transfer, list_world, claim_world, reconcile_world, cancel_world, agree, open_agreement_accession, sign, say, me, moderate
 - me is not read-only: with resident auth, me resolves due timers where you stand and look resolves them at a place it observes, which can change the city
-- A failed tool call returns JSON with a stable error_class (bad_input, auth_required, forbidden, payment_required, conflict, rate_limited, city_fault, unreachable) plus http_status and the original error fields; the class derives only from the HTTP status, never from private detail
+- A failed tool call returns JSON with a stable error_class (bad_input, auth_required, forbidden, payment_required, conflict, rate_limited, city_fault, unreachable); a city error keeps its original fields and http_status beside the class, which derives only from the HTTP status or transport state, never from body content
 
 ## Agent skill
 - Install with your host's official skill installer: https://github.com/onetapstudiogames/1f3d9-citylife

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -617,8 +617,8 @@ function errorClassForStatus(status: number): McpErrorClass {
 
 /**
  * Wrap a failed tool result so the class and status are machine-readable
- * while every field of the original error body stays intact. Non-JSON text
- * is carried whole in the error field.
+ * while every field of the original error body stays intact. Text that is
+ * not a JSON object is carried whole in the error field.
  */
 function classifiedErrorText(
   text: string,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -588,6 +588,56 @@ const TOOLS: readonly ToolDefinition[] = [
 const rpcError = (c: Context, id: unknown, code: number, message: string) =>
   c.json({ jsonrpc: '2.0', id: id ?? null, error: { code, message } })
 
+/**
+ * The stable machine-readable failure classes both MCP doors expose, so an
+ * agent knows whether to correct its call, authenticate, pay, wait, retry,
+ * or report a city fault. A class derives only from the downstream HTTP
+ * status or transport state — never from body content — so the set stays
+ * small and no private operational detail can leak through it.
+ */
+export type McpErrorClass =
+  | 'bad_input'
+  | 'auth_required'
+  | 'forbidden'
+  | 'payment_required'
+  | 'conflict'
+  | 'rate_limited'
+  | 'city_fault'
+  | 'unreachable'
+
+function errorClassForStatus(status: number): McpErrorClass {
+  if (status === 401) return 'auth_required'
+  if (status === 402) return 'payment_required'
+  if (status === 403) return 'forbidden'
+  if (status === 409) return 'conflict'
+  if (status === 429) return 'rate_limited'
+  if (status >= 500) return 'city_fault'
+  return 'bad_input'
+}
+
+/**
+ * Wrap a failed tool result so the class and status are machine-readable
+ * while every field of the original error body stays intact. Non-JSON text
+ * is carried whole in the error field.
+ */
+function classifiedErrorText(
+  text: string,
+  errorClass: McpErrorClass,
+  httpStatus?: number,
+): string {
+  const envelope: Record<string, unknown> = { error_class: errorClass }
+  if (httpStatus !== undefined) envelope.http_status = httpStatus
+  try {
+    const parsed: unknown = JSON.parse(text)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return JSON.stringify({ ...(parsed as Record<string, unknown>), ...envelope })
+    }
+  } catch {
+    // fall through to the plain-text envelope
+  }
+  return JSON.stringify({ ...envelope, error: text })
+}
+
 const SENSITIVE_ARGUMENT_KEYS = new Set([
   'secret',
   'authorization',
@@ -782,17 +832,25 @@ export async function mcp(c: Context, app: Hono, options: McpOptions = {}) {
     return toolResult(
       c,
       id,
-      'Do not put secrets in tool arguments. Configure the HTTP Authorization header instead.',
+      classifiedErrorText(
+        'Do not put secrets in tool arguments. Configure the HTTP Authorization header instead.',
+        'bad_input',
+      ),
       true,
     )
   }
   if (containsUnknownArgument(tool, args)) {
-    return toolResult(c, id, 'Unsupported tool argument. Use only fields advertised by tools/list.', true)
+    return toolResult(
+      c,
+      id,
+      classifiedErrorText('Unsupported tool argument. Use only fields advertised by tools/list.', 'bad_input'),
+      true,
+    )
   }
   const enumRejection = invalidEnumArgument(tool, args)
-  if (enumRejection) return toolResult(c, id, enumRejection, true)
+  if (enumRejection) return toolResult(c, id, classifiedErrorText(enumRejection, 'bad_input'), true)
   if (!hostedChat && !c.req.header('authorization') && !allowsAnonymous(name)) {
-    return toolResult(c, id, publicMcpDoorAuthMessage(), true)
+    return toolResult(c, id, classifiedErrorText(publicMcpDoorAuthMessage(), 'auth_required'), true)
   }
 
   if (hostedChat && name === 'moderate') {
@@ -800,7 +858,10 @@ export async function mcp(c: Context, app: Hono, options: McpOptions = {}) {
     return toolResult(
       c,
       id,
-      'Use your hosted chat app\'s 1F3D9 sign-in door. A resident key is never returned through chat.',
+      classifiedErrorText(
+        'Use your hosted chat app\'s 1F3D9 sign-in door. A resident key is never returned through chat.',
+        'auth_required',
+      ),
       true,
       { oauthChallenge, forwardUnauthorizedStatus: options.forwardUnauthorizedStatus === true },
     )
@@ -827,13 +888,35 @@ export async function mcp(c: Context, app: Hono, options: McpOptions = {}) {
     const safeguarded = safeguardToolResponse(rawText)
     if (hostedChat && response.status === 401) {
       const oauthChallenge = safeOAuthChallenge(response.headers.get('www-authenticate'))
-      return toolResult(c, id, safeguarded.text, true, {
-        oauthChallenge,
-        forwardUnauthorizedStatus: options.forwardUnauthorizedStatus === true,
-      })
+      return toolResult(
+        c,
+        id,
+        classifiedErrorText(safeguarded.text, 'auth_required', 401),
+        true,
+        {
+          oauthChallenge,
+          forwardUnauthorizedStatus: options.forwardUnauthorizedStatus === true,
+        },
+      )
     }
-    return toolResult(c, id, safeguarded.text, safeguarded.withheld || response.status >= 400)
+    if (response.status >= 400) {
+      return toolResult(
+        c,
+        id,
+        classifiedErrorText(safeguarded.text, errorClassForStatus(response.status), response.status),
+        true,
+      )
+    }
+    if (safeguarded.withheld) {
+      return toolResult(c, id, classifiedErrorText(safeguarded.text, 'city_fault'), true)
+    }
+    return toolResult(c, id, safeguarded.text, false)
   } catch {
-    return toolResult(c, id, 'The city API could not answer this tool call.', true)
+    return toolResult(
+      c,
+      id,
+      classifiedErrorText('The city API could not answer this tool call.', 'unreachable'),
+      true,
+    )
   }
 }

--- a/test/mcp-auth.test.ts
+++ b/test/mcp-auth.test.ts
@@ -697,33 +697,54 @@ test('failed tool calls carry a stable machine-readable error class on both door
 })
 
 test('successes stay unwrapped, transport failure is unreachable, pre-flight rejections carry their class', async () => {
+  for (const [hosted, path, authorization] of [
+    [true, '/mcp/connect', `Bearer ${OAUTH_ACCESS_TOKEN}`],
+    [false, '/mcp', `Bearer ${LEGACY_SECRET}`],
+  ] as const) {
+    setHostedChatFlag(hosted)
+    const city = new Hono()
+    city.all('*', c => c.json({ note: { id: 7 } }, 201))
+    const gateway = new Hono()
+    gateway.post('/mcp', c => mcp(c, city))
+    gateway.post('/mcp/connect', c => mcp(c, city, { hostedChat: true }))
+    const ok = await rpc(gateway, 'tools/call', {
+      name: 'say', arguments: { place_id: 2, body: 'plain success' },
+    }, authorization, path) as { result: ToolResult }
+    assert.equal(ok.result.isError, false, path)
+    assert.equal(
+      (JSON.parse(ok.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
+      undefined,
+      `${path}: successful results keep their exact downstream shape`,
+    )
+
+    const downCity = { request: () => Promise.reject(new Error('down')) } as unknown as Hono
+    const downGateway = new Hono()
+    downGateway.post('/mcp', c => mcp(c, downCity))
+    downGateway.post('/mcp/connect', c => mcp(c, downCity, { hostedChat: true }))
+    const failed = await rpc(downGateway, 'tools/call', {
+      name: 'say', arguments: { place_id: 2, body: 'x' },
+    }, authorization, path) as { result: ToolResult }
+    assert.equal(failed.result.isError, true, path)
+    assert.equal(
+      (JSON.parse(failed.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
+      'unreachable',
+      path,
+    )
+
+    const harness = createHarness()
+    const secret = await rpc(harness.gateway, 'tools/call', {
+      name: 'say', arguments: { place_id: 2, body: `keep this out: ${LEGACY_SECRET}` },
+    }, authorization, path) as { result: ToolResult }
+    assert.equal(
+      (JSON.parse(secret.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
+      'bad_input',
+      path,
+    )
+    assert.doesNotMatch(JSON.stringify(secret), new RegExp(LEGACY_SECRET, 'i'), path)
+  }
+
+  // The public legacy door's unauthenticated pointer is its own auth_required.
   setHostedChatFlag(false)
-  const city = new Hono()
-  city.all('*', c => c.json({ note: { id: 7 } }, 201))
-  const gateway = new Hono()
-  gateway.post('/mcp', c => mcp(c, city))
-  const ok = await rpc(gateway, 'tools/call', {
-    name: 'say', arguments: { place_id: 2, body: 'plain success' },
-  }, `Bearer ${LEGACY_SECRET}`, '/mcp') as { result: ToolResult }
-  assert.equal(ok.result.isError, false)
-  assert.equal(
-    (JSON.parse(ok.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
-    undefined,
-    'successful results keep their exact downstream shape',
-  )
-
-  const downCity = { request: () => Promise.reject(new Error('down')) } as unknown as Hono
-  const downGateway = new Hono()
-  downGateway.post('/mcp', c => mcp(c, downCity))
-  const failed = await rpc(downGateway, 'tools/call', {
-    name: 'say', arguments: { place_id: 2, body: 'x' },
-  }, `Bearer ${LEGACY_SECRET}`, '/mcp') as { result: ToolResult }
-  assert.equal(failed.result.isError, true)
-  assert.equal(
-    (JSON.parse(failed.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
-    'unreachable',
-  )
-
   const harness = createHarness()
   const anonymous = await rpc(harness.gateway, 'tools/call', {
     name: 'me', arguments: {},
@@ -732,15 +753,6 @@ test('successes stay unwrapped, transport failure is unreachable, pre-flight rej
     (JSON.parse(anonymous.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
     'auth_required',
   )
-
-  const secret = await rpc(harness.gateway, 'tools/call', {
-    name: 'say', arguments: { place_id: 2, body: `keep this out: ${LEGACY_SECRET}` },
-  }, `Bearer ${LEGACY_SECRET}`, '/mcp') as { result: ToolResult }
-  assert.equal(
-    (JSON.parse(secret.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
-    'bad_input',
-  )
-  assert.doesNotMatch(JSON.stringify(secret), new RegExp(LEGACY_SECRET, 'i'))
 })
 
 test('hosted and legacy MCP reads redact every resident credential family', async () => {

--- a/test/mcp-auth.test.ts
+++ b/test/mcp-auth.test.ts
@@ -658,6 +658,91 @@ test('an invalid enum value rejects plainly and never routes to a different acti
   }
 })
 
+test('failed tool calls carry a stable machine-readable error class on both doors', async () => {
+  const statuses = [
+    [400, 'bad_input'],
+    [404, 'bad_input'],
+    [401, 'auth_required'],
+    [402, 'payment_required'],
+    [403, 'forbidden'],
+    [409, 'conflict'],
+    [429, 'rate_limited'],
+    [500, 'city_fault'],
+  ] as const
+  for (const [hosted, path, authorization] of [
+    [true, '/mcp/connect', `Bearer ${OAUTH_ACCESS_TOKEN}`],
+    [false, '/mcp', `Bearer ${LEGACY_SECRET}`],
+  ] as const) {
+    setHostedChatFlag(hosted)
+    for (const [status, expected] of statuses) {
+      const city = new Hono()
+      city.all('*', c => c.json({ error: 'downstream detail' }, status))
+      const gateway = new Hono()
+      gateway.post('/mcp', c => mcp(c, city))
+      gateway.post('/mcp/connect', c => mcp(c, city, { hostedChat: true }))
+      const response = await rpc(gateway, 'tools/call', {
+        name: 'say', arguments: { place_id: 2, body: 'hello square' },
+      }, authorization, path) as { result: ToolResult }
+      assert.equal(response.result.isError, true, `${path} ${status}`)
+      const parsed = JSON.parse(response.result.content[0]?.text ?? '{}') as {
+        error_class?: string
+        http_status?: number
+        error?: string
+      }
+      assert.equal(parsed.error_class, expected, `${path} ${status}`)
+      assert.equal(parsed.http_status, status, `${path} ${status}`)
+      assert.equal(parsed.error, 'downstream detail', `${path} ${status}: body fields preserved`)
+    }
+  }
+})
+
+test('successes stay unwrapped, transport failure is unreachable, pre-flight rejections carry their class', async () => {
+  setHostedChatFlag(false)
+  const city = new Hono()
+  city.all('*', c => c.json({ note: { id: 7 } }, 201))
+  const gateway = new Hono()
+  gateway.post('/mcp', c => mcp(c, city))
+  const ok = await rpc(gateway, 'tools/call', {
+    name: 'say', arguments: { place_id: 2, body: 'plain success' },
+  }, `Bearer ${LEGACY_SECRET}`, '/mcp') as { result: ToolResult }
+  assert.equal(ok.result.isError, false)
+  assert.equal(
+    (JSON.parse(ok.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
+    undefined,
+    'successful results keep their exact downstream shape',
+  )
+
+  const downCity = { request: () => Promise.reject(new Error('down')) } as unknown as Hono
+  const downGateway = new Hono()
+  downGateway.post('/mcp', c => mcp(c, downCity))
+  const failed = await rpc(downGateway, 'tools/call', {
+    name: 'say', arguments: { place_id: 2, body: 'x' },
+  }, `Bearer ${LEGACY_SECRET}`, '/mcp') as { result: ToolResult }
+  assert.equal(failed.result.isError, true)
+  assert.equal(
+    (JSON.parse(failed.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
+    'unreachable',
+  )
+
+  const harness = createHarness()
+  const anonymous = await rpc(harness.gateway, 'tools/call', {
+    name: 'me', arguments: {},
+  }, undefined, '/mcp') as { result: ToolResult }
+  assert.equal(
+    (JSON.parse(anonymous.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
+    'auth_required',
+  )
+
+  const secret = await rpc(harness.gateway, 'tools/call', {
+    name: 'say', arguments: { place_id: 2, body: `keep this out: ${LEGACY_SECRET}` },
+  }, `Bearer ${LEGACY_SECRET}`, '/mcp') as { result: ToolResult }
+  assert.equal(
+    (JSON.parse(secret.result.content[0]?.text ?? '{}') as { error_class?: string }).error_class,
+    'bad_input',
+  )
+  assert.doesNotMatch(JSON.stringify(secret), new RegExp(LEGACY_SECRET, 'i'))
+})
+
 test('hosted and legacy MCP reads redact every resident credential family', async () => {
   const credentials = [
     `1f3d9_sk_${'a1'.repeat(24)}`,


### PR DESCRIPTION
Wave 3, item 13 of docs/AUDIT_OUTCOME_PLAN_2026-08-15.md.

Both MCP doors flattened caller mistakes, conflicts, payment needs, limits, and city failures into indistinguishable tool errors. A failed tool call now returns JSON carrying a stable `error_class` — `bad_input`, `auth_required`, `forbidden`, `payment_required`, `conflict`, `rate_limited`, `city_fault`, or `unreachable` — so an agent knows whether to correct, authenticate, pay, wait, retry, or report.

- The class derives only from the downstream HTTP status or transport state, never from body content, so no private operational detail can leak through it (`{"error":"internal"}` remains the only 5xx body).
- A city error keeps every original field plus its `http_status`; the envelope keys always win a collision, so a body can never spoof its own class. The x402 402 body's `accepts` array and fields survive intact.
- Pre-flight rejections (secret arguments, unknown fields, invalid enum values, unauthenticated public-door calls, hosted `moderate`) carry classes too; the hosted 401 OAuth challenge metadata is unchanged beside the envelope.
- Successful results keep their exact downstream shape — no wrapping.
- The front door and /llms.txt document the class set precisely (status or transport state).

## Test plan
- [x] 591/591 unit tests: all 8 classes pinned on both doors; success-unwrapped, unreachable, and pre-flight classes pinned on both doors; existing regex-based error assertions unaffected
- [x] Adversarial review: no CRITICAL/HIGH; three LOW doc-precision nits fixed in eb0ba88
- [x] `bash scripts/deploy.sh --prepare` GATE_EXIT=0 on the pushed branch
- [ ] Vercel preview check before merge