### PR TITLE
feat: a complete, stable activity window (audit item 7)

### DIFF
--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -233,7 +233,7 @@ POST /api/note              auth {"place_id","body"}
 GET  /api/residents         census, recent arrivals first
 GET  /api/me                auth — what you own, signed, said, owe
 GET  /api/official          real addresses; there is no token
-GET  /api/events            append-only log; ?kind=, ?before_id=, ?limit=1..200
+GET  /api/events            append-only log; ?kind=, ?actor=, ?place_id=, ?before_id=, ?limit=1..200
 POST /api/moderation        founder #1 only — append remove/restore with public reason
 GET  /api/moderation        public moderation history
 GET  /treasury              public books

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -198,7 +198,7 @@ History and catalogs are recent-first: 10 records by default. The maximum is 200
 If has_more is true, send the returned next_before cursor to read the next older
 page. Nothing older becomes private or disappears.
 
-  GET /api/events?before_id=&limit=
+  GET /api/events?kind=&actor=&place_id=&before_id=&limit=
   GET /api/place/:id?limit=
                     &before_subplace_id=&subplace_limit=
                     &before_thing_id=&thing_limit=

--- a/e2e/oauth-test-server.ts
+++ b/e2e/oauth-test-server.ts
@@ -186,7 +186,11 @@ interface PublicWindowObservationState {
     readonly has_authorization: boolean
     readonly has_cookie: boolean
   }>
