### PR TITLE
perf: share one short-lived build of the public map

### DIFF
--- a/src/world.ts
+++ b/src/world.ts
@@ -74,40 +74,65 @@ async function activePlaceLabels(placeId: number): Promise<string[]> {
   return rows.map(row => row.label)
 }
 
+async function readPublicMap(): Promise<{ places: unknown[] }> {
+  const rows = (await sql`
+    WITH RECURSIVE place_tree AS (
+      SELECT p.id, p.parent_id, p.name, p.description, p.owner_id,
+        p.open_to_building, p.open_to_things, p.open_to_notes, p.created_at,
+        ARRAY[p.id] AS path
+      FROM places p
+      WHERE p.parent_id IS NULL
+      UNION ALL
+      SELECT child.id, child.parent_id, child.name, child.description, child.owner_id,
+        child.open_to_building, child.open_to_things, child.open_to_notes, child.created_at,
+        parent.path || child.id
+      FROM places child
+      JOIN place_tree parent ON parent.id = child.parent_id
+      WHERE NOT child.id = ANY(parent.path)
+    )
+    SELECT tree.id, tree.parent_id, tree.name, tree.description, tree.owner_id,
+      owner.handle AS owner, tree.open_to_building, tree.open_to_things,
+      tree.open_to_notes, tree.created_at,
+      (SELECT count(*)::int FROM places child WHERE child.parent_id = tree.id) AS places,
+      (SELECT count(*)::int FROM things thing
+        WHERE thing.place_id = tree.id AND thing.withdrawn_at IS NULL) AS things,
+      (SELECT count(*)::int FROM notes note WHERE note.place_id = tree.id) AS notes
+    FROM place_tree tree
+    LEFT JOIN residents owner ON owner.id = tree.owner_id
+    ORDER BY tree.path
+  `) as PlaceRow[]
+  const publicRows = await moderatePublicRows('place', rows)
+  return { places: buildPlaceTree(publicRows as PlaceRow[], null) }
+}
+
+// The whole-city rebuild is the busiest anonymous read, so one short-lived
+// build is shared by every request in the window (same shape and TTL as the
+// window snapshot cache in window.ts).
+type PublicMap = Awaited<ReturnType<typeof readPublicMap>>
+let mapCache: { expiresAt: number; pending: Promise<PublicMap> } | null = null
+
+async function cachedPublicMap() {
+  const now = Date.now()
+  if (mapCache && mapCache.expiresAt > now) return mapCache.pending
+  const pending = readPublicMap()
+  mapCache = { expiresAt: now + 30_000, pending }
+  try {
+    return await pending
+  } catch (error) {
+    if (mapCache?.pending === pending) mapCache = null
+    throw error
+  }
+}
+
 export function mountWorldRoutes(app: Hono): void {
   app.get('/api/map', async c => {
-    const rows = (await sql`
-      WITH RECURSIVE place_tree AS (
-        SELECT p.id, p.parent_id, p.name, p.description, p.owner_id,
-          p.open_to_building, p.open_to_things, p.open_to_notes, p.created_at,
-          ARRAY[p.id] AS path
-        FROM places p
-        WHERE p.parent_id IS NULL
-        UNION ALL
-        SELECT child.id, child.parent_id, child.name, child.description, child.owner_id,
-          child.open_to_building, child.open_to_things, child.open_to_notes, child.created_at,
-          parent.path || child.id
-        FROM places child
-        JOIN place_tree parent ON parent.id = child.parent_id
-        WHERE NOT child.id = ANY(parent.path)
-      )
-      SELECT tree.id, tree.parent_id, tree.name, tree.description, tree.owner_id,
-        owner.handle AS owner, tree.open_to_building, tree.open_to_things,
-        tree.open_to_notes, tree.created_at,
-        (SELECT count(*)::int FROM places child WHERE child.parent_id = tree.id) AS places,
-        (SELECT count(*)::int FROM things thing
-          WHERE thing.place_id = tree.id AND thing.withdrawn_at IS NULL) AS things,
-        (SELECT count(*)::int FROM notes note WHERE note.place_id = tree.id) AS notes
-      FROM place_tree tree
-      LEFT JOIN residents owner ON owner.id = tree.owner_id
-      ORDER BY tree.path
-    `) as PlaceRow[]
-    const publicRows = await moderatePublicRows('place', rows)
+    const body = await cachedPublicMap()
     // The map tree is unbounded, so the proactive traversal budgets in
     // publicJson would withhold a large credential-free city. The app-wide
     // publicResponseSafety middleware still guards this response and only
     // parses it when the raw text actually matches the credential rule.
-    return c.json({ places: buildPlaceTree(publicRows as PlaceRow[], null) })
+    c.header('Cache-Control', 'public, max-age=15, s-maxage=60, stale-while-revalidate=300')
+    return c.json(body)
   })
 
   app.get('/api/place/:id', async c => {

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -1829,32 +1829,59 @@ test('note validation distinguishes place errors and preserves valid Unicode exa
   assert.equal(acceptedBody.note.body, body)
 })
 
-test('the public map is a recursive owner-attributed tree', async () => {
-  reset({ scenario: 'map' })
-  const response = await app.request('/api/map')
-  assert.equal(response.status, 200)
-  const body = await response.json() as { places: { id: number; owner: string; children: { id: number }[] }[] }
-  assert.equal(body.places[0]?.id, 1)
-  assert.equal(body.places[0]?.owner, 'founder')
-  assert.equal(body.places[0]?.children[0]?.id, 2)
-  assert.ok(sqlCalls().some(call => /with\s+recursive/i.test(call.query ?? '')))
+test('the public map is a recursive owner-attributed tree with a short shared cache', async () => {
+  const originalNow = Date.now
+  try {
+    // Backdate the clock so the map cache this test warms is already expired
+    // for every later test.
+    const realNow = originalNow()
+    Date.now = () => realNow - 180_000
+    reset({ scenario: 'map' })
+    const response = await app.request('/api/map')
+    assert.equal(response.status, 200)
+    assert.equal(
+      response.headers.get('cache-control'),
+      'public, max-age=15, s-maxage=60, stale-while-revalidate=300',
+    )
+    const body = await response.json() as { places: { id: number; owner: string; children: { id: number }[] }[] }
+    assert.equal(body.places[0]?.id, 1)
+    assert.equal(body.places[0]?.owner, 'founder')
+    assert.equal(body.places[0]?.children[0]?.id, 2)
+    assert.ok(sqlCalls().some(call => /with\s+recursive/i.test(call.query ?? '')))
+
+    const queriesAfterFirst = sqlCalls().length
+    const cached = await app.request('/api/map')
+    assert.equal(cached.status, 200)
+    assert.equal(sqlCalls().length, queriesAfterFirst, 'a map within the TTL reuses the shared build')
+  } finally {
+    Date.now = originalNow
+  }
 })
 
 test('a large, deep, credential-free map is served instead of withheld', async () => {
-  reset({ scenario: 'large map' })
-  const response = await app.request('/api/map')
-  assert.equal(response.status, 200)
-  const body = await response.json() as { places: Array<{ id: number; children: Array<{ id: number }> }> }
-  assert.equal(body.places[0]?.id, 1)
-  assert.ok((body.places[0]?.children.length ?? 0) >= 1400)
-  let depth = 0
-  let cursor = body.places[0]?.children.find(child => child.id === 3000) as
-    { id: number; children: { id: number; children: unknown[] }[] } | undefined
-  while (cursor) {
-    depth += 1
-    cursor = cursor.children[0] as typeof cursor
+  const originalNow = Date.now
+  try {
+    // A different backdate than the previous map test so its cache entry is
+    // already stale here, and this test's own entry is stale for later ones.
+    const realNow = originalNow()
+    Date.now = () => realNow - 120_000
+    reset({ scenario: 'large map' })
+    const response = await app.request('/api/map')
+    assert.equal(response.status, 200)
+    const body = await response.json() as { places: Array<{ id: number; children: Array<{ id: number }> }> }
+    assert.equal(body.places[0]?.id, 1)
+    assert.ok((body.places[0]?.children.length ?? 0) >= 1400)
+    let depth = 0
+    let cursor = body.places[0]?.children.find(child => child.id === 3000) as
+      { id: number; children: { id: number; children: unknown[] }[] } | undefined
+    while (cursor) {
+      depth += 1
+      cursor = cursor.children[0] as typeof cursor
+    }
+    assert.equal(depth, 16)
+  } finally {
+    Date.now = originalNow
   }
-  assert.equal(depth, 16)
 })
 
 test('the window snapshot marks residents asleep from their last public act', async () => {


### PR DESCRIPTION
Wave 3, item 4 of docs/AUDIT_OUTCOME_PLAN_2026-08-15.md.

Every `/api/map` request rebuilt the whole city: an unbounded recursive tree scan with three per-row count subqueries plus a moderation-overlay round-trip, on the busiest anonymous read. The route now shares one 30-second module build — the same promise-cache shape and clear-on-error rule as the window snapshot in `window.ts` — and answers with the window's public CDN header (`max-age=15, s-maxage=60, stale-while-revalidate=300`).

- Response shape and city model unchanged; no pagination, invalidation, or new map model (per the plan, measure first).
- `/api/map` is fully request-independent (no auth, headers, or query input reach the build), so a shared public cache is safe; MCP map-mode `look` never resolved timers, so nothing advertised changes.
- The ~30s+CDN staleness matches the human window's already-accepted precedent for the same tree.

## Test plan
- [x] 593/593 unit tests (cache header pinned; TTL reuse proven by SQL-call count; both map tests backdate the clock so the cache cannot poison later tests)
- [x] Adversarial review: no defects on cache safety, promise mechanics, staleness contract, tests, doc parity, or moderation overlay
- [x] `bash scripts/deploy.sh --prepare` GATE_EXIT=0 on the pushed branch
- [ ] Vercel preview check, then post-merge production measurement recorded in the plan