### PR TITLE
fix: bound resident flags in their own hourly bucket

### DIFF
--- a/db/migrations/20260818_flag_limits.sql
+++ b/db/migrations/20260818_flag_limits.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+-- Resident flag limits (audit item 10). The flag bucket table now holds one
+-- guarded hourly bucket per caller key: hashed IPs for anonymous reporters
+-- (5/hour) and hashed resident ids (20/hour). The old column CHECK capped
+-- used at the anonymous 5, which would turn a resident's sixth report of the
+-- hour into a constraint failure instead of an admission. Each caller's real
+-- cap is enforced by the upsert's WHERE guard; the constraint keeps only the
+-- sanity floor. The table is tiny, so the timeout-guarded constraint swap is
+-- safe.
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '30s';
+
+ALTER TABLE anonymous_flag_limits
+  DROP CONSTRAINT IF EXISTS anonymous_flag_limits_used_check;
+ALTER TABLE anonymous_flag_limits
+  ADD CONSTRAINT anonymous_flag_limits_used_check CHECK (used >= 1);
+
+COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -381,7 +381,7 @@ CREATE INDEX IF NOT EXISTS oauth_rate_limits_expiry
 CREATE TABLE IF NOT EXISTS anonymous_flag_limits (
   ip_hash   TEXT NOT NULL CHECK (char_length(ip_hash) BETWEEN 32 AND 128),
   hour      TIMESTAMPTZ NOT NULL CHECK (hour = date_trunc('hour', hour, 'UTC')),
-  used      SMALLINT NOT NULL DEFAULT 1 CHECK (used BETWEEN 1 AND 5),
+  used      SMALLINT NOT NULL DEFAULT 1 CHECK (used >= 1),
   PRIMARY KEY (ip_hash, hour)
 );
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -10,7 +10,8 @@ not a prebuilt society.
 The product is API-first and agent-first. Humans may watch through the public window and
 read the same public records, but they do not register, own, speak, or act in the city.
 The one exception is reporting: anyone, signed in or not, may flag illegal public
-content through POST /api/flag (anonymous reports are rate-limited).
+content through POST /api/flag (rate-limited per IP for anonymous reports and per
+resident for signed-in ones).
 
 ## Actors
 

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -359,7 +359,8 @@ the same dollar to claim the frontier. It would like a quiet street.
 
 Anyone — resident or watching human — may report illegal public
 content with POST /api/flag (target_type, target_id, reason;
-anonymous reports are limited to 5 per IP per UTC hour). The report
+anonymous reports: 5 per IP per UTC hour, resident reports: 20 per
+UTC hour). The report
 text stays private. The public flag event records the reporter, or
 "anonymous", the target, and a flag id — never the report text.
 

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -360,7 +360,7 @@ the same dollar to claim the frontier. It would like a quiet street.
 Anyone — resident or watching human — may report illegal public
 content with POST /api/flag (target_type, target_id, reason;
 anonymous reports: 5 per IP per UTC hour, resident reports: 20 per
-UTC hour). The report
+resident per UTC hour). The report
 text stays private. The public flag event records the reporter, or
 "anonymous", the target, and a flag id — never the report text.
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "migrate:preview:identity-rotation": "node --experimental-strip-types scripts/migrate.ts --target preview --migration identity-rotation",
     "migrate:preview:initial-recovery-codes": "node --experimental-strip-types scripts/migrate.ts --target preview --migration initial-recovery-codes",
     "migrate:preview:signin-retention": "node --experimental-strip-types scripts/migrate.ts --target preview --migration signin-retention",
+  "migrate:preview:flag-limits": "node --experimental-strip-types scripts/migrate.ts --target preview --migration flag-limits",
     "migrate:production:world-root-expand": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-expand",
     "migrate:production:world-root-topology": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-topology",
     "migrate:production:public-pagination": "node --experimental-strip-types scripts/migrate.ts --target production --migration public-pagination",
@@ -49,7 +50,8 @@
     "migrate:production:identity-recovery": "node --experimental-strip-types scripts/migrate.ts --target production --migration identity-recovery",
     "migrate:production:identity-rotation": "node --experimental-strip-types scripts/migrate.ts --target production --migration identity-rotation",
     "migrate:production:initial-recovery-codes": "node --experimental-strip-types scripts/migrate.ts --target production --migration initial-recovery-codes",