-  readonly event_queries: ReadonlyArray<{ readonly before_id: number; readonly limit: number }>
+  readonly event_queries: ReadonlyArray<{
+    readonly before_id: number | null
+    readonly limit: number
+    readonly place_id: number | null
+  }>
 }
 
 let publicWindowObservations: PublicWindowObservationState = {
@@ -681,13 +685,26 @@ app.get('/api/note/:id', c => {
   return c.json({ note: { id: 301, body: noteFull } })
 })
 app.get('/api/events', c => {
-  const beforeId = Number(c.req.query('before_id'))
+  const beforeIdValue = c.req.query('before_id')
+  const placeIdValue = c.req.query('place_id')
+  const beforeId = beforeIdValue == null ? null : Number(beforeIdValue)
+  const placeId = placeIdValue == null ? null : Number(placeIdValue)
   const limit = Number(c.req.query('limit'))
   publicWindowObservations = {
     ...publicWindowObservations,
-    event_queries: [...publicWindowObservations.event_queries, { before_id: beforeId, limit }],
+    event_queries: [...publicWindowObservations.event_queries, {
+      before_id: beforeId, limit, place_id: placeId,
+    }],
   }
-  if (beforeId !== 502 || limit !== 50) {
+  if (placeId !== 11 || limit !== 50) {
+    return c.json({ error: 'unexpected deterministic pagination request' }, 400)
+  }
+  if (beforeId === null) {
+    return c.json({
+      events: publicWindowFixture.events, has_more: true, next_before_id: 502,
+    })
+  }
+  if (beforeId !== 502) {
     return c.json({ error: 'unexpected deterministic pagination request' }, 400)
   }
   return c.json({ events: olderPublicEvents, has_more: false, next_before_id: null })

--- a/e2e/oauth-test-server.ts
+++ b/e2e/oauth-test-server.ts
@@ -696,7 +696,7 @@ app.get('/api/events', c => {
       before_id: beforeId, limit, place_id: placeId,
     }],
   }
-  if (placeId !== 11 || limit !== 50) {
+  if ((placeId !== null && placeId !== 11) || limit !== 50) {
     return c.json({ error: 'unexpected deterministic pagination request' }, 400)
   }
   if (beforeId === null) {

--- a/e2e/public-window-interactions.spec.ts
+++ b/e2e/public-window-interactions.spec.ts
@@ -157,9 +157,15 @@ test.beforeEach(async ({ page }) => {
       json: { agreements: [OLDER_AGREEMENT], has_more: false, next_before_id: null },
     })
   })
-  await page.route('**/api/events**', route => route.fulfill({
-    json: { events: [OLDER_EVENT], has_more: false, next_before_id: null },
-  }))
+  await page.route('**/api/events**', route => {
+    const url = new URL(route.request().url())
+    if (url.searchParams.get('before_id') === '51') {
+      return route.fulfill({ json: { events: [OLDER_EVENT], has_more: false, next_before_id: null } })
+    }
+    return route.fulfill({
+      json: { events: SNAPSHOT.events, has_more: true, next_before_id: 51 },
+    })
+  })
 
   const htmlWithoutAutomaticClient = WINDOW_HTML.replace(
     /\s*<script src="\/window\.js" defer><\/script>/,
@@ -222,8 +228,12 @@ test('long notes, things, and agreements can be expanded and collapsed', async (
   await expect(placeNote.locator('.note-body')).toHaveAttribute('data-expanded', 'true')
 
   await page.getByRole('tab', { name: 'Conversations' }).click()
+  // The same note was expanded on the place panel; its reading state
+  // survives the re-render into this view.
   const conversationNote = page.locator('#conversation-stream .note-card')
-  await expect(conversationNote.getByRole('button', { name: 'Show more' })).toBeVisible()
+  await expect(conversationNote.locator('.note-body')).toHaveAttribute('data-expanded', 'true')
+  await conversationNote.getByRole('button', { name: 'Show less' }).click()
+  await expect(conversationNote.locator('.note-body')).toHaveAttribute('data-expanded', 'false')
   await conversationNote.getByRole('button', { name: 'Show more' }).click()
   await expect(conversationNote.locator('.note-body')).toHaveAttribute('data-expanded', 'true')
 
@@ -295,10 +305,19 @@ test('recent window slices can be extended independently in every public view', 
   await olderPlaceNoteRequest
   await expect(page.locator('#place-conversation')).toContainText('An older conversation remains readable.')
 
+  // The place chosen on the Place tab is still watched, so Happenings
+  // fetches its place-filtered slice from the server on its own.
+  const filteredEventRequest = page.waitForRequest(request => {
+    const url = new URL(request.url())
+    return url.pathname === '/api/events' && url.searchParams.get('place_id') === '11' &&
+      !url.searchParams.has('before_id')
+  })
   await page.getByRole('tab', { name: 'Happenings' }).click()
+  await filteredEventRequest
   const olderEventRequest = page.waitForRequest(request => {
     const url = new URL(request.url())
-    return url.pathname === '/api/events' && url.searchParams.get('before_id') === '51'
+    return url.pathname === '/api/events' && url.searchParams.get('before_id') === '51' &&
+      url.searchParams.get('place_id') === '11'
   })
   await page.getByRole('button', { name: 'Load older happenings' }).click()
   await olderEventRequest

--- a/e2e/public-window.spec.ts
+++ b/e2e/public-window.spec.ts
@@ -81,6 +81,25 @@ test('public window keeps excerpts bounded and loads older happenings without wr
   expect(browserWrites).toEqual([])
 })
 
+test('unfiltered happenings still page older history on demand', async ({ page }) => {
+  await page.goto('/window#view=happenings')
+  await expect(page.getByRole('status')).toContainText('Watching')
+
+  // No filter is active, so nothing fetches by itself; the snapshot slice
+  // renders and the reader pages backward deliberately.
+  await expect(page.locator('#activity-list .activity-row')).toHaveCount(2)
+  const olderResponse = page.waitForResponse(response => {
+    const url = new URL(response.url())
+    return url.pathname === '/api/events' && url.searchParams.get('before_id') === '502' &&
+      !url.searchParams.has('place_id') &&
+      url.searchParams.get('limit') === '50' && response.status() === 200
+  })
+  await page.getByRole('button', { name: 'Load older happenings' }).click()
+  await olderResponse
+  await expect(page.locator('#activity-list .activity-row')).toHaveCount(4)
+  await expect(page.getByRole('button', { name: 'Load older happenings' })).toBeHidden()
+})
+
 test('all-place conversations stay newest-first and name each room', async ({ page }) => {
   await page.goto('/window#view=conversations')
   await expect(page.getByRole('status')).toContainText('Watching')

--- a/e2e/public-window.spec.ts
+++ b/e2e/public-window.spec.ts
@@ -10,7 +10,11 @@ interface PublicWindowTestState {
     readonly has_authorization?: unknown
     readonly has_cookie?: unknown
   }>
-  readonly event_queries?: Array<{ readonly before_id?: unknown; readonly limit?: unknown }>
+  readonly event_queries?: Array<{
+    readonly before_id?: unknown
+    readonly limit?: unknown
+    readonly place_id?: unknown
+  }>
 }
 
 function isWrite(request: Request): boolean {
@@ -40,11 +44,21 @@ test('public window keeps excerpts bounded and loads older happenings without wr
   await expect(noteCard).toContainText('Excerpt only — the full text is not included in this snapshot.')
   await expect(noteCard.getByRole('button', { name: 'Read full' })).toHaveCount(0)
 
+  // Watching one place: opening Happenings fetches the place-filtered slice
+  // from the server by itself instead of leaving the view falsely quiet.
+  const filteredResponse = page.waitForResponse(response => {
+    const url = new URL(response.url())
+    return url.pathname === '/api/events' && url.searchParams.get('place_id') === '11' &&
+      !url.searchParams.has('before_id') &&
+      url.searchParams.get('limit') === '50' && response.status() === 200
+  })
   await page.getByRole('tab', { name: 'Happenings' }).click()
+  await filteredResponse
   await expect(page.locator('#activity-list .activity-row')).toHaveCount(2)
   const olderResponse = page.waitForResponse(response => {
     const url = new URL(response.url())
     return url.pathname === '/api/events' && url.searchParams.get('before_id') === '502' &&
+      url.searchParams.get('place_id') === '11' &&
       url.searchParams.get('limit') === '50' && response.status() === 200
   })
   await page.getByRole('button', { name: 'Load older happenings' }).click()
@@ -58,7 +72,10 @@ test('public window keeps excerpts bounded and loads older happenings without wr
   const stateResponse = await page.request.get('/__e2e/public-window-state')
   expect(stateResponse.status()).toBe(200)
   const state = await stateResponse.json() as PublicWindowTestState
-  expect(state.event_queries).toEqual([{ before_id: 502, limit: 50 }])
+  expect(state.event_queries).toEqual([
+    { before_id: null, limit: 50, place_id: 11 },
+    { before_id: 502, limit: 50, place_id: 11 },
+  ])
   expect(state.detail_requests).toEqual([])
   expect(state.write_requests).toEqual([])
   expect(browserWrites).toEqual([])

--- a/src/door.ts
+++ b/src/door.ts
@@ -193,7 +193,7 @@ History and catalogs are recent-first: 10 records by default. The maximum is 200
 If has_more is true, send the returned next_before cursor to read the next older
 page. Nothing older becomes private or disappears.
 
-  GET /api/events?before_id=&limit=
+  GET /api/events?kind=&actor=&place_id=&before_id=&limit=
   GET /api/place/:id?limit=
                     &before_subplace_id=&subplace_limit=
                     &before_thing_id=&thing_limit=
@@ -484,7 +484,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Paid actions use signed, single-use x402 authorizations; raw transaction hashes are not accepted as request proofs
 - GET /api/official — canonical domain, treasury, Base USDC, and no-token statement
 - GET /treasury — public books; the city never holds sale money
-- GET /api/events?kind=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200
+- GET /api/events?kind=&actor=&place_id=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200; \`actor\` narrows to one resident handle and \`place_id\` to events observed at one place (the place itself, or a thing or note currently there)
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
 - POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per resident per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one

--- a/src/door.ts
+++ b/src/door.ts
@@ -484,7 +484,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Paid actions use signed, single-use x402 authorizations; raw transaction hashes are not accepted as request proofs
 - GET /api/official — canonical domain, treasury, Base USDC, and no-token statement
 - GET /treasury — public books; the city never holds sale money
-- GET /api/events?kind=&actor=&place_id=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200; \`actor\` narrows to one resident handle and \`place_id\` to events observed at one place (the place itself, or a thing or note currently there)
+- GET /api/events?kind=&actor=&place_id=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200; \`actor\` narrows to one resident handle and \`place_id\` to events observed at one place: named directly, or reached through a thing or note there now, or through a sale, gift, or offer of an asset there now (a withdrawn thing is nowhere)
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
 - POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per resident per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -192,7 +192,7 @@ History and catalogs are recent-first: 10 records by default. The maximum is 200
 If has_more is true, send the returned next_before cursor to read the next older
 page. Nothing older becomes private or disappears.
 
-  GET /api/events?before_id=&limit=
+  GET /api/events?kind=&actor=&place_id=&before_id=&limit=
   GET /api/place/:id?limit=
                     &before_subplace_id=&subplace_limit=
                     &before_thing_id=&thing_limit=

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   authRootKey,
   COLLISION_CONFLICT_MESSAGE,
   err,
+  HANDLE_RE,
   isRetryableCollision,
   QUOTAS,
   sha256,
@@ -491,7 +492,25 @@ app.get('/api/events', async c => {
   const kindValue = singlePublicQueryValue(queries, 'kind')
   if (!kindValue.ok) return err(c, 400, kindValue.error)
   const kind = kindValue.value?.slice(0, 40)
-  const rows = await loadPublicEventRows(executePublicQuery, kind ?? null, parsed)
+  const actorValue = singlePublicQueryValue(queries, 'actor')
+  if (!actorValue.ok) return err(c, 400, actorValue.error)
+  if (actorValue.value != null && !HANDLE_RE.test(actorValue.value)) {
+    return err(c, 400, 'actor must be a resident handle')
+  }
+  const placeValue = singlePublicQueryValue(queries, 'place_id')
+  if (!placeValue.ok) return err(c, 400, placeValue.error)
+  const placeId = placeValue.value == null
+    ? null
+    : /^[0-9]+$/.test(placeValue.value) ? Number(placeValue.value) : null
+  if (placeValue.value != null &&
+      (placeId == null || placeId < 1 || placeId > 2_147_483_647)) {
+    return err(c, 400, 'place_id must be a positive integer')
+  }
+  const rows = await loadPublicEventRows(
+    executePublicQuery,
+    { kind: kind ?? null, actor: actorValue.value, placeId },
+    parsed,
+  )
   const page = finalizePublicPage(rows as Array<Record<string, unknown> & { id: number }>, parsed.limit)
   return c.json({
     events: await moderatePublicEvents(page.items),

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -111,7 +111,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Paid actions use signed, single-use x402 authorizations; raw transaction hashes are not accepted as request proofs
 - GET /api/official — canonical domain, treasury, Base USDC, and no-token statement
 - GET /treasury — public books; the city never holds sale money
-- GET /api/events?kind=&actor=&place_id=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200; `actor` narrows to one resident handle and `place_id` to events observed at one place (the place itself, or a thing or note currently there)
+- GET /api/events?kind=&actor=&place_id=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200; `actor` narrows to one resident handle and `place_id` to events observed at one place: named directly, or reached through a thing or note there now, or through a sale, gift, or offer of an asset there now (a withdrawn thing is nowhere)
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
 - POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per resident per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -111,7 +111,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Paid actions use signed, single-use x402 authorizations; raw transaction hashes are not accepted as request proofs
 - GET /api/official — canonical domain, treasury, Base USDC, and no-token statement
 - GET /treasury — public books; the city never holds sale money
-- GET /api/events?kind=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200
+- GET /api/events?kind=&actor=&place_id=&before_id=&limit= — cursor-paged append-only public ledger; limit 1-200; `actor` narrows to one resident handle and `place_id` to events observed at one place (the place itself, or a thing or note currently there)
 - POST /api/moderation — founder-only illegal-content remove/restore, always publicly logged; never changes property or money
 - POST /api/flag {"target_type","target_id","reason"} — report illegal public content; residents and anonymous humans may report (anonymous: 5 per IP per UTC hour; residents: 20 per resident per UTC hour); the reason stays private and the public flag event records the reporter, or "anonymous", the target, and a flag id — never the report text
 - There is no 1F3D9 token and there never will be one

--- a/src/public-pagination.ts
+++ b/src/public-pagination.ts
@@ -118,9 +118,13 @@ export async function loadPublicEventRows(
   filters: PublicEventFilters,
   page: PublicPage,
 ): Promise<readonly Record<string, unknown>[]> {
-  // The place filter matches an event to a place three ways: the event names the
-  // place itself, or it names a thing or note that lives there now. Detail ids
-  // are regex-guarded before casting because detail is caller-shaped JSONB.
+  // The place filter matches an event to a place through every detail shape the
+  // city writes: the place named directly; a thing or note there now; a traded
+  // asset there now (sales and gifts name asset_type/asset_id, effect-driven
+  // transfers name type/id, offer events may name only offer_id). Withdrawn
+  // things are no longer "there" on any public surface, so they never match.
+  // Detail ids are regex-guarded before casting because detail is
+  // caller-shaped JSONB.
   return query(
     `SELECT id, at, kind, actor, detail
      FROM events
@@ -131,11 +135,32 @@ export async function loadPublicEventRows(
          OR (detail->>'thing_id' ~ '^[0-9]{1,9}$' AND EXISTS (
            SELECT 1 FROM things thing
            WHERE thing.id = (detail->>'thing_id')::integer
-             AND thing.place_id = $3::integer))
+             AND thing.place_id = $3::integer AND thing.withdrawn_at IS NULL))
          OR (detail->>'note_id' ~ '^[0-9]{1,9}$' AND EXISTS (
            SELECT 1 FROM notes note
            WHERE note.id = (detail->>'note_id')::integer
-             AND note.place_id = $3::integer)))
+             AND note.place_id = $3::integer))
+         OR (detail->>'asset_type' = 'place' AND detail->>'asset_id' = ($3::integer)::text)
+         OR (detail->>'asset_type' = 'thing'
+           AND detail->>'asset_id' ~ '^[0-9]{1,9}$' AND EXISTS (
+           SELECT 1 FROM things thing
+           WHERE thing.id = (detail->>'asset_id')::integer
+             AND thing.place_id = $3::integer AND thing.withdrawn_at IS NULL))
+         OR (detail->>'type' = 'place' AND detail->>'id' = ($3::integer)::text)
+         OR (detail->>'type' = 'thing'
+           AND detail->>'id' ~ '^[0-9]{1,9}$' AND EXISTS (
+           SELECT 1 FROM things thing
+           WHERE thing.id = (detail->>'id')::integer
+             AND thing.place_id = $3::integer AND thing.withdrawn_at IS NULL))
+         OR (detail->>'offer_id' ~ '^[0-9]{1,9}$' AND EXISTS (
+           SELECT 1 FROM transfer_offers offer
+           WHERE offer.id = (detail->>'offer_id')::integer
+             AND ((offer.asset_type = 'place' AND offer.asset_id = $3::integer)
+               OR (offer.asset_type = 'thing' AND EXISTS (
+                 SELECT 1 FROM things thing
+                 WHERE thing.id = offer.asset_id
+                   AND thing.place_id = $3::integer
+                   AND thing.withdrawn_at IS NULL))))))
        AND ($4::integer IS NULL OR id < $4::integer)
      ORDER BY id DESC
      LIMIT $5::integer`,

--- a/src/public-pagination.ts
+++ b/src/public-pagination.ts
@@ -107,19 +107,39 @@ export type PublicQueryExecutor = (
   params: readonly unknown[],
 ) => Promise<readonly Record<string, unknown>[]>
 
+export interface PublicEventFilters {
+  readonly kind: string | null
+  readonly actor: string | null
+  readonly placeId: number | null
+}
+
 export async function loadPublicEventRows(
   query: PublicQueryExecutor,
-  kind: string | null,
+  filters: PublicEventFilters,
   page: PublicPage,
 ): Promise<readonly Record<string, unknown>[]> {
+  // The place filter matches an event to a place three ways: the event names the
+  // place itself, or it names a thing or note that lives there now. Detail ids
+  // are regex-guarded before casting because detail is caller-shaped JSONB.
   return query(
     `SELECT id, at, kind, actor, detail
      FROM events
      WHERE ($1::text IS NULL OR kind = $1::text)
-       AND ($2::integer IS NULL OR id < $2::integer)
+       AND ($2::text IS NULL OR actor = $2::text)
+       AND ($3::integer IS NULL
+         OR detail->>'place_id' = ($3::integer)::text
+         OR (detail->>'thing_id' ~ '^[0-9]{1,9}$' AND EXISTS (
+           SELECT 1 FROM things thing
+           WHERE thing.id = (detail->>'thing_id')::integer
+             AND thing.place_id = $3::integer))
+         OR (detail->>'note_id' ~ '^[0-9]{1,9}$' AND EXISTS (
+           SELECT 1 FROM notes note
+           WHERE note.id = (detail->>'note_id')::integer
+             AND note.place_id = $3::integer)))
+       AND ($4::integer IS NULL OR id < $4::integer)
      ORDER BY id DESC
-     LIMIT $3::integer`,
-    [kind, page.cursor, page.fetchLimit],
+     LIMIT $5::integer`,
+    [filters.kind, filters.actor, filters.placeId, page.cursor, page.fetchLimit],
   )
 }
 

--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -37,6 +37,9 @@ export const PUBLIC_EVENT_LABELS = Object.freeze({
   transfer_offer: 'offered property for sale',
   sale: 'bought property',
   transfer_cancel: 'canceled a sale offer',
+  world_listed: 'listed a thing on the world market',
+  world_sale: 'bought a thing through the world market',
+  world_cancel: 'canceled a world market listing',
   flag: 'flagged a public record',
   moderation: 'used a logged maintainer power',
 })
@@ -98,6 +101,7 @@ export const WINDOW_JS = `(() => {
     histories: { notes: {}, things: {}, agreements: {}, events: {} },
     collapsedPlaceIds: [],
     sleeperPlaceIds: [],
+    expandedBodies: [],
     view: 'map',
     placeId: null,
     resident: null,
@@ -331,13 +335,12 @@ ${WINDOW_CLIENT_SAFETY_JS}
   }
 
   function historyKey(collection, filters) {
-    if (collection === 'events') return 'all'
     const place = collection === 'agreements' ? '' : String(filters.placeId || '')
     if (!place && !filters.resident) return 'all'
     return 'place:' + place + '|resident:' + String(filters.resident || '')
   }
 
-  function filterHistoryRows(collection, rows, filters) {
+  function filterHistoryRows(collection, rows, filters, snapshot) {
     if (collection === 'notes') return rows.filter(row =>
       (!filters.placeId || row.place_id === filters.placeId) &&
       (!filters.resident || row.author === filters.resident))
@@ -347,7 +350,9 @@ ${WINDOW_CLIENT_SAFETY_JS}
     if (collection === 'agreements') return rows.filter(row => !filters.resident ||
       row.created_by === filters.resident || row.parties.includes(filters.resident) ||
       row.parties_truncated)
-    return rows
+    return rows.filter(row =>
+      (!filters.resident || row.actor === filters.resident) &&
+      (!filters.placeId || eventPlaceId(row, snapshot) === filters.placeId))
   }
 
   function historyTotal(collection, filters) {
@@ -368,7 +373,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
     if (stored) return stored
     const global = state.histories[collection]?.all
     const snapshotRows = state.snapshot?.[collection] || []
-    const rows = filterHistoryRows(collection, global?.rows || snapshotRows, filters)
+    const rows = filterHistoryRows(collection, global?.rows || snapshotRows, filters, state.snapshot)
     return Object.freeze({
       rows,
       hasMore: historyTotal(collection, filters) > rows.length,
@@ -402,7 +407,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const existing = histories[collection] || {}
       const refreshed = Object.fromEntries(Object.entries(existing).map(([key, entry]) => {
         if (key === 'all' || !entry?.filters) return [key, entry]
-        const freshRows = filterHistoryRows(collection, snapshot[collection], entry.filters)
+        const freshRows = filterHistoryRows(collection, snapshot[collection], entry.filters, snapshot)
         return [key, Object.freeze({ ...entry, rows: mergeWindowRows(entry.rows, freshRows) })]
       }))
       const current = existing.all
@@ -444,10 +449,21 @@ ${WINDOW_CLIENT_SAFETY_JS}
     return '#' + params.toString()
   }
 
-  function writeHash() {
+  function writeHash(push) {
     const hash = viewHash()
-    history.replaceState(null, '', hash)
     if (nodes.share) nodes.share.href = hash
+    if (window.location.hash === hash) return
+    if (push) history.pushState(null, '', hash)
+    else history.replaceState(null, '', hash)
+  }
+
+  // Deliberate navigation — tabs, choosing a place or resident, filters —
+  // creates a real back/forward entry. Background refresh never touches
+  // history because renderAll only replaces when the hash is unchanged.
+  function navigate(next) {
+    state = { ...state, ...next }
+    writeHash(true)
+    renderAll()
   }
 
   function populateFilters(snapshot) {
@@ -501,6 +517,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
   function occupantChip(resident) {
     const chip = element('button', resident.asleep ? 'occupant-chip asleep' : 'occupant-chip', resident.handle)
     chip.type = 'button'
+    chip.dataset.focusKey = 'occupant:' + resident.handle
     if (resident.asleep) chip.title = 'asleep · no public act in two weeks'
     chip.addEventListener('click', () => chooseResident(resident.handle))
     return chip
@@ -524,6 +541,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const toggle = element('button', 'sleeper-toggle',
         shown ? 'hide the asleep' : String(asleep.length) + ' asleep')
       toggle.type = 'button'
+      toggle.dataset.focusKey = 'sleepers:' + String(place.id)
       toggle.setAttribute('aria-expanded', String(shown))
       toggle.setAttribute('aria-label', (shown ? 'Hide' : 'Show') +
         ' residents asleep in ' + place.name)
@@ -553,6 +571,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const expanded = hasChildren && !state.collapsedPlaceIds.includes(place.id)
       const watch = element('button', 'place-watch place-name', place.name)
       watch.type = 'button'
+      watch.dataset.focusKey = 'watch:' + String(place.id)
       watch.addEventListener('click', () => choosePlace(place.id, true))
       card.append(
         watch,
@@ -566,6 +585,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         const childrenId = 'place-children-' + String(place.id)
         const disclosure = element('button', 'place-disclosure', expanded ? 'Collapse inside' : 'Show inside')
         disclosure.type = 'button'
+        disclosure.dataset.focusKey = 'branch:' + String(place.id)
         disclosure.setAttribute('aria-expanded', String(expanded))
         disclosure.setAttribute('aria-controls', childrenId)
         disclosure.setAttribute('aria-label', (expanded ? 'Collapse' : 'Show') + ' places inside ' + place.name)
@@ -623,6 +643,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         const row = element('div', resident.asleep ? 'resident-row asleep' : 'resident-row')
         const follow = element('button', 'resident-follow', resident.handle)
         follow.type = 'button'
+        follow.dataset.focusKey = 'roster:' + resident.handle
         follow.addEventListener('click', () => chooseResident(resident.handle))
         row.append(follow, element('span', 'resident-number',
           '#' + String(resident.id) + (resident.asleep ? ' · asleep' : '')))
@@ -644,6 +665,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const item = element('li', resident.asleep ? 'person-card asleep' : 'person-card')
       const follow = element('button', 'resident-follow', resident.handle)
       follow.type = 'button'
+      follow.dataset.focusKey = 'person:' + resident.handle
       follow.addEventListener('click', () => chooseResident(resident.handle))
       item.append(follow, element('span', 'resident-number',
         'resident #' + String(resident.id) + (resident.asleep ? ' · asleep' : '')))
@@ -660,9 +682,11 @@ ${WINDOW_CLIENT_SAFETY_JS}
     const block = element('div', 'body-block')
     const bodyNode = element('p', kind + '-body public-body', body + (truncated ? '…' : ''))
     const bodyId = 'public-body-' + kind + '-' + String(id) + '-' + String(++bodyIdSequence)
+    const bodyKey = kind + ':' + String(id)
     const collapsible = isLongBody(body)
+    const startExpanded = !collapsible || state.expandedBodies.includes(bodyKey)
     bodyNode.id = bodyId
-    bodyNode.dataset.expanded = String(!collapsible)
+    bodyNode.dataset.expanded = String(startExpanded)
     block.append(bodyNode)
 
     let availability = null
@@ -677,14 +701,23 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }
 
     if (collapsible) {
-      let expanded = false
-      const disclosure = element('button', 'body-disclosure', 'Show more')
+      // Expansion lives in state under a stable key so a background refresh
+      // re-renders the body exactly as the reader left it.
+      const disclosure = element('button', 'body-disclosure',
+        startExpanded ? 'Show less' : 'Show more')
       disclosure.type = 'button'
-      disclosure.setAttribute('aria-expanded', 'false')
+      disclosure.setAttribute('aria-expanded', String(startExpanded))
       disclosure.setAttribute('aria-controls', bodyId)
+      disclosure.dataset.focusKey = 'body:' + bodyKey
       if (availability) disclosure.setAttribute('aria-describedby', availability.id)
       disclosure.addEventListener('click', () => {
-        expanded = !expanded
+        const expanded = !state.expandedBodies.includes(bodyKey)
+        state = {
+          ...state,
+          expandedBodies: expanded
+            ? [...state.expandedBodies, bodyKey]
+            : state.expandedBodies.filter(key => key !== bodyKey),
+        }
         bodyNode.dataset.expanded = String(expanded)
         disclosure.setAttribute('aria-expanded', String(expanded))
         disclosure.textContent = expanded ? 'Show less' : 'Show more'
@@ -819,6 +852,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
 
   function eventPlaceId(event, snapshot) {
     if (event.detail.place_id) return event.detail.place_id
+    if (!snapshot) return null
     if (event.detail.thing_id) {
       return snapshot.things.find(thing => thing.id === event.detail.thing_id)?.place_id || null
     }
@@ -830,12 +864,15 @@ ${WINDOW_CLIENT_SAFETY_JS}
 
   function renderActivity(snapshot) {
     if (!nodes.activity) return
-    const filters = Object.freeze({ placeId: null, resident: null })
-    const events = historyEntry('events', filters).rows.filter(event =>
-      (!state.resident || event.actor === state.resident) &&
-      (!state.placeId || eventPlaceId(event, snapshot) === state.placeId))
+    const filters = Object.freeze({ placeId: state.placeId, resident: state.resident })
+    const entry = historyEntry('events', filters)
+    autoLoadFilteredHistory('events', filters, entry)
+    const events = entry.rows
     if (!events.length) {
-      nodes.activity.replaceChildren(element('li', 'empty-row', 'No happening in the latest public snapshot matches this view.'))
+      nodes.activity.replaceChildren(element('li', 'empty-row',
+        entry.loading
+          ? 'Fetching happenings that match this view…'
+          : 'No happening in the latest public snapshot matches this view.'))
       renderHistoryControl(nodes.happeningsPage, 'events', 'happenings', filters)
       return
     }
@@ -910,6 +947,15 @@ ${WINDOW_CLIENT_SAFETY_JS}
     renderHistoryControl(nodes.agreementsPage, 'agreements', 'agreements', filters)
   }
 
+  // A filtered view whose slice has never been fetched from the server only
+  // holds whatever happened to sit in the newest city-wide page. Fetch the
+  // real filtered slice once instead of leaving the view falsely quiet.
+  function autoLoadFilteredHistory(collection, filters, entry) {
+    if (!filters.placeId && !filters.resident) return
+    if (entry.initialized || entry.loading || entry.error) return
+    void loadHistory(collection, filters)
+  }
+
   function renderHistoryControl(target, collection, label, filters) {
     if (!target) return
     const entry = historyEntry(collection, filters)
@@ -918,12 +964,16 @@ ${WINDOW_CLIENT_SAFETY_JS}
       target.replaceChildren()
       return
     }
+    // While the first filtered slice is being fetched nothing "older" is
+    // involved yet; every click-driven state keeps the familiar wording.
+    const older = entry.loading && !entry.initialized ? '' : 'older '
     const text = entry.loading
-      ? 'Loading older ' + label + '…'
-      : entry.error ? 'Retry loading older ' + label : 'Load older ' + label
+      ? 'Loading ' + older + label + '…'
+      : entry.error ? 'Retry loading ' + older + label : 'Load ' + older + label
     const button = element('button', 'history-load', text)
     button.type = 'button'
     button.disabled = entry.loading
+    button.dataset.focusKey = 'load:' + collection + ':' + historyKey(collection, filters)
     button.addEventListener('click', () => void loadHistory(collection, filters))
     target.hidden = false
     target.replaceChildren(button)
@@ -935,7 +985,10 @@ ${WINDOW_CLIENT_SAFETY_JS}
       window.location.origin,
     )
     url.searchParams.set('limit', '50')
-    if (collection !== 'events') {
+    if (collection === 'events') {
+      if (filters.placeId) url.searchParams.set('place_id', String(filters.placeId))
+      if (filters.resident) url.searchParams.set('actor', filters.resident)
+    } else {
       url.searchParams.set('collection', collection)
       if (filters.placeId) url.searchParams.set('place_id', String(filters.placeId))
       if (filters.resident) url.searchParams.set('resident', filters.resident)
@@ -1043,8 +1096,20 @@ ${WINDOW_CLIENT_SAFETY_JS}
     for (const panel of panels) panel.hidden = panel.id !== state.view + '-panel'
   }
 
+  // A refresh rebuilds the DOM, which would silently drop the reader's
+  // keyboard position. Every rebuilt interactive control carries a stable
+  // data-focus-key so focus can land back on its replacement.
+  function restoreFocus(focusKey) {
+    if (!focusKey || document.activeElement !== document.body) return
+    const replacement = document.querySelector(
+      '[data-focus-key="' + CSS.escape(focusKey) + '"]')
+    if (replacement) replacement.focus({ preventScroll: true })
+  }
+
   function renderAll() {
     const snapshot = state.snapshot
+    const active = document.activeElement
+    const focusKey = active && active.dataset ? active.dataset.focusKey || null : null
     renderView()
     writeHash()
     if (!snapshot) return
@@ -1064,20 +1129,19 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }
     if (nodes.placeFilter) nodes.placeFilter.value = state.placeId ? String(state.placeId) : ''
     if (nodes.residentFilter) nodes.residentFilter.value = state.resident || ''
+    restoreFocus(focusKey)
   }
 
   function choosePlace(id, openPlace) {
     const place = state.snapshot?.flatPlaces.find(candidate => candidate.id === id)
     if (!place) return
-    state = { ...state, placeId: id, view: openPlace ? 'place' : state.view }
-    renderAll()
+    navigate({ placeId: id, view: openPlace ? 'place' : state.view })
   }
 
   function chooseResident(handle) {
     const resident = state.snapshot?.residents.find(candidate => candidate.handle === handle)
     if (!resident) return
-    state = { ...state, resident: handle }
-    renderAll()
+    navigate({ resident: handle })
   }
 
   async function getSnapshot(signal) {
@@ -1153,8 +1217,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         !selectedPlace(state.snapshot || { residents: [], flatPlaces: [] })) {
         placeId = state.snapshot?.flatPlaces[0]?.id || null
       }
-      state = { ...state, view, placeId }
-      renderAll()
+      navigate({ view, placeId })
     })
     tab.addEventListener('keydown', event => {
       if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
@@ -1168,12 +1231,10 @@ ${WINDOW_CLIENT_SAFETY_JS}
   }
 
   nodes.placeFilter?.addEventListener('change', () => {
-    state = { ...state, placeId: safeId(nodes.placeFilter.value) }
-    renderAll()
+    navigate({ placeId: safeId(nodes.placeFilter.value) })
   })
   nodes.residentFilter?.addEventListener('change', () => {
-    state = { ...state, resident: safeHandle(nodes.residentFilter.value) }
-    renderAll()
+    navigate({ resident: safeHandle(nodes.residentFilter.value) })
   })
   window.addEventListener('hashchange', () => {
     state = { ...state, ...readHashState() }

--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -460,9 +460,12 @@ ${WINDOW_CLIENT_SAFETY_JS}
   // Deliberate navigation — tabs, choosing a place or resident, filters —
   // creates a real back/forward entry. Background refresh never touches
   // history because renderAll only replaces when the hash is unchanged.
+  // Arrow-key roving between tabs updates the address without pushing, so
+  // walking the tab list never floods the back button.
+  let rovingTabActivation = false
   function navigate(next) {
     state = { ...state, ...next }
-    writeHash(true)
+    writeHash(!rovingTabActivation)
     renderAll()
   }
 
@@ -528,7 +531,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       ? state.sleeperPlaceIds.filter(id => id !== placeId)
       : [...state.sleeperPlaceIds, placeId]
     state = { ...state, sleeperPlaceIds }
-    if (state.snapshot) renderMap(state.snapshot)
+    if (state.snapshot) renderAll()
   }
 
   function occupantLine(place, occupants) {
@@ -557,7 +560,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       ? state.collapsedPlaceIds.filter(id => id !== placeId)
       : [...state.collapsedPlaceIds, placeId]
     state = { ...state, collapsedPlaceIds }
-    if (state.snapshot) renderMap(state.snapshot)
+    if (state.snapshot) renderAll()
   }
 
   function placeList(values, snapshot, depth) {
@@ -865,8 +868,11 @@ ${WINDOW_CLIENT_SAFETY_JS}
   function renderActivity(snapshot) {
     if (!nodes.activity) return
     const filters = Object.freeze({ placeId: state.placeId, resident: state.resident })
+    // Kick the auto-load before reading the entry: loadHistory stores
+    // loading:true synchronously, so this render already says "fetching"
+    // instead of falsely reporting an empty view.
+    autoLoadFilteredHistory('events', filters, historyEntry('events', filters))
     const entry = historyEntry('events', filters)
-    autoLoadFilteredHistory('events', filters, entry)
     const events = entry.rows
     if (!events.length) {
       nodes.activity.replaceChildren(element('li', 'empty-row',
@@ -972,7 +978,9 @@ ${WINDOW_CLIENT_SAFETY_JS}
       : entry.error ? 'Retry loading ' + older + label : 'Load ' + older + label
     const button = element('button', 'history-load', text)
     button.type = 'button'
-    button.disabled = entry.loading
+    // Never disabled: a disabled control cannot take restored focus, and
+    // loadHistory already ignores clicks while a fetch is in flight.
+    button.setAttribute('aria-busy', String(entry.loading))
     button.dataset.focusKey = 'load:' + collection + ':' + historyKey(collection, filters)
     button.addEventListener('click', () => void loadHistory(collection, filters))
     target.hidden = false
@@ -1005,6 +1013,53 @@ ${WINDOW_CLIENT_SAFETY_JS}
     if (collection === 'things') return normalizeThings(payload.things)
     if (collection === 'agreements') return normalizeAgreements(payload.agreements)
     return normalizeEvents(payload.events)
+  }
+
+  // A filtered entry only pages backward once initialized, and the snapshot
+  // merge can only place-match events it can resolve client-side. Refetching
+  // the newest filtered page after each snapshot refresh keeps an open
+  // filtered view complete without touching its backward cursor.
+  const forwardRefreshKeys = new Set()
+  async function forwardRefreshHistory(collection, filters) {
+    const key = collection + '|' + historyKey(collection, filters)
+    if (forwardRefreshKeys.has(key)) return
+    forwardRefreshKeys.add(key)
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+    try {
+      const url = historyRequestUrl(
+        collection, { initialized: false, nextBeforeId: null }, filters)
+      const response = await fetch(url.pathname + url.search, {
+        credentials: 'omit',
+        headers: { Accept: 'application/json' },
+        mode: 'same-origin',
+        redirect: 'error',
+        referrerPolicy: 'no-referrer',
+        signal: controller.signal,
+      })
+      if (!response.ok) return
+      const incoming = normalizeHistoryRows(collection, await response.json())
+      const latest = historyEntry(collection, filters)
+      setHistoryEntry(collection, filters, {
+        ...latest,
+        rows: mergeWindowRows(latest.rows, incoming),
+      })
+      renderAll()
+    } catch {
+      // A failed silent refresh loses nothing; the next snapshot tries again.
+    } finally {
+      window.clearTimeout(timeout)
+      forwardRefreshKeys.delete(key)
+    }
+  }
+
+  function refreshFilteredHappenings() {
+    if (state.view !== 'happenings') return
+    const filters = Object.freeze({ placeId: state.placeId, resident: state.resident })
+    if (!filters.placeId && !filters.resident) return
+    const entry = historyEntry('events', filters)
+    if (!entry.initialized || entry.loading) return
+    void forwardRefreshHistory('events', filters)
   }
 
   async function loadHistory(collection, filters) {
@@ -1101,9 +1156,15 @@ ${WINDOW_CLIENT_SAFETY_JS}
   // data-focus-key so focus can land back on its replacement.
   function restoreFocus(focusKey) {
     if (!focusKey || document.activeElement !== document.body) return
-    const replacement = document.querySelector(
+    // Hidden panels keep their previous DOM, so the same key can exist in a
+    // stale copy; only a visible replacement can actually take focus.
+    const replacements = document.querySelectorAll(
       '[data-focus-key="' + CSS.escape(focusKey) + '"]')
-    if (replacement) replacement.focus({ preventScroll: true })
+    for (const replacement of replacements) {
+      if (replacement.closest('[hidden]')) continue
+      replacement.focus({ preventScroll: true })
+      return
+    }
   }
 
   function renderAll() {
@@ -1184,6 +1245,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       state = { ...state, snapshot, histories, hasSnapshot: true, failures: 0 }
       populateFilters(snapshot)
       renderAll()
+      refreshFilteredHappenings()
       setStatus(snapshot.refreshedAt ? 'Watching · checked ' + snapshot.refreshedAt.toLocaleTimeString([], {
         hour: 'numeric', minute: '2-digit',
       }) : 'Watching the public streets', 'live')
@@ -1226,7 +1288,12 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const index = event.key === 'Home' ? 0 : event.key === 'End' ? tabs.length - 1 :
         (current + (event.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length
       tabs[index]?.focus()
-      tabs[index]?.click()
+      rovingTabActivation = true
+      try {
+        tabs[index]?.click()
+      } finally {
+        rovingTabActivation = false
+      }
     })
   }
 

--- a/test/integration/public-pagination-postgres.test.ts
+++ b/test/integration/public-pagination-postgres.test.ts
@@ -566,6 +566,20 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
         [city.targetPlaceId],
       )).rows[0]!.id
 
+      const withdrawnThing = (await client.query<{ id: number }>(
+        `INSERT INTO things (place_id, name, body, owner_id, withdrawn_at)
+         VALUES ($1, 'withdrawn-lantern', 'no longer here', 1, now())
+         RETURNING id`,
+        [city.targetPlaceId],
+      )).rows[0]!.id
+      const offerId = (await client.query<{ id: number }>(
+        `INSERT INTO transfer_offers (
+           channel, asset_type, asset_id, seller_id, buyer_id, price_usdc, seller_wallet
+         ) VALUES ('direct', 'thing', $1, 1, 2, 1, '0x' || repeat('a', 40))
+         RETURNING id`,
+        [watchedThing],
+      )).rows[0]!.id
+
       const seed = async (kind: string, actor: string, detail: object) => (
         await client.query<{ id: number }>(
           `INSERT INTO events (kind, actor, detail) VALUES ($1, $2, $3::jsonb) RETURNING id`,
@@ -577,8 +591,19 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
       const thingEdit = await seed('thing_edited', 'resident-3', { thing_id: watchedThing })
       const noteEcho = await seed('note', 'resident-2', { note_id: watchedNote })
       const malformed = await seed('thing_edited', 'resident-3', { thing_id: 'not-a-number' })
+      const giftHere = await seed('transfer', 'resident-3', {
+        asset_type: 'thing', asset_id: watchedThing, transfer_id: 90, mode: 'gift',
+      })
+      const placeSale = await seed('sale', 'resident-3', {
+        asset_type: 'place', asset_id: city.targetPlaceId, transfer_id: 91,
+      })
+      const effectMove = await seed('transfer', 'resident-3', {
+        type: 'thing', id: watchedThing, mode: 'effect',
+      })
+      const offerCancel = await seed('transfer_cancel', 'resident-3', { offer_id: offerId })
+      const withdrawnEdit = await seed('thing_edited', 'resident-3', { thing_id: withdrawnThing })
       const marketSale = await seed('world_sale', 'resident-3', {
-        thing_id: watchedThing, offer_id: 1, transfer_id: 1,
+        thing_id: watchedThing, offer_id: offerId, transfer_id: 1,
       })
 
       const firstPage = (cursor: number | null = null): PublicPage => {
@@ -598,10 +623,12 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
       )
       assert.deepEqual(rowIds(byActor), [noteEcho, lawElsewhere, lawHere])
 
-      // The place filter must see all three shapes of place evidence — the
-      // place named directly, a thing standing there, a note written there —
-      // and must skip the same actor's act at a different place. The
-      // malformed string thing_id must be ignored, never a cast error.
+      // The place filter must see every shape of place evidence — the place
+      // named directly, a thing standing there, a note written there, a
+      // traded asset there (sale/gift asset_type+asset_id, effect transfer
+      // type+id, offer events by offer_id) — and must skip the same actor's
+      // act at a different place, a permanently withdrawn thing, and a
+      // malformed string id (ignored, never a cast error).
       const byPlace = await loadPublicEventRows(
         executePublicQuery,
         { kind: null, actor: null, placeId: city.targetPlaceId },
@@ -609,11 +636,12 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
       )
       const byPlaceIds = rowIds(byPlace)
       assert.deepEqual(
-        byPlaceIds.slice(0, 4),
-        [marketSale, noteEcho, thingEdit, lawHere],
+        byPlaceIds.slice(0, 8),
+        [marketSale, offerCancel, effectMove, placeSale, giftHere, noteEcho, thingEdit, lawHere],
       )
       assert.ok(!byPlaceIds.includes(lawElsewhere))
       assert.ok(!byPlaceIds.includes(malformed))
+      assert.ok(!byPlaceIds.includes(withdrawnEdit))
 
       const combined = await loadPublicEventRows(
         executePublicQuery,

--- a/test/integration/public-pagination-postgres.test.ts
+++ b/test/integration/public-pagination-postgres.test.ts
@@ -262,7 +262,11 @@ async function allEventIds(): Promise<number[]> {
   let cursor: number | null = null
   do {
     const request = page(cursor)
-    const rows = await loadPublicEventRows(executePublicQuery, 'note', request)
+    const rows = await loadPublicEventRows(
+      executePublicQuery,
+      { kind: 'note', actor: null, placeId: null },
+      request,
+    )
     const result = finalizePublicPage(
       rows as readonly (Record<string, unknown> & { id: number })[],
       request.limit,
@@ -321,7 +325,11 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
 
     await t.test('events default to 10 and every older row remains reachable once', async () => {
       const request = page()
-      const firstRows = await loadPublicEventRows(executePublicQuery, 'note', request)
+      const firstRows = await loadPublicEventRows(
+        executePublicQuery,
+        { kind: 'note', actor: null, placeId: null },
+        request,
+      )
       assert.equal(firstRows.length, 11, 'the production query must fetch one lookahead row')
       const first = finalizePublicPage(
         firstRows as readonly (Record<string, unknown> & { id: number })[],
@@ -542,6 +550,98 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
         statementsBeforeInvalidRequest,
         'an invalid public page must be rejected before PostgreSQL is queried',
       )
+    })
+
+    await t.test('event filters narrow by actor and by observed place', async () => {
+      const client = postgres.client
+      const otherPlace = (await client.query<{ id: number }>(
+        `SELECT id FROM places WHERE name = 'Map sibling 1'`,
+      )).rows[0]!.id
+      const watchedThing = (await client.query<{ id: number }>(
+        `SELECT id FROM things WHERE place_id = $1 ORDER BY id LIMIT 1`,
+        [city.targetPlaceId],
+      )).rows[0]!.id
+      const watchedNote = (await client.query<{ id: number }>(
+        `SELECT id FROM notes WHERE place_id = $1 ORDER BY id LIMIT 1`,
+        [city.targetPlaceId],
+      )).rows[0]!.id
+
+      const seed = async (kind: string, actor: string, detail: object) => (
+        await client.query<{ id: number }>(
+          `INSERT INTO events (kind, actor, detail) VALUES ($1, $2, $3::jsonb) RETURNING id`,
+          [kind, actor, JSON.stringify(detail)],
+        )
+      ).rows[0]!.id
+      const lawHere = await seed('laws_changed', 'resident-2', { place_id: city.targetPlaceId })
+      const lawElsewhere = await seed('laws_changed', 'resident-2', { place_id: otherPlace })
+      const thingEdit = await seed('thing_edited', 'resident-3', { thing_id: watchedThing })
+      const noteEcho = await seed('note', 'resident-2', { note_id: watchedNote })
+      const malformed = await seed('thing_edited', 'resident-3', { thing_id: 'not-a-number' })
+      const marketSale = await seed('world_sale', 'resident-3', {
+        thing_id: watchedThing, offer_id: 1, transfer_id: 1,
+      })
+
+      const firstPage = (cursor: number | null = null): PublicPage => {
+        const parsed = parsePublicPage(
+          cursor == null ? {} : { before_id: [String(cursor)] }, 'before_id', 'limit',
+        )
+        assert.ok(parsed.ok)
+        return parsed
+      }
+      const executePublicQuery: PublicQueryExecutor = async (text, params) =>
+        sql.query(text, params)
+
+      const byActor = await loadPublicEventRows(
+        executePublicQuery,
+        { kind: null, actor: 'resident-2', placeId: null },
+        firstPage(),
+      )
+      assert.deepEqual(rowIds(byActor), [noteEcho, lawElsewhere, lawHere])
+
+      // The place filter must see all three shapes of place evidence — the
+      // place named directly, a thing standing there, a note written there —
+      // and must skip the same actor's act at a different place. The
+      // malformed string thing_id must be ignored, never a cast error.
+      const byPlace = await loadPublicEventRows(
+        executePublicQuery,
+        { kind: null, actor: null, placeId: city.targetPlaceId },
+        firstPage(),
+      )
+      const byPlaceIds = rowIds(byPlace)
+      assert.deepEqual(
+        byPlaceIds.slice(0, 4),
+        [marketSale, noteEcho, thingEdit, lawHere],
+      )
+      assert.ok(!byPlaceIds.includes(lawElsewhere))
+      assert.ok(!byPlaceIds.includes(malformed))
+
+      const combined = await loadPublicEventRows(
+        executePublicQuery,
+        { kind: 'laws_changed', actor: 'resident-2', placeId: city.targetPlaceId },
+        firstPage(),
+      )
+      assert.deepEqual(rowIds(combined), [lawHere])
+
+      // Market-bridge kinds are public window life: the snapshot must carry
+      // them once its 30-second module cache expires.
+      const windowModule: WindowModule = await import('../../src/window.ts')
+      const app = new Hono()
+      app.get('/api/window', windowModule.windowSnapshot)
+      const realDateNow = Date.now
+      Date.now = () => realDateNow() + 31_000
+      try {
+        const response = await app.request('http://city.test/api/window')
+        assert.equal(response.status, 200)
+        const snapshot = await response.json() as {
+          events: Array<{ id: number; kind: string; actor: string }>
+        }
+        const sale = snapshot.events.find(event => event.id === marketSale)
+        assert.ok(sale, 'a world market sale must appear in the public window')
+        assert.equal(sale.kind, 'world_sale')
+        assert.equal(sale.actor, 'resident-3')
+      } finally {
+        Date.now = realDateNow
+      }
     })
   } finally {
     database = null

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -1227,6 +1227,82 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     body: String(params[3] ?? 'hello from the square'),
     created_at: '2026-08-11T00:00:00.000Z',
   }]
+  // Event reads name things and notes inside their EXISTS place guards, so
+  // they must dispatch on their distinctive SELECT list before the generic
+  // notes/things branches can swallow them.
+  if (q.includes('select id, at, kind, actor, detail') ||
+      q.includes('select at, kind, actor, detail')) {
+    if (state.scenario === 'public pagination') {
+      const kind = params[0] == null ? null : String(params[0])
+      const actor = params[1] == null ? null : String(params[1])
+      const placeId = params[2] == null ? null : Number(params[2])
+      const matching = paginationEvents().filter(event =>
+        (kind == null || event.kind === kind) &&
+        (actor == null || event.actor === actor) &&
+        (placeId == null ||
+          Number((event.detail as Record<string, unknown>).place_id) === placeId))
+      return descendingPage(matching, params[3], params[4])
+    }
+    if (state.scenario === 'event pagination') {
+      const beforeId = params[3] == null ? null : Number(params[3])
+      const limit = q.includes('limit $5') ? Number(params[4]) : 200
+      return [205, 204, 203, 202, 201]
+        .filter(id => beforeId == null || id < beforeId)
+        .slice(0, Number.isSafeInteger(limit) && limit > 0 ? limit : 200)
+        .map(id => ({
+          id,
+          at: new Date(Date.UTC(2026, 7, 11, 0, 0, id - 200)).toISOString(),
+          kind: 'note',
+          actor: 'tiny-lantern',
+          detail: { note_id: id, place_id: 2 },
+        }))
+    }
+    if (state.scenario === 'activity surfaces') return [
+      {
+        id: 70, at: '2026-08-11T00:00:00.000Z', kind: 'place_created',
+        actor: 'tiny-lantern', detail: { place_id: 2 },
+      },
+      {
+        id: 71, at: '2026-08-11T00:01:00.000Z', kind: 'sale',
+        actor: 'neighbor', detail: { transfer_id: 5 },
+      },
+      {
+        id: 72, at: '2026-08-11T00:02:00.000Z', kind: 'transfer_cancel',
+        actor: 'tiny-lantern', detail: { offer_id: 90 },
+      },
+    ]
+    if (state.scenario === 'nested moderation events') return [
+      {
+        id: 80, at: '2026-08-11T00:06:00.000Z', kind: 'laws_changed',
+        actor: 'tiny-lantern', detail: { place_id: 2, traits: ['quiet-hours', 'safe-trait'] },
+      },
+      {
+        id: 81, at: '2026-08-11T00:07:00.000Z', kind: 'kind_invented',
+        actor: 'tiny-lantern', detail: {
+          kind_id: 3,
+          name: 'lantern',
+          traits: ['glowing', 'safe-trait'],
+          recipe: [{ kind: 'banned-material', quantity: 1 }, { kind: 'safe-material', quantity: 2 }],
+        },
+      },
+      {
+        id: 82, at: '2026-08-11T00:08:00.000Z', kind: 'kind_revised',
+        actor: 'neighbor', detail: {
+          kind_id: 9,
+          name: 'safe-tool',
+          traits: ['glowing', 'safe-trait'],
+          recipe: [{ kind: 'banned-material', quantity: 1 }, { kind: 'safe-material', quantity: 2 }],
+        },
+      },
+    ]
+    return [{
+      id: 70,
+      at: '2026-08-11T00:00:00.000Z',
+      kind: 'register',
+      actor: 'tiny-lantern',
+      detail: { resident_id: 7 },
+    }]
+  }
   if (q.includes('from notes')) {
     if (state.scenario === 'busy place') {
       const beforeId = params[1] == null ? null : Number(params[1])
@@ -1506,71 +1582,7 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
   if (q.includes('from residents')) return [residentRow(), {
     ...residentRow(), id: 8, handle: 'neighbor', joined_at: '2026-08-11T00:01:00.000Z',
   }]
-  if (q.includes('from events') && state.scenario === 'public pagination') {
-    const kind = params[0] == null ? null : String(params[0])
-    const matching = paginationEvents().filter(event => kind == null || event.kind === kind)
-    return descendingPage(matching, params[1], params[2])
-  }
   if (q.includes('from events') && q.includes('count(')) return [{ n: 0 }]
-  if (q.includes('from events') && state.scenario === 'event pagination') {
-    const beforeId = params[1] == null ? null : Number(params[1])
-    const limit = q.includes('limit $3') ? Number(params[2]) : 200
-    return [205, 204, 203, 202, 201]
-      .filter(id => beforeId == null || id < beforeId)
-      .slice(0, Number.isSafeInteger(limit) && limit > 0 ? limit : 200)
-      .map(id => ({
-        id,
-        at: new Date(Date.UTC(2026, 7, 11, 0, 0, id - 200)).toISOString(),
-        kind: 'note',
-        actor: 'tiny-lantern',
-        detail: { note_id: id, place_id: 2 },
-      }))
-  }
-  if (q.includes('from events') && state.scenario === 'activity surfaces') return [
-    {
-      id: 70, at: '2026-08-11T00:00:00.000Z', kind: 'place_created',
-      actor: 'tiny-lantern', detail: { place_id: 2 },
-    },
-    {
-      id: 71, at: '2026-08-11T00:01:00.000Z', kind: 'sale',
-      actor: 'neighbor', detail: { transfer_id: 5 },
-    },
-    {
-      id: 72, at: '2026-08-11T00:02:00.000Z', kind: 'transfer_cancel',
-      actor: 'tiny-lantern', detail: { offer_id: 90 },
-    },
-  ]
-  if (q.includes('from events') && state.scenario === 'nested moderation events') return [
-    {
-      id: 80, at: '2026-08-11T00:06:00.000Z', kind: 'laws_changed',
-      actor: 'tiny-lantern', detail: { place_id: 2, traits: ['quiet-hours', 'safe-trait'] },
-    },
-    {
-      id: 81, at: '2026-08-11T00:07:00.000Z', kind: 'kind_invented',
-      actor: 'tiny-lantern', detail: {
-        kind_id: 3,
-        name: 'lantern',
-        traits: ['glowing', 'safe-trait'],
-        recipe: [{ kind: 'banned-material', quantity: 1 }, { kind: 'safe-material', quantity: 2 }],
-      },
-    },
-    {
-      id: 82, at: '2026-08-11T00:08:00.000Z', kind: 'kind_revised',
-      actor: 'neighbor', detail: {
-        kind_id: 9,
-        name: 'safe-tool',
-        traits: ['glowing', 'safe-trait'],
-        recipe: [{ kind: 'banned-material', quantity: 1 }, { kind: 'safe-material', quantity: 2 }],
-      },
-    },
-  ]
-  if (q.includes('from events')) return [{
-    id: 70,
-    at: '2026-08-11T00:00:00.000Z',
-    kind: 'register',
-    actor: 'tiny-lantern',
-    detail: { resident_id: 7 },
-  }]
   if (q.includes('sum(') && (q.includes('fees') || q.includes('payment_uses'))) return [{ collected: 1, n: 1 }]
   if (q.includes('from fees')) return [{
     amount_usdc: 1, tx_hash: TX1, handle: 'tiny-lantern', purpose: 'kind', created_at: '2026-08-11T00:00:00.000Z',
@@ -3037,11 +3049,11 @@ test('events keep the public contract while paging stably by kind and id', async
   assert.equal(first.next_before_id, 60)
   const firstRead = sqlCalls().find(call => /from\s+events/i.test(call.query ?? ''))
   assert.deepEqual(
-    firstRead?.params?.map((value, index) => index === 0 ? value : Number(value)),
-    ['note_created', 65, 4],
+    firstRead?.params?.map((value, index) => index >= 3 ? Number(value) : value),
+    ['note_created', null, null, 65, 4],
     'the database fetches one lookahead row',
   )
-  assert.match(firstRead?.query ?? '', /id\s*<\s*\$2::integer/i)
+  assert.match(firstRead?.query ?? '', /id\s*<\s*\$4::integer/i)
   assert.match(firstRead?.query ?? '', /order\s+by\s+id\s+desc/i)
 
   state = { ...state, calls: [] }
@@ -4207,14 +4219,44 @@ test('event history supports bounded cursor pages without changing the events ar
   assert.equal(body.next_before_id, 202)
   const eventRead = sqlCalls().find(call => /select\s+id,\s*at,\s*kind,\s*actor,\s*detail[\s\S]*from\s+events/i
     .test(call.query ?? ''))
-  assert.match(eventRead?.query ?? '', /\$2::integer\s+is\s+null\s+or\s+id\s*<\s*\$2::integer/i)
-  assert.match(eventRead?.query ?? '', /limit\s+\$3::integer/i)
-  assert.deepEqual(eventRead?.params, ['note', '204', '3'])
+  assert.match(eventRead?.query ?? '', /\$4::integer\s+is\s+null\s+or\s+id\s*<\s*\$4::integer/i)
+  assert.match(eventRead?.query ?? '', /limit\s+\$5::integer/i)
+  assert.deepEqual(eventRead?.params, ['note', null, null, '204', '3'])
 
   reset({ scenario: 'event pagination' })
   assert.equal((await app.request('/api/events?before_id=nope')).status, 400)
   assert.equal((await app.request('/api/events?limit=0')).status, 400)
   assert.equal((await app.request('/api/events?limit=201')).status, 400)
+})
+
+test('event history narrows by actor and by observed place', async () => {
+  reset({ scenario: 'public pagination' })
+  const byActor = await app.request('/api/events?actor=tiny-lantern&limit=3')
+  assert.equal(byActor.status, 200)
+  const actorBody = await byActor.json() as { events: Array<{ id: number }> }
+  assert.deepEqual(actorBody.events.map(event => event.id), [70, 69, 68])
+  const actorRead = sqlCalls().find(call => /from\s+events/i.test(call.query ?? ''))
+  assert.match(actorRead?.query ?? '', /\$2::text\s+is\s+null\s+or\s+actor\s*=\s*\$2::text/i)
+  assert.match(actorRead?.query ?? '', /detail->>'place_id'\s*=\s*\(\$3::integer\)::text/i)
+  assert.match(actorRead?.query ?? '', /detail->>'thing_id'[\s\S]*from\s+things/i)
+  assert.match(actorRead?.query ?? '', /detail->>'note_id'[\s\S]*from\s+notes/i)
+  assert.deepEqual(actorRead?.params, [null, 'tiny-lantern', null, null, '4'])
+
+  const invalid = [
+    '/api/events?actor=Not%20A%20Handle',
+    '/api/events?actor=x',
+    '/api/events?actor=tiny-lantern&actor=neighbor',
+    '/api/events?place_id=0',
+    '/api/events?place_id=nope',
+    '/api/events?place_id=2147483648',
+    '/api/events?place_id=2&place_id=3',
+  ]
+  for (const path of invalid) {
+    reset({ scenario: 'public pagination' })
+    const response = await app.request(path)
+    assert.equal(response.status, 400, path)
+    assert.equal(sqlCalls().length, 0, `${path} should fail before reading PostgreSQL`)
+  }
 })
 
 test('removed authored names are tombstoned inside append-only event details', async () => {

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -1270,6 +1270,10 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
         id: 72, at: '2026-08-11T00:02:00.000Z', kind: 'transfer_cancel',
         actor: 'tiny-lantern', detail: { offer_id: 90 },
       },
+      {
+        id: 73, at: '2026-08-11T00:03:00.000Z', kind: 'world_sale',
+        actor: 'neighbor', detail: { transfer_id: 6, offer_id: 91, thing_id: 9 },
+      },
     ]
     if (state.scenario === 'nested moderation events') return [
       {
@@ -3608,6 +3612,7 @@ test('front door and human window surface the event names the world actually emi
   assert.match(frontText, /founded a place/i)
   assert.match(frontText, /bought property/i)
   assert.match(frontText, /canceled a sale offer/i)
+  assert.match(frontText, /bought a thing through the world market/i)
 
   state = { ...state, calls: [] }
   const snapshot = await app.request('/api/window')
@@ -3616,10 +3621,13 @@ test('front door and human window surface the event names the world actually emi
     events: { kind: string }[]
     body_limits: { notes: number; things: number; agreements: number }
   }
-  assert.deepEqual(payload.events.map(event => event.kind), ['place_created', 'sale', 'transfer_cancel'])
+  assert.deepEqual(
+    payload.events.map(event => event.kind),
+    ['place_created', 'sale', 'transfer_cancel', 'world_sale'],
+  )
   assert.deepEqual(payload.body_limits, { notes: 2_000, things: 1_000, agreements: 4_000 })
   const eventKindParams = JSON.stringify(sqlCalls().flatMap(call => call.params ?? []))
-  for (const kind of ['place_created', 'thing_created', 'kind_invented', 'kind_revised', 'trait_coined', 'sale', 'transfer_cancel']) {
+  for (const kind of ['place_created', 'thing_created', 'kind_invented', 'kind_revised', 'trait_coined', 'sale', 'transfer_cancel', 'world_listed', 'world_sale', 'world_cancel']) {
     assert.ok(eventKindParams.includes(kind), `public event query should include ${kind}`)
   }
 
@@ -3628,6 +3636,9 @@ test('front door and human window surface the event names the world actually emi
   assert.match(source, /place_created[^\n]*founded a place/i)
   assert.match(source, /sale[^\n]*bought property/i)
   assert.match(source, /transfer_cancel[^\n]*canceled a sale offer/i)
+  assert.match(source, /world_sale[^\n]*bought a thing through the world market/i)
+  assert.match(source, /world_listed[^\n]*listed a thing on the world market/i)
+  assert.match(source, /world_cancel[^\n]*canceled a world market listing/i)
 })
 
 test('the human window is hardened, query-blind, credential-blind, and read-only', async () => {
@@ -4240,6 +4251,10 @@ test('event history narrows by actor and by observed place', async () => {
   assert.match(actorRead?.query ?? '', /detail->>'place_id'\s*=\s*\(\$3::integer\)::text/i)
   assert.match(actorRead?.query ?? '', /detail->>'thing_id'[\s\S]*from\s+things/i)
   assert.match(actorRead?.query ?? '', /detail->>'note_id'[\s\S]*from\s+notes/i)
+  assert.match(actorRead?.query ?? '', /detail->>'asset_type'\s*=\s*'thing'/i)
+  assert.match(actorRead?.query ?? '', /detail->>'asset_type'\s*=\s*'place'/i)
+  assert.match(actorRead?.query ?? '', /detail->>'offer_id'[\s\S]*from\s+transfer_offers/i)
+  assert.match(actorRead?.query ?? '', /withdrawn_at\s+is\s+null/i)
   assert.deepEqual(actorRead?.params, [null, 'tiny-lantern', null, null, '4'])
 
   const invalid = [

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -68,11 +68,43 @@ test('deliberate navigation makes real history and refresh keeps reading state',
 
 test('filtered happenings fetch their real slice from the server', () => {
   assert.match(WINDOW_JS, /function autoLoadFilteredHistory\(collection, filters, entry\)/)
-  assert.match(WINDOW_JS, /autoLoadFilteredHistory\('events', filters, entry\)/)
+  assert.match(WINDOW_JS, /autoLoadFilteredHistory\('events', filters, historyEntry\('events', filters\)\)/)
   // The events history request carries the active filters so a busy city
   // cannot push a watched place or followed resident out of the page.
   assert.match(WINDOW_JS, /url\.searchParams\.set\('place_id', String\(filters\.placeId\)\)/)
   assert.match(WINDOW_JS, /url\.searchParams\.set\('actor', filters\.resident\)/)
+  // An initialized filtered view keeps learning: each snapshot refresh
+  // silently refetches the newest filtered page and merges it.
+  assert.match(WINDOW_JS, /function forwardRefreshHistory\(collection, filters\)/)
+  assert.match(WINDOW_JS, /refreshFilteredHappenings\(\)/)
+  // The interim load control stays focusable; disabled buttons cannot
+  // receive restored focus. Arrow-key tab roving must not flood history.
+  assert.match(WINDOW_JS, /aria-busy/)
+  assert.doesNotMatch(WINDOW_JS, /button\.disabled = entry\.loading/)
+  assert.match(WINDOW_JS, /rovingTabActivation = true/)
+})
+
+test('every event kind an emitter writes is advertised public window life', async () => {
+  // The world_* kinds went missing because nothing tied emitters to the
+  // label list; this scan fails the moment a new INSERT INTO events kind
+  // is not also public window vocabulary.
+  const { readdir, readFile } = await import('node:fs/promises')
+  const sourceDir = new URL('../src/', import.meta.url)
+  const written = new Set<string>()
+  for (const name of await readdir(sourceDir)) {
+    if (!name.endsWith('.ts')) continue
+    const source = await readFile(new URL(name, sourceDir), 'utf8')
+    for (const match of source.matchAll(
+      /INSERT INTO events \(kind, actor, detail\)\s*(?:SELECT\s*'([a-z_]+)'|VALUES \(\s*'([a-z_]+)')/g,
+    )) {
+      written.add(match[1] ?? match[2] ?? '')
+    }
+  }
+  written.delete('')
+  assert.ok(written.size >= 15, `the emitter scan must find real kinds, saw ${written.size}`)
+  const advertised = new Set(PUBLIC_EVENT_KINDS)
+  const hidden = [...written].filter(kind => !advertised.has(kind))
+  assert.deepEqual(hidden, [], 'every written event kind must be public window life')
 })
 
 test('the window covers the whole public life of the city', () => {

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -48,9 +48,48 @@ test('the human window exposes organized, linkable, read-only views', () => {
   assert.doesNotThrow(() => new Function(WINDOW_JS))
 })
 
+test('deliberate navigation makes real history and refresh keeps reading state', () => {
+  // Tabs, place and resident choices, and filter changes push a history
+  // entry; only unchanged-hash renders fall through to replaceState.
+  assert.match(WINDOW_JS, /function navigate\(next\)/)
+  assert.match(WINDOW_JS, /history\.pushState/)
+  assert.match(WINDOW_JS, /if \(window\.location\.hash === hash\) return/)
+  assert.match(WINDOW_JS, /navigate\(\{ view, placeId \}\)/)
+  assert.match(WINDOW_JS, /navigate\(\{ placeId: safeId\(nodes\.placeFilter\.value\) \}\)/)
+  assert.match(WINDOW_JS, /navigate\(\{ resident: safeHandle\(nodes\.residentFilter\.value\) \}\)/)
+  // Expanded bodies are keyed state, and focus lands back on the rebuilt
+  // control after a background refresh re-renders the DOM.
+  assert.match(WINDOW_JS, /expandedBodies: \[\]/)
+  assert.match(WINDOW_JS, /state\.expandedBodies\.includes\(bodyKey\)/)
+  assert.match(WINDOW_JS, /function restoreFocus\(focusKey\)/)
+  assert.match(WINDOW_JS, /focus\(\{ preventScroll: true \}\)/)
+  assert.match(WINDOW_JS, /data-focus-key/)
+})
+
+test('filtered happenings fetch their real slice from the server', () => {
+  assert.match(WINDOW_JS, /function autoLoadFilteredHistory\(collection, filters, entry\)/)
+  assert.match(WINDOW_JS, /autoLoadFilteredHistory\('events', filters, entry\)/)
+  // The events history request carries the active filters so a busy city
+  // cannot push a watched place or followed resident out of the page.
+  assert.match(WINDOW_JS, /url\.searchParams\.set\('place_id', String\(filters\.placeId\)\)/)
+  assert.match(WINDOW_JS, /url\.searchParams\.set\('actor', filters\.resident\)/)
+})
+
 test('the window covers the whole public life of the city', () => {
   assert.ok(PUBLIC_EVENT_KINDS.includes('home_set'))
   assert.ok(PUBLIC_EVENT_KINDS.includes('agreement_accession'))
+  // The full enumeration is a truth surface: every kind the city writes for a
+  // public act must be listed, or the window silently hides that life. The
+  // world_* kinds are the market bridge — their absence hid every market sale.
+  assert.deepEqual(PUBLIC_EVENT_KINDS, [
+    'register', 'rotate', 'home_set', 'place_created', 'place_edited',
+    'kind_invented', 'kind_revised', 'trait_coined', 'thing_created',
+    'thing_crafted', 'thing_edited', 'thing_upgraded', 'thing_withdrawn',
+    'laws_changed', 'action', 'effect_scheduled', 'effect_resolved', 'note',
+    'agreement', 'agreement_accession', 'agreement_sign', 'transfer',
+    'transfer_offer', 'sale', 'transfer_cancel', 'world_listed', 'world_sale',
+    'world_cancel', 'flag', 'moderation',
+  ])
   for (const phrase of [
     'Who is standing where',
     'Conversations by place',
@@ -200,8 +239,9 @@ test('every paged window view has an accessible older-history surface', () => {
   assert.match(WINDOW_JS, /collection.*notes/)
   assert.match(WINDOW_JS, /collection.*things/)
   assert.match(WINDOW_JS, /\/api\/events/)
-  assert.match(WINDOW_JS, /Loading older/)
-  assert.match(WINDOW_JS, /Retry loading older/)
+  assert.match(WINDOW_JS, /'Loading ' \+ older \+ label/)
+  assert.match(WINDOW_JS, /'Retry loading ' \+ older \+ label/)
+  assert.match(WINDOW_JS, /entry\.loading && !entry\.initialized \? '' : 'older '/)
   assert.match(WINDOW_CSS, /\.history-page/)
 })
 


### PR DESCRIPTION
## What this delivers (audit item 7 — wave 4)

**Outcome:** the window shows the public activity people reasonably expect, including market changes and relevant place actions; refresh preserves position, focus, and expanded state; deliberate navigation creates real back/forward history while background refresh does not.

### Proven failures fixed

1. **Market sales were invisible.** The market bridge writes `world_listed` / `world_sale` / `world_cancel` events, but none were in `PUBLIC_EVENT_LABELS`, so the window, the front door's RECENT ACTIVITY block, the asleep calculation, and the totals all silently dropped every market act. They are now first-class public events, and a new emitter-scan test fails the moment any `INSERT INTO events` kind is missing from the public vocabulary.
2. **Filtering dropped relevant events.** Happenings were only ever fetched city-wide (newest 10) and filtered client-side, so a busy city pushed a watched place or followed resident out of view. `GET /api/events` now accepts `actor=` and `place_id=`; the place filter matches every detail shape the city writes — the place named directly, a thing or note there now, a sale/gift's `asset_type`+`asset_id`, an effect transfer's `type`+`id`, or an offer-only event resolved through `transfer_offers`. Withdrawn things are "nowhere", matching every other public surface. The client fetches the real filtered slice by itself, pages onward with the same filters, and silently refetches the newest filtered page on each snapshot refresh so an open view keeps learning.
3. **Refresh discarded reading state.** Expanded bodies now live in state under stable keys, every rebuilt control carries a `data-focus-key`, and focus is restored onto the visible replacement (history-load buttons stay focusable via `aria-busy` instead of `disabled`; sleeper/branch toggles render through the same restoration path).
4. **Navigation bypassed browser history.** Tabs, place/resident choices, and filter changes push real history entries; background refresh never touches history; arrow-key tab roving replaces instead of pushing so it cannot flood the back button.

### Truth surfaces in the same release

`src/frontdoor.txt`, `src/llms.txt` (with exact place-filter semantics), regenerated `src/door.ts`, the `docs/published/FRONTDOOR.md` fence, and the `docs/SYSTEM_DESIGN.md` API table row.

### Review

Independently adversarially reviewed (six lenses, verify-to-refute): thirteen confirmed findings, all fixed in the second commit — including the in-city sale place-filter gap, the falsely-quiet auto-load render, two focus-restoration breaks, the roving-tab history flood, and the post-initialization staleness of filtered views.

Deliberately **not** done: no new index (27k events measured — item 18 re-measures after the observability work), no `/api/events` caching (left unchanged by explicit wave-3 decision), no place-panel notes/things auto-load (item 8 covers the resident view).

## Test plan

- [x] 597/597 unit tests (new: emitter scan, exhaustive kind enumeration, filter validation with zero-SQL guards, front-door world-label pins, client-mechanics pins)
- [x] Full `test:postgres` suite 75/75; pagination file extended with every place-evidence shape, actor filter, malformed-detail safety, withdrawn exclusion, and the world_sale snapshot path
- [x] 19/19 Playwright e2e (place-filtered auto-load flow, restored unfiltered paging coverage, persisted expansion across views)
- [ ] `deploy.sh --prepare` gate on this pushed branch
- [ ] Vercel preview verified before merge