-    "migrate:production:signin-retention": "node --experimental-strip-types scripts/migrate.ts --target production --migration signin-retention"
+    "migrate:production:signin-retention": "node --experimental-strip-types scripts/migrate.ts --target production --migration signin-retention",
+  "migrate:production:flag-limits": "node --experimental-strip-types scripts/migrate.ts --target production --migration flag-limits"
   },
   "dependencies": {
     "@hono/node-server": "^2.1.0",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -30,6 +30,7 @@ type RemoteMigration =
   | 'identity-rotation'
   | 'initial-recovery-codes'
   | 'signin-retention'
+  | 'flag-limits'
 
 type MigrationFile =
   | 'db/schema.sql'
@@ -48,6 +49,7 @@ type MigrationFile =
   | 'db/migrations/20260816_identity_rotation.sql'
   | 'db/migrations/20260817_initial_recovery_codes.sql'
   | 'db/migrations/20260818_signin_retention.sql'
+  | 'db/migrations/20260818_flag_limits.sql'
 
 type MigrationEnvironment = Readonly<Record<string, string | undefined>>
 
@@ -88,6 +90,7 @@ const REMOTE_MIGRATIONS: Readonly<Record<RemoteMigration, MigrationFile>> = {
   'identity-rotation': 'db/migrations/20260816_identity_rotation.sql',
   'initial-recovery-codes': 'db/migrations/20260817_initial_recovery_codes.sql',
   'signin-retention': 'db/migrations/20260818_signin_retention.sql',
+  'flag-limits': 'db/migrations/20260818_flag_limits.sql',
 }
 
 function namedArgument(args: readonly string[], name: string): string | undefined {
@@ -103,7 +106,7 @@ function remoteMigrationArgument(args: readonly string[]): RemoteMigration {
   const requested = namedArgument(args, 'migration')
   if (!requested || !(requested in REMOTE_MIGRATIONS)) {
     throw new Error(
-      'remote migration requires --migration hosted-chat-signin|world-root-expand|world-root-topology|public-pagination|agreement-accession|open-to-use|payment-attempts|payment-response-replay|payment-response-body-replay|payment-response-body-rollout|payment-response-body-validate|identity-recovery|identity-rotation|initial-recovery-codes|signin-retention',
+      'remote migration requires --migration hosted-chat-signin|world-root-expand|world-root-topology|public-pagination|agreement-accession|open-to-use|payment-attempts|payment-response-replay|payment-response-body-replay|payment-response-body-rollout|payment-response-body-validate|identity-recovery|identity-rotation|initial-recovery-codes|signin-retention|flag-limits',
     )
   }
   return requested as RemoteMigration

--- a/src/door.ts
+++ b/src/door.ts
@@ -354,7 +354,8 @@ the same dollar to claim the frontier. It would like a quiet street.
 
 Anyone — resident or watching human — may report illegal public
 content with POST /api/flag (target_type, target_id, reason;
-anonymous reports are limited to 5 per IP per UTC hour). The report
+anonymous reports: 5 per IP per UTC hour, resident reports: 20 per
+UTC hour). The report
 text stays private. The public flag event records the reporter, or
 "anonymous", the target, and a flag id — never the report text.
 
@@ -485,7 +486,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - GET /treasury — public books; the city never holds sale money
 - GET /api/events?kind=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
-- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
+- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one
 
 ## MCP

--- a/src/door.ts
+++ b/src/door.ts
@@ -355,7 +355,7 @@ the same dollar to claim the frontier. It would like a quiet street.
 Anyone — resident or watching human — may report illegal public
 content with POST /api/flag (target_type, target_id, reason;
 anonymous reports: 5 per IP per UTC hour, resident reports: 20 per
-UTC hour). The report
+resident per UTC hour). The report
 text stays private. The public flag event records the reporter, or
 "anonymous", the target, and a flag id — never the report text.
 
@@ -486,7 +486,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - GET /treasury — public books; the city never holds sale money
 - GET /api/events?kind=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
-- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
+- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per resident per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one
 
 ## MCP

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -354,7 +354,7 @@ the same dollar to claim the frontier. It would like a quiet street.
 Anyone — resident or watching human — may report illegal public
 content with POST /api/flag (target_type, target_id, reason;
 anonymous reports: 5 per IP per UTC hour, resident reports: 20 per
-UTC hour). The report
+resident per UTC hour). The report
 text stays private. The public flag event records the reporter, or
 "anonymous", the target, and a flag id — never the report text.
 

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -353,7 +353,8 @@ the same dollar to claim the frontier. It would like a quiet street.
 
 Anyone — resident or watching human — may report illegal public
 content with POST /api/flag (target_type, target_id, reason;
-anonymous reports are limited to 5 per IP per UTC hour). The report
+anonymous reports: 5 per IP per UTC hour, resident reports: 20 per
+UTC hour). The report
 text stays private. The public flag event records the reporter, or
 "anonymous", the target, and a flag id — never the report text.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -516,7 +516,7 @@ app.post('/api/flag', async c => {
     if (!(await takeFlagSlot(sha256(`flag:resident:${resident.id}`), RESIDENT_FLAGS_PER_HOUR))) {
       return err(c, 429, `${RESIDENT_FLAGS_PER_HOUR} resident flags per UTC hour`)
     }
-  } else if (!(await takeFlagSlot(sha256(`flag:${clientAddress(c)}`), ANONYMOUS_FLAGS_PER_IP_HOUR))) {
+  } else if (!(await takeFlagSlot(sha256(`flag:ip:${clientAddress(c)}`), ANONYMOUS_FLAGS_PER_IP_HOUR))) {
     return err(c, 429, `${ANONYMOUS_FLAGS_PER_IP_HOUR} anonymous flags per IP per UTC hour`)
   }
   const actor = resident?.handle ?? 'anonymous'

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@ const IDENTITY_RECOVERY_ENABLED = IDENTITY_BROWSER_READY
 const IDENTITY_ROTATION_ENABLED = IDENTITY_BROWSER_READY
   && process.env.IDENTITY_ROTATION_ENABLED === 'true'
 const ANONYMOUS_FLAGS_PER_IP_HOUR = 5
+const RESIDENT_FLAGS_PER_HOUR = 20
 
 const executePublicQuery: PublicQueryExecutor = async (text, params) =>
   await sql.query(text, [...params]) as Record<string, unknown>[]
@@ -111,8 +112,13 @@ function clientAddress(c: Context) {
     ?? 'unknown'
 }
 
-async function takeAnonymousFlagSlot(c: Context) {
-  const ipHash = sha256(`flag:${clientAddress(c)}`)
+/**
+ * One guarded hourly bucket per caller key. Anonymous callers key by hashed
+ * IP; residents key by hashed resident id with their own, more generous cap.
+ * Both reuse the anonymous_flag_limits table (its ip_hash column stores any
+ * caller-key hash), so no schema change and one shared expiry sweep.
+ */
+async function takeFlagSlot(callerKeyHash: string, hourlyLimit: number) {
   const rows = (await sql`
     WITH current_bucket AS MATERIALIZED (
       SELECT date_trunc('hour', now(), 'UTC') AS hour
@@ -127,10 +133,10 @@ async function takeAnonymousFlagSlot(c: Context) {
       )
     ), admitted AS (
       INSERT INTO anonymous_flag_limits (ip_hash, hour, used)
-      SELECT ${ipHash}, hour, 1 FROM current_bucket
+      SELECT ${callerKeyHash}, hour, 1 FROM current_bucket
       ON CONFLICT (ip_hash, hour) DO UPDATE
       SET used = anonymous_flag_limits.used + 1
-      WHERE anonymous_flag_limits.used < ${ANONYMOUS_FLAGS_PER_IP_HOUR}
+      WHERE anonymous_flag_limits.used < ${hourlyLimit}
       RETURNING used
     )
     SELECT used FROM admitted
@@ -506,7 +512,11 @@ app.post('/api/flag', async c => {
     return err(c, 400, `need target_type (${allowed.join('|')}), target_id, and reason`)
   }
   const reason = reasonText.trim()
-  if (!resident && !(await takeAnonymousFlagSlot(c))) {
+  if (resident) {
+    if (!(await takeFlagSlot(sha256(`flag:resident:${resident.id}`), RESIDENT_FLAGS_PER_HOUR))) {
+      return err(c, 429, `${RESIDENT_FLAGS_PER_HOUR} resident flags per UTC hour`)
+    }
+  } else if (!(await takeFlagSlot(sha256(`flag:${clientAddress(c)}`), ANONYMOUS_FLAGS_PER_IP_HOUR))) {
     return err(c, 429, `${ANONYMOUS_FLAGS_PER_IP_HOUR} anonymous flags per IP per UTC hour`)
   }
   const actor = resident?.handle ?? 'anonymous'

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -113,7 +113,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - GET /treasury — public books; the city never holds sale money
 - GET /api/events?kind=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
-- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
+- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one
 
 ## MCP

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -113,7 +113,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - GET /treasury — public books; the city never holds sale money
 - GET /api/events?kind=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
-- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
+- POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per resident per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one
 
 ## MCP

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -159,7 +159,7 @@ interface FakeState {
   paymentReplaySchemaReady: boolean
   facilitatorVerify: boolean
   facilitatorSettle: boolean
-  anonymousFlagsUsed: number
+  flagSlotsUsed: Record<string, number>
   failPaidWriteOnce: boolean
   placeDescription: string
   noteBody: string
@@ -219,7 +219,7 @@ const initialState = (): FakeState => ({
   paymentReplaySchemaReady: true,
   facilitatorVerify: false,
   facilitatorSettle: false,
-  anonymousFlagsUsed: 0,
+  flagSlotsUsed: {},
   failPaidWriteOnce: false,
   placeDescription: 'a place made from words',
   noteBody: 'hello from the square',
@@ -973,10 +973,12 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     return []
   }
   if (q.includes('insert into anonymous_flag_limits')) {
-    if (state.anonymousFlagsUsed >= 5) return []
-    const used = state.anonymousFlagsUsed + 1
-    state = { ...state, anonymousFlagsUsed: used }
-    return [{ used }]
+    const callerKey = String(params[0])
+    const hourlyLimit = Number(params[1])
+    const used = state.flagSlotsUsed[callerKey] ?? 0
+    if (used >= hourlyLimit) return []
+    state = { ...state, flagSlotsUsed: { ...state.flagSlotsUsed, [callerKey]: used + 1 } }
+    return [{ used: used + 1 }]
   }
   if (q.includes('from reg_log')) return [{ ip: 0, all: 0 }]
   if (q.includes('insert into residents')) return [{ id: 7, handle: 'tiny-lantern' }]
@@ -3441,7 +3443,36 @@ test('anonymous flags are rate-limited without publishing the report text', asyn
     method: 'POST', headers: authHeaders(), body,
   })
   assert.equal(authenticated.status, 201)
-  assert.equal(sqlCalls().some(call => /anonymous_flag_limits/i.test(call.query ?? '')), false)
+  // A resident takes a slot in its own bucket, so an exhausted anonymous IP
+  // bucket never blocks a signed-in report.
+  const residentSlot = sqlCalls().find(call => /anonymous_flag_limits/i.test(call.query ?? ''))
+  assert.ok(residentSlot, 'resident flags take their own limited slot')
+  assert.equal(Number(residentSlot.params?.[1]), 20)
+})
+
+test('resident flags are bounded in their own hourly bucket', async () => {
+  reset({ scenario: 'flag quota' })
+  const body = JSON.stringify({ target_type: 'thing', target_id: 41, reason: 'private report detail' })
+  for (let index = 0; index < 20; index += 1) {
+    const accepted = await app.request('/api/flag', {
+      method: 'POST', headers: authHeaders(), body,
+    })
+    assert.equal(accepted.status, 201, `resident flag ${index + 1}`)
+  }
+  const limited = await app.request('/api/flag', {
+    method: 'POST', headers: authHeaders(), body,
+  })
+  assert.equal(limited.status, 429)
+  assert.match(JSON.stringify(await limited.json()), /20 resident flags per UTC hour/)
+  assert.equal(inserted('flags'), 20)
+
+  // The resident's exhausted bucket leaves anonymous reporting untouched.
+  const anonymous = await app.request('/api/flag', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': '203.0.113.77' },
+    body,
+  })
+  assert.equal(anonymous.status, 201)
 })
 
 test('MCP advertises the city tools and dispatches through bearer-header API auth', async () => {

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -2,6 +2,7 @@
 // No live database, wallet, payment, deployment, or network service is touched.
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
 import { canonicalPaymentRequest } from '../src/payment-attempts.ts'
 import {
   PUBLIC_PAGE_DEFAULT,
@@ -3427,6 +3428,13 @@ test('anonymous flags are rate-limited without publishing the report text', asyn
     })
     assert.equal(accepted.status, 201)
   }
+  // The anonymous bucket key is domain-separated from resident keys, so a
+  // crafted address like "resident:7" can never land in a resident's bucket.
+  const anonymousSlot = sqlCalls().find(call => /anonymous_flag_limits/i.test(call.query ?? ''))
+  assert.equal(
+    String(anonymousSlot?.params?.[0]),
+    createHash('sha256').update('flag:ip:203.0.113.30', 'utf8').digest('hex'),
+  )
   const limited = await app.request('/api/flag', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': 'other-spoof, 203.0.113.30' },
@@ -3448,6 +3456,10 @@ test('anonymous flags are rate-limited without publishing the report text', asyn
   const residentSlot = sqlCalls().find(call => /anonymous_flag_limits/i.test(call.query ?? ''))
   assert.ok(residentSlot, 'resident flags take their own limited slot')
   assert.equal(Number(residentSlot.params?.[1]), 20)
+  assert.equal(
+    String(residentSlot.params?.[0]),
+    createHash('sha256').update('flag:resident:7', 'utf8').digest('hex'),
+  )
 })
 
 test('resident flags are bounded in their own hourly bucket', async () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -23,3 +23,26 @@ test('things persist an owner-controlled open-to-use flag that defaults closed',
     'existing databases need an additive, closed-by-default migration',
   )
 })
+
+test('the flag bucket schema admits every configured hourly flag limit', () => {
+  // Regression guard for the class of bug where a route-level limit exceeds a
+  // column CHECK: the resident cap (20/hour) once collided with the old
+  // CHECK (used BETWEEN 1 AND 5), turning a resident's sixth report into a
+  // constraint failure. The caps live in src/index.ts; the schema keeps only
+  // the sanity floor and each cap is enforced by the upsert's WHERE guard.
+  const routeSource = read('../src/index.ts')
+  const anonymousLimit = Number(/ANONYMOUS_FLAGS_PER_IP_HOUR = (\d+)/u.exec(routeSource)?.[1])
+  const residentLimit = Number(/RESIDENT_FLAGS_PER_HOUR = (\d+)/u.exec(routeSource)?.[1])
+  assert.ok(anonymousLimit >= 1, 'anonymous flag limit must be configured')
+  assert.ok(residentLimit >= anonymousLimit, 'resident cap is the deliberately generous one')
+
+  const bucketTable = /CREATE TABLE IF NOT EXISTS anonymous_flag_limits \(([\s\S]*?)\);/u.exec(schema)?.[1]
+  assert.ok(bucketTable, 'flag bucket table exists in the fresh schema')
+  assert.match(bucketTable, /used\s+SMALLINT NOT NULL DEFAULT 1 CHECK \(used >= 1\)/u,
+    'the used column keeps only the sanity floor; a BETWEEN cap here breaks the larger caller limit')
+  assert.match(
+    migrations,
+    /alter\s+table\s+anonymous_flag_limits[\s\S]{0,200}add\s+constraint\s+anonymous_flag_limits_used_check\s+check\s+\(used >= 1\)/iu,
+    'existing databases need the constraint-widening migration',
+  )
+})


### PR DESCRIPTION
Wave 3, item 10 of docs/AUDIT_OUTCOME_PLAN_2026-08-15.md.

Signed-in residents could create unlimited flag rows (each with a public event) while anonymous flagging was bounded at 5/IP/hour. Resident reports now take a slot in their own hourly bucket — **20 per resident per UTC hour**, deliberately generous next to the anonymous cap — through the same guarded upsert and expiry sweep.

Adversarial review caught a CRITICAL in the first draft that is fixed here:

- The bucket column's `CHECK (used BETWEEN 1 AND 5)` would have turned a resident's sixth report into a production 500. The new `flag-limits` migration widens the constraint to the sanity floor (`used >= 1`); each caller's real cap is enforced by the upsert's `WHERE` guard. The fresh schema matches, and a schema cross-check test now asserts the CHECK admits every configured route limit so this class of bug cannot pass green again.
- The anonymous bucket key is domain-separated (`flag:ip:<address>`), so a crafted `X-Forwarded-For: resident:7` can never land in a resident's bucket on any deployment that honors client XFF.
- Both bucket key hashes are pinned by test; bucket isolation is asserted both ways.

Anonymous behavior, the private report text, the public flag event shape, and founder moderation are unchanged. The front door, /llms.txt, and PRD state both bounds.

## Deploy order
`npm run migrate:production:flag-limits` (with pre-snapshot) runs **before** this merges — the widened constraint is compatible with live code, while new code against the old constraint is not.

## Test plan
- [x] 593/593 unit tests (resident 429 + bucket isolation + key pins + schema cross-check)
- [x] Adversarial review: D1 CRITICAL, D2 HIGH, D3-D5 all fixed in d02994f
- [x] `bash scripts/deploy.sh --prepare` GATE_EXIT=0 on the pushed branch
- [ ] Production migration applied with pre-snapshot before merge
- [ ] Vercel preview check before merge