### PR TITLE
feat: a followed resident never looks falsely silent (audit item 8)

### DIFF
--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -257,7 +257,10 @@ a matching specific limit overrides it. `/api/me` independently uses
 `before_kind_id`/`kind_limit`, `before_agreement_id`/`agreement_limit`,
 `before_note_id`/`note_limit`, and `before_offer_id`/`offer_limit`. The window
 initially loads the full map and resident presence plus recent activity; its
-Load older controls page backward without changing what is public.
+Load older controls page backward without changing what is public. Watching one
+place or following one resident fetches that view's real server-side slice by
+itself; following a resident also brings bounded same-place context notes so
+what others said back stays visible — a contextual view, not reply threads.
 
 Creating an agreement, opening accession for the first time, and signing each use one of
 the same 5 daily agreement actions. Opening returns 201 the first time and 200 without

--- a/e2e/oauth-test-server.ts
+++ b/e2e/oauth-test-server.ts
@@ -165,6 +165,31 @@ const publicWindowFixture = Object.freeze({
   refreshed_at: '2026-08-13T19:04:00.000Z',
 })
 
+// The followed-resident context slice: oldwalker's own notes in the side
+// room plus what a neighbor said back, newest first.
+const followedResidentContextNotes = Object.freeze([{
+  id: 302,
+  place_id: 12,
+  author: 'oldwalker',
+  body: 'Middle in side room',
+  created_at: '2026-08-13T19:04:00.000Z',
+  moderated: false,
+}, {
+  id: 300,
+  place_id: 12,
+  author: 'oldwalker',
+  body: 'An earlier thought in the side room.',
+  created_at: '2026-08-13T18:58:00.000Z',
+  moderated: false,
+}, {
+  id: 299,
+  place_id: 12,
+  author: 'browser-resident',
+  body: 'A neighbor answers in the side room.',
+  created_at: '2026-08-13T18:57:00.000Z',
+  moderated: false,
+}])
+
 const olderPublicEvents = Object.freeze([{
   id: 501,
   at: '2026-08-13T19:01:00.000Z',
@@ -657,7 +682,19 @@ setOAuthResidentResolver(token => residentByOAuthAccessToken(token, environment,
 app.get('/window', windowPage)
 app.get('/window.css', windowStyle)
 app.get('/window.js', windowScript)
-app.get('/api/window', c => c.json(publicWindowFixture))
+app.get('/api/window', c => {
+  const url = new URL(c.req.url)
+  const collection = url.searchParams.get('collection')
+  if (!collection) return c.json(publicWindowFixture)
+  if (collection === 'notes' && url.searchParams.get('context') === 'place' &&
+      url.searchParams.get('resident') === 'oldwalker' &&
+      url.searchParams.get('limit') === '25') {
+    return c.json({
+      notes: followedResidentContextNotes, has_more: false, next_before_id: null,
+    })
+  }
+  return c.json({ error: 'unexpected deterministic window request' }, 400)
+})
 app.get('/api/thing/:id', c => {
   if (c.req.param('id') !== '401') return c.json({ error: 'thing not found' }, 404)
   const path = new URL(c.req.url).pathname

--- a/e2e/public-window-interactions.spec.ts
+++ b/e2e/public-window-interactions.spec.ts
@@ -229,8 +229,10 @@ test('long notes, things, and agreements can be expanded and collapsed', async (
 
   await page.getByRole('tab', { name: 'Conversations' }).click()
   // The same note was expanded on the place panel; its reading state
-  // survives the re-render into this view.
+  // survives the re-render into this view. The watched place's real slice
+  // loads by itself now, so scope to the long note among its neighbors.
   const conversationNote = page.locator('#conversation-stream .note-card')
+    .filter({ hasText: 'Opening note.' })
   await expect(conversationNote.locator('.note-body')).toHaveAttribute('data-expanded', 'true')
   await conversationNote.getByRole('button', { name: 'Show less' }).click()
   await expect(conversationNote.locator('.note-body')).toHaveAttribute('data-expanded', 'false')

--- a/e2e/public-window.spec.ts
+++ b/e2e/public-window.spec.ts
@@ -115,6 +115,32 @@ test('all-place conversations stay newest-first and name each room', async ({ pa
   await expect(cards.nth(1).locator('.note-meta')).toContainText('side_room')
 })
 
+test('a followed resident shows their notes with what others said back', async ({ page }) => {
+  const contextResponse = page.waitForResponse(response => {
+    const url = new URL(response.url())
+    return url.pathname === '/api/window' && url.searchParams.get('collection') === 'notes' &&
+      url.searchParams.get('resident') === 'oldwalker' &&
+      url.searchParams.get('context') === 'place' && response.status() === 200
+  })
+  await page.goto('/window#view=conversations&resident=oldwalker')
+  await expect(page.getByRole('status')).toContainText('Watching')
+  await contextResponse
+
+  const cards = page.locator('#conversation-stream .note-card')
+  await expect(cards).toHaveCount(3)
+  expect(await cards.locator('.note-body').allTextContents()).toEqual([
+    'Middle in side room',
+    'An earlier thought in the side room.',
+    'A neighbor answers in the side room.',
+  ])
+  const contextCard = page.locator('#conversation-stream .note-card.context-note')
+  await expect(contextCard).toHaveCount(1)
+  await expect(contextCard).toContainText('A neighbor answers in the side room.')
+  await expect(contextCard).toContainText('same room, said around then')
+  await expect(contextCard.locator('.note-meta')).toContainText('side_room')
+  await expect(page.getByRole('button', { name: /Load .*conversations/ })).toBeHidden()
+})
+
 test('agreements show author consent and distinguish later signers', async ({ page }) => {
   await page.goto('/window#view=agreements')
   await expect(page.getByRole('status')).toContainText('Watching')

--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -337,7 +337,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
   function historyKey(collection, filters) {
     const place = collection === 'agreements' ? '' : String(filters.placeId || '')
     if (!place && !filters.resident) return 'all'
-    return 'place:' + place + '|resident:' + String(filters.resident || '')
+    return (filters.context ? 'context|' : '') +
+      'place:' + place + '|resident:' + String(filters.resident || '')
   }
 
   function filterHistoryRows(collection, rows, filters, snapshot) {
@@ -394,7 +395,11 @@ ${WINDOW_CLIENT_SAFETY_JS}
           ...state.histories[collection],
           [key]: Object.freeze({
             ...entry,
-            filters: Object.freeze({ placeId: filters.placeId, resident: filters.resident }),
+            filters: Object.freeze({
+              placeId: filters.placeId,
+              resident: filters.resident,
+              context: filters.context === true,
+            }),
           }),
         },
       },
@@ -823,16 +828,27 @@ ${WINDOW_CLIENT_SAFETY_JS}
 
   function renderConversations(snapshot) {
     if (!nodes.conversations) return
-    const filters = Object.freeze({ placeId: state.placeId, resident: state.resident })
-    const notes = historyEntry('notes', filters).rows
+    // Following one resident fetches their bounded server-side slice plus
+    // same-place context, so an active resident never looks falsely silent
+    // just because the newest city-wide page missed them.
+    const filters = Object.freeze({
+      placeId: state.placeId,
+      resident: state.resident,
+      context: Boolean(state.resident),
+    })
+    autoLoadFilteredHistory('notes', filters, historyEntry('notes', filters))
+    const entry = historyEntry('notes', filters)
+    const notes = entry.rows
     const placeOf = placeId => snapshot.flatPlaces.find(candidate => candidate.id === placeId) || null
     const place = state.placeId ? placeOf(state.placeId) : null
     if (!notes.length || (state.placeId && !place)) {
-      renderEmpty(nodes.conversations, 'empty-row', 'No conversation in the latest public snapshot matches this view.')
+      renderEmpty(nodes.conversations, 'empty-row', entry.loading
+        ? 'Fetching this conversation…'
+        : 'No conversation in the latest public snapshot matches this view.')
       renderHistoryControl(nodes.conversationPage, 'notes', 'conversations', filters)
       return
     }
-    if (place) {
+    if (place && !state.resident) {
       const group = element('section', 'conversation-group')
       const heading = element('header', '')
       heading.append(
@@ -845,9 +861,18 @@ ${WINDOW_CLIENT_SAFETY_JS}
       nodes.conversations.replaceChildren(group)
     } else {
       // Every room at once. The server pages notes newest first, so retain that
-      // order and name each room without regrouping the stream by place.
+      // order and name each room without regrouping the stream by place. When
+      // following a resident, what others said in the same room stays visible
+      // as marked context — a contextual view, not a reply thread.
       const list = element('div', 'note-list')
-      list.append(...notes.map(note => noteCard(note, placeOf(note.place_id))))
+      list.append(...notes.map(note => {
+        const card = noteCard(note, placeOf(note.place_id))
+        if (state.resident && note.author !== state.resident) {
+          card.classList.add('context-note')
+          card.append(element('span', 'context-mark', 'same room, said around then'))
+        }
+        return card
+      }))
       nodes.conversations.replaceChildren(list)
     }
     renderHistoryControl(nodes.conversationPage, 'notes', 'conversations', filters)
@@ -992,7 +1017,9 @@ ${WINDOW_CLIENT_SAFETY_JS}
       collection === 'events' ? '/api/events' : '/api/window',
       window.location.origin,
     )
-    url.searchParams.set('limit', '50')
+    // Context pages carry up to four neighbors per own note, so they use a
+    // smaller page to stay well inside the client's 200-row safety cap.
+    url.searchParams.set('limit', filters.context ? '25' : '50')
     if (collection === 'events') {
       if (filters.placeId) url.searchParams.set('place_id', String(filters.placeId))
       if (filters.resident) url.searchParams.set('actor', filters.resident)
@@ -1000,6 +1027,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       url.searchParams.set('collection', collection)
       if (filters.placeId) url.searchParams.set('place_id', String(filters.placeId))
       if (filters.resident) url.searchParams.set('resident', filters.resident)
+      if (filters.context) url.searchParams.set('context', 'place')
     }
     if (entry.initialized && entry.nextBeforeId) {
       url.searchParams.set('before_id', String(entry.nextBeforeId))
@@ -1053,13 +1081,21 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }
   }
 
-  function refreshFilteredHappenings() {
-    if (state.view !== 'happenings') return
-    const filters = Object.freeze({ placeId: state.placeId, resident: state.resident })
-    if (!filters.placeId && !filters.resident) return
-    const entry = historyEntry('events', filters)
-    if (!entry.initialized || entry.loading) return
-    void forwardRefreshHistory('events', filters)
+  function refreshFilteredViews() {
+    if (state.view === 'happenings') {
+      const filters = Object.freeze({ placeId: state.placeId, resident: state.resident })
+      if (!filters.placeId && !filters.resident) return
+      const entry = historyEntry('events', filters)
+      if (!entry.initialized || entry.loading) return
+      void forwardRefreshHistory('events', filters)
+    } else if (state.view === 'conversations' && state.resident) {
+      const filters = Object.freeze({
+        placeId: state.placeId, resident: state.resident, context: true,
+      })
+      const entry = historyEntry('notes', filters)
+      if (!entry.initialized || entry.loading) return
+      void forwardRefreshHistory('notes', filters)
+    }
   }
 
   async function loadHistory(collection, filters) {
@@ -1245,7 +1281,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       state = { ...state, snapshot, histories, hasSnapshot: true, failures: 0 }
       populateFilters(snapshot)
       renderAll()
-      refreshFilteredHappenings()
+      refreshFilteredViews()
       setStatus(snapshot.refreshedAt ? 'Watching · checked ' + snapshot.refreshedAt.toLocaleTimeString([], {
         hour: 'numeric', minute: '2-digit',
       }) : 'Watching the public streets', 'live')

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -437,6 +437,14 @@ button { color: inherit; }
 .note-card::before { content: ""; position: absolute; inset: 0 auto 0 0; width: 0.35rem; background: var(--brick); }
 .note-body { margin: 0.45rem 0 0; line-height: 1.6; }
 .note-author { color: var(--forest-deep); font-weight: 900; }
+.context-note { opacity: 0.82; margin-inline-start: 1.1rem; }
+.context-note::before { width: 0.2rem; background: var(--line); }
+.context-mark {
+  display: inline-block; margin-top: 0.35rem; padding: 0.1rem 0.45rem;
+  border: 1px solid var(--line); border-radius: 999px;
+  color: var(--muted); font-size: 0.58rem; letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 
 .activity-list { padding: 0; margin: 0; list-style: none; }
 .activity-row {

--- a/src/window.ts
+++ b/src/window.ts
@@ -466,6 +466,14 @@ const WINDOW_HISTORY_COLLECTIONS = new Set(['notes', 'things', 'agreements'])
 // resident's notes when the caller asks for conversational context.
 export const NOTE_CONTEXT_NEIGHBORS = 2
 
+// A context page carries one lookahead own note plus up to 2*NEIGHBORS
+// neighbors per kept own note. Bound its page size so the whole page always
+// fits inside the public row cap; otherwise the shaper's slice would silently
+// drop own notes the cursor has already stepped past.
+export const NOTE_CONTEXT_PAGE_MAX = Math.floor(
+  (PUBLIC_PAGE_MAX - 1) / (1 + 2 * NOTE_CONTEXT_NEIGHBORS),
+)
+
 export interface WindowHistoryQuery {
   readonly collection: 'notes' | 'things' | 'agreements'
   readonly beforeId: number | null
@@ -516,13 +524,14 @@ export function parseWindowHistoryQuery(
   if (contextValue !== undefined &&
       (contextValue !== 'place' || collection !== 'notes' || resident === null)) return null
 
+  const context = contextValue === 'place'
   return Object.freeze({
     collection: collection as WindowHistoryQuery['collection'],
     beforeId: page.cursor,
-    limit: page.limit,
+    limit: context ? Math.min(page.limit, NOTE_CONTEXT_PAGE_MAX) : page.limit,
     placeId,
     resident,
-    context: contextValue === 'place',
+    context,
   })
 }
 
@@ -539,19 +548,31 @@ export function windowCollectionStatement(options: WindowHistoryQuery): WindowCo
     // what others said back is visible. Neighbors shared between adjacent own
     // notes collapse via DISTINCT ON, and the page cursor advances over the
     // resident's notes alone.
+    //
+    // Two invariants keep that cursor honest. Context excludes the followed
+    // resident, so an own note from an earlier page can never return disguised
+    // as context and be counted again — that would freeze the cursor and hide
+    // the note underneath it. And context anchors only to page_notes, the rows
+    // this page actually keeps, so the trimmed lookahead note never leaves its
+    // neighbors behind without their anchor. Context rows may still repeat
+    // across pages when neighbors sit between two own notes; ids are stable,
+    // so readers merge them by id.
     return Object.freeze({
       text: `WITH resident_notes AS (
-          SELECT note.id, note.place_id, author.handle AS author, note.body, note.created_at
+          SELECT note.id, note.place_id, author.handle AS author, note.body, note.created_at,
+            row_number() OVER (ORDER BY note.id DESC) AS own_position
           FROM notes note JOIN residents author ON author.id = note.author_id
           WHERE ($1::integer IS NULL OR note.id < $1::integer)
             AND ($2::integer IS NULL OR note.place_id = $2::integer)
             AND author.handle = $3::text
           ORDER BY note.id DESC
           LIMIT $4::integer
+        ), page_notes AS (
+          SELECT * FROM resident_notes WHERE own_position <= $5::integer
         ), context_notes AS (
           SELECT DISTINCT ON (ctx.id)
             ctx.id, ctx.place_id, ctx_author.handle AS author, ctx.body, ctx.created_at
-          FROM resident_notes own
+          FROM page_notes own
           CROSS JOIN LATERAL (
             (SELECT neighbor.id, neighbor.place_id, neighbor.author_id,
                neighbor.body, neighbor.created_at
@@ -568,13 +589,15 @@ export function windowCollectionStatement(options: WindowHistoryQuery): WindowCo
              LIMIT ${NOTE_CONTEXT_NEIGHBORS})
           ) ctx
           JOIN residents ctx_author ON ctx_author.id = ctx.author_id
-          WHERE ctx.id NOT IN (SELECT own_note.id FROM resident_notes own_note)
+          WHERE ctx_author.handle <> $3::text
         )
         SELECT id, place_id, author, body, created_at FROM resident_notes
         UNION ALL
         SELECT id, place_id, author, body, created_at FROM context_notes
         ORDER BY id DESC`,
-      values: Object.freeze([options.beforeId, options.placeId, options.resident, fetchLimit]),
+      values: Object.freeze([
+        options.beforeId, options.placeId, options.resident, fetchLimit, options.limit,
+      ]),
     })
   }
   if (options.collection === 'notes') {
@@ -686,7 +709,9 @@ export async function readWindowCollectionPage(
   const rows = await loadWindowCollectionRows(options, query)
   if (options.collection === 'notes' && options.context && options.resident) {
     // The cursor pages over the followed resident's own notes; context rows
-    // ride along and never affect has_more or the next cursor.
+    // ride along and never affect has_more or the next cursor. The statement
+    // guarantees no context row is authored by the followed resident, so
+    // classifying by author here cannot miscount an own note.
     const typed = rows as readonly (Record<string, unknown> & { id: number })[]
     const ownRows = typed.filter(row => row.author === options.resident)
     const ownPage = finalizePublicPage(ownRows, options.limit)

--- a/src/window.ts
+++ b/src/window.ts
@@ -458,9 +458,13 @@ export function mergeWindowThingTraits(
 }
 
 const WINDOW_HISTORY_KEYS = new Set([
-  'collection', 'before_id', 'limit', 'place_id', 'resident',
+  'collection', 'before_id', 'limit', 'place_id', 'resident', 'context',
 ])
 const WINDOW_HISTORY_COLLECTIONS = new Set(['notes', 'things', 'agreements'])
+
+// How many same-place neighbors ride along with each of a followed
+// resident's notes when the caller asks for conversational context.
+export const NOTE_CONTEXT_NEIGHBORS = 2
 
 export interface WindowHistoryQuery {
   readonly collection: 'notes' | 'things' | 'agreements'
@@ -468,6 +472,7 @@ export interface WindowHistoryQuery {
   readonly limit: number
   readonly placeId: number | null
   readonly resident: string | null
+  readonly context: boolean
 }
 
 function oneWindowQueryValue(
@@ -504,12 +509,20 @@ export function parseWindowHistoryQuery(
   if (residentValue !== undefined && resident === null) return null
   if (collection === 'agreements' && placeId !== null) return null
 
+  // context=place asks for the same-place notes around a followed
+  // resident's own notes. It has exactly one value and only makes sense
+  // for notes with a resident to follow.
+  const contextValue = oneWindowQueryValue(queries, 'context')
+  if (contextValue !== undefined &&
+      (contextValue !== 'place' || collection !== 'notes' || resident === null)) return null
+
   return Object.freeze({
     collection: collection as WindowHistoryQuery['collection'],
     beforeId: page.cursor,
     limit: page.limit,
     placeId,
     resident,
+    context: contextValue === 'place',
   })
 }
 
@@ -520,6 +533,50 @@ export interface WindowCollectionStatement {
 
 export function windowCollectionStatement(options: WindowHistoryQuery): WindowCollectionStatement {
   const fetchLimit = options.limit + 1
+  if (options.collection === 'notes' && options.context) {
+    // The followed resident's own notes drive the page; each own note brings
+    // along up to NOTE_CONTEXT_NEIGHBORS same-place notes on either side so
+    // what others said back is visible. Neighbors shared between adjacent own
+    // notes collapse via DISTINCT ON, and the page cursor advances over the
+    // resident's notes alone.
+    return Object.freeze({
+      text: `WITH resident_notes AS (
+          SELECT note.id, note.place_id, author.handle AS author, note.body, note.created_at
+          FROM notes note JOIN residents author ON author.id = note.author_id
+          WHERE ($1::integer IS NULL OR note.id < $1::integer)
+            AND ($2::integer IS NULL OR note.place_id = $2::integer)
+            AND author.handle = $3::text
+          ORDER BY note.id DESC
+          LIMIT $4::integer
+        ), context_notes AS (
+          SELECT DISTINCT ON (ctx.id)
+            ctx.id, ctx.place_id, ctx_author.handle AS author, ctx.body, ctx.created_at
+          FROM resident_notes own
+          CROSS JOIN LATERAL (
+            (SELECT neighbor.id, neighbor.place_id, neighbor.author_id,
+               neighbor.body, neighbor.created_at
+             FROM notes neighbor
+             WHERE neighbor.place_id = own.place_id AND neighbor.id < own.id
+             ORDER BY neighbor.id DESC
+             LIMIT ${NOTE_CONTEXT_NEIGHBORS})
+            UNION ALL
+            (SELECT neighbor.id, neighbor.place_id, neighbor.author_id,
+               neighbor.body, neighbor.created_at
+             FROM notes neighbor
+             WHERE neighbor.place_id = own.place_id AND neighbor.id > own.id
+             ORDER BY neighbor.id ASC
+             LIMIT ${NOTE_CONTEXT_NEIGHBORS})
+          ) ctx
+          JOIN residents ctx_author ON ctx_author.id = ctx.author_id
+          WHERE ctx.id NOT IN (SELECT own_note.id FROM resident_notes own_note)
+        )
+        SELECT id, place_id, author, body, created_at FROM resident_notes
+        UNION ALL
+        SELECT id, place_id, author, body, created_at FROM context_notes
+        ORDER BY id DESC`,
+      values: Object.freeze([options.beforeId, options.placeId, options.resident, fetchLimit]),
+    })
+  }
   if (options.collection === 'notes') {
     return Object.freeze({
       text: `SELECT note.id, note.place_id, author.handle AS author, note.body, note.created_at
@@ -627,6 +684,22 @@ export async function readWindowCollectionPage(
   query: PublicQueryExecutor = executePublicQuery,
 ): Promise<WindowCollectionPage> {
   const rows = await loadWindowCollectionRows(options, query)
+  if (options.collection === 'notes' && options.context && options.resident) {
+    // The cursor pages over the followed resident's own notes; context rows
+    // ride along and never affect has_more or the next cursor.
+    const typed = rows as readonly (Record<string, unknown> & { id: number })[]
+    const ownRows = typed.filter(row => row.author === options.resident)
+    const ownPage = finalizePublicPage(ownRows, options.limit)
+    const keptOwn = new Set(ownPage.items.map(row => row.id))
+    const pageRows = typed.filter(row =>
+      row.author !== options.resident || keptOwn.has(row.id))
+    const moderated = await moderatePublicRows('note', [...pageRows])
+    return Object.freeze({
+      items: Object.freeze(publicWindowNotes([...moderated])),
+      hasMore: ownPage.hasMore,
+      nextBeforeId: ownPage.nextCursor,
+    })
+  }
   const rawPage = finalizePublicPage(
     rows as readonly (Record<string, unknown> & { id: number })[],
     options.limit,
@@ -698,6 +771,7 @@ const defaultWindowHistoryQuery = (
   limit: PUBLIC_PAGE_DEFAULT,
   placeId: null,
   resident: null,
+  context: false,
 })
 
 async function readWindowSnapshot() {

--- a/test/integration/public-pagination-postgres.test.ts
+++ b/test/integration/public-pagination-postgres.test.ts
@@ -671,6 +671,94 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
         Date.now = realDateNow
       }
     })
+
+    await t.test('a followed resident view carries same-place context', async () => {
+      const client = postgres.client
+      const room = (await client.query<{ id: number }>(
+        `INSERT INTO places (parent_id, place_kind, name, owner_id)
+         SELECT id, 'place', 'Context Room', 1
+         FROM places WHERE name = 'Pagination Continent'
+         RETURNING id`,
+      )).rows[0]!.id
+      const quietRoom = (await client.query<{ id: number }>(
+        `INSERT INTO places (parent_id, place_kind, name, owner_id)
+         SELECT id, 'place', 'Quiet Room', 1
+         FROM places WHERE name = 'Pagination Continent'
+         RETURNING id`,
+      )).rows[0]!.id
+      const say = async (placeId: number, residentId: number, body: string) => (
+        await client.query<{ id: number }>(
+          `INSERT INTO notes (place_id, author_id, body) VALUES ($1, $2, $3) RETURNING id`,
+          [placeId, residentId, body],
+        )
+      ).rows[0]!.id
+      // resident-5 speaks twice in the room and once in a second room; others
+      // answer around them; an unrelated room stays out of the slice.
+      const before = await say(room, 6, 'the question before')
+      const own1 = await say(room, 5, 'first own note')
+      const reply1 = await say(room, 7, 'an answer right after')
+      const drift = await say(room, 7, 'the room drifts on')
+      const own2 = await say(room, 5, 'second own note')
+      const reply2 = await say(room, 6, 'a late answer')
+      const unrelated = await say(quietRoom, 6, 'somewhere else entirely')
+      const own3 = await say(quietRoom, 5, 'own note in the quiet room')
+
+      const windowModule: WindowModule = await import('../../src/window.ts')
+      const contextQuery = (limit: number, beforeId: number | null) => Object.freeze({
+        collection: 'notes' as const,
+        beforeId,
+        limit,
+        placeId: null,
+        resident: 'resident-5',
+        context: true,
+      })
+      const firstPage = await windowModule.readWindowCollectionPage(contextQuery(10, null))
+      const firstIds = firstPage.items.map(item => item.id)
+      // Own notes and their neighbors, newest first; the unrelated quiet-room
+      // note only appears because resident-5 later spoke there (it is a
+      // same-place neighbor of own3), which is exactly the intended context.
+      assert.deepEqual(
+        firstIds,
+        [own3, unrelated, reply2, own2, drift, reply1, own1, before],
+      )
+      assert.equal(firstPage.hasMore, false)
+      const authors = new Map(firstPage.items.map(item => [
+        item.id, (item as { author: string }).author,
+      ]))
+      assert.equal(authors.get(own1), 'resident-5')
+      assert.equal(authors.get(reply1), 'resident-7')
+
+      // The cursor pages over the resident's own notes alone: limit 1 shows
+      // the newest own note with its context and points at it for the next
+      // older page.
+      const paged = await windowModule.readWindowCollectionPage(contextQuery(1, null))
+      assert.equal(paged.hasMore, true)
+      assert.equal(paged.nextBeforeId, own3)
+      assert.ok(paged.items.some(item => item.id === own3))
+      assert.ok(!paged.items.some(item => item.id === own1))
+      const olderPage = await windowModule.readWindowCollectionPage(contextQuery(1, paged.nextBeforeId))
+      assert.ok(olderPage.items.some(item => item.id === own2))
+      assert.equal(olderPage.nextBeforeId, own2)
+
+      // The route rejects context without a resident before touching SQL.
+      const app = new Hono()
+      app.get('/api/window', windowModule.windowSnapshot)
+      const statementsBefore = statementCount
+      const invalid = await app.request(
+        'http://city.test/api/window?collection=notes&context=place',
+      )
+      assert.equal(invalid.status, 400)
+      assert.equal(statementCount, statementsBefore)
+      const valid = await app.request(
+        'http://city.test/api/window?collection=notes&resident=resident-5&context=place&limit=25',
+      )
+      assert.equal(valid.status, 200)
+      const payload = await valid.json() as { notes: Array<{ id: number }>; has_more: boolean }
+      assert.deepEqual(
+        payload.notes.map(note => note.id),
+        [own3, unrelated, reply2, own2, drift, reply1, own1, before],
+      )
+    })
   } finally {
     database = null
     await postgres.client.end().catch(() => undefined)

--- a/test/integration/public-pagination-postgres.test.ts
+++ b/test/integration/public-pagination-postgres.test.ts
@@ -740,6 +740,34 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
       assert.ok(olderPage.items.some(item => item.id === own2))
       assert.equal(olderPage.nextBeforeId, own2)
 
+      // Context never carries the followed resident, and no page shows a
+      // context note whose own note was trimmed to the next page.
+      const anchored = await windowModule.readWindowCollectionPage(Object.freeze({
+        collection: 'notes' as const,
+        beforeId: null,
+        limit: 1,
+        placeId: room,
+        resident: 'resident-5',
+        context: true,
+      }))
+      // own2 is the only kept own note: it brings its two neighbors below
+      // (drift, reply1) and one above (reply2). `before` belongs to own1,
+      // which was trimmed to the next page, so it must not appear.
+      assert.deepEqual(
+        anchored.items.map(item => item.id),
+        [reply2, own2, drift, reply1],
+        'only the kept own note anchors context',
+      )
+      assert.ok(!anchored.items.some(item => item.id === before))
+      assert.ok(!anchored.items.some(item => (item as { author: string }).author === 'resident-5'
+        && item.id !== own2))
+
+      // The route bounds a context page so the whole page fits the row cap.
+      const bounded = windowModule.parseWindowHistoryQuery({
+        collection: ['notes'], resident: ['resident-5'], context: ['place'], limit: ['200'],
+      })
+      assert.equal(bounded?.limit, windowModule.NOTE_CONTEXT_PAGE_MAX)
+
       // The route rejects context without a resident before touching SQL.
       const app = new Hono()
       app.get('/api/window', windowModule.windowSnapshot)
@@ -758,6 +786,38 @@ test('public listing pages use bounded keyset reads against PostgreSQL', async t
         payload.notes.map(note => note.id),
         [own3, unrelated, reply2, own2, drift, reply1, own1, before],
       )
+
+      // Regression: consecutive own notes straddling a page boundary. The
+      // resident's own note from the previous page must never return as a
+      // context row — counting it again froze the cursor and buried the note
+      // underneath it, the exact "falsely silent" failure this view fixes.
+      const monologue = (await client.query<{ id: number }>(
+        `INSERT INTO places (parent_id, place_kind, name, owner_id)
+         SELECT id, 'place', 'Monologue Room', 1
+         FROM places WHERE name = 'Pagination Continent'
+         RETURNING id`,
+      )).rows[0]!.id
+      const solo1 = await say(monologue, 5, 'first of three in a row')
+      const solo2 = await say(monologue, 5, 'second of three in a row')
+      const solo3 = await say(monologue, 5, 'third of three in a row')
+      const soloQuery = (beforeId: number | null) => Object.freeze({
+        collection: 'notes' as const,
+        beforeId,
+        limit: 1,
+        placeId: monologue,
+        resident: 'resident-5',
+        context: true,
+      })
+      const soloFirst = await windowModule.readWindowCollectionPage(soloQuery(null))
+      assert.deepEqual(soloFirst.items.map(item => item.id), [solo3])
+      assert.equal(soloFirst.nextBeforeId, solo3)
+      const soloSecond = await windowModule.readWindowCollectionPage(soloQuery(soloFirst.nextBeforeId))
+      assert.deepEqual(soloSecond.items.map(item => item.id), [solo2])
+      assert.equal(soloSecond.nextBeforeId, solo2, 'the cursor must advance past every own note')
+      const soloThird = await windowModule.readWindowCollectionPage(soloQuery(soloSecond.nextBeforeId))
+      assert.deepEqual(soloThird.items.map(item => item.id), [solo1])
+      assert.equal(soloThird.hasMore, false)
+      assert.equal(soloThird.nextBeforeId, null)
     })
   } finally {
     database = null

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -197,6 +197,20 @@ test('window history queries accept only one safe value for each supported filte
     collection: 'notes', beforeId: null, limit: 10, placeId: 7, resident: 'tiny-lantern',
     context: true,
   })
+  // A context page carries neighbors as well as own notes, so its page size
+  // is bounded to keep the whole page inside the public row cap.
+  assert.deepEqual(parse({
+    collection: ['notes'], resident: ['tiny-lantern'], context: ['place'], limit: ['200'],
+  }), {
+    collection: 'notes', beforeId: null, limit: 39, placeId: null, resident: 'tiny-lantern',
+    context: true,
+  })
+  assert.deepEqual(parse({
+    collection: ['notes'], limit: ['200'],
+  }), {
+    collection: 'notes', beforeId: null, limit: 200, placeId: null, resident: null,
+    context: false,
+  })
 
   for (const unsafe of [
     { collection: ['events'] },
@@ -267,9 +281,16 @@ test('window collection statements enforce limit plus one without client SQL ide
   assert.match(context.text, /neighbor\.id < own\.id/i)
   assert.match(context.text, /neighbor\.id > own\.id/i)
   assert.match(context.text, /LIMIT 2\)/)
-  assert.match(context.text, /NOT IN \(SELECT own_note\.id FROM resident_notes own_note\)/i)
   assert.match(context.text, /UNION ALL/i)
-  assert.deepEqual(context.values, [91, null, 'tiny-lantern', 26])
+  // Two cursor-safety invariants: context never contains the followed
+  // resident (an own note returning as context would freeze the cursor and
+  // bury the note under it), and context anchors only to the rows this page
+  // keeps, never to the trimmed lookahead note.
+  assert.match(context.text, /ctx_author\.handle <> \$3::text/i)
+  assert.match(context.text, /row_number\(\) OVER \(ORDER BY note\.id DESC\) AS own_position/i)
+  assert.match(context.text, /page_notes AS \(\s*SELECT \* FROM resident_notes WHERE own_position <= \$5::integer/i)
+  assert.match(context.text, /FROM page_notes own/i)
+  assert.deepEqual(context.values, [91, null, 'tiny-lantern', 26, 25])
 })
 
 test('window histories merge immutably, dedupe by id, and stay newest first', () => {

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -76,7 +76,7 @@ test('filtered happenings fetch their real slice from the server', () => {
   // An initialized filtered view keeps learning: each snapshot refresh
   // silently refetches the newest filtered page and merges it.
   assert.match(WINDOW_JS, /function forwardRefreshHistory\(collection, filters\)/)
-  assert.match(WINDOW_JS, /refreshFilteredHappenings\(\)/)
+  assert.match(WINDOW_JS, /refreshFilteredViews\(\)/)
   // The interim load control stays focusable; disabled buttons cannot
   // receive restored focus. Arrow-key tab roving must not flood history.
   assert.match(WINDOW_JS, /aria-busy/)
@@ -172,15 +172,30 @@ test('window history queries accept only one safe value for each supported filte
 
   assert.deepEqual(parse({ collection: ['notes'] }), {
     collection: 'notes', beforeId: null, limit: 10, placeId: null, resident: null,
+    context: false,
   })
   assert.deepEqual(parse({
     collection: ['things'], before_id: ['91'], limit: ['12'],
     place_id: ['7'], resident: ['tiny-lantern'],
   }), {
     collection: 'things', beforeId: 91, limit: 12, placeId: 7, resident: 'tiny-lantern',
+    context: false,
   })
   assert.deepEqual(parse({ collection: ['agreements'], resident: ['tiny-lantern'] }), {
     collection: 'agreements', beforeId: null, limit: 10, placeId: null, resident: 'tiny-lantern',
+    context: false,
+  })
+  assert.deepEqual(parse({
+    collection: ['notes'], resident: ['tiny-lantern'], context: ['place'],
+  }), {
+    collection: 'notes', beforeId: null, limit: 10, placeId: null, resident: 'tiny-lantern',
+    context: true,
+  })
+  assert.deepEqual(parse({
+    collection: ['notes'], resident: ['tiny-lantern'], context: ['place'], place_id: ['7'],
+  }), {
+    collection: 'notes', beforeId: null, limit: 10, placeId: 7, resident: 'tiny-lantern',
+    context: true,
   })
 
   for (const unsafe of [
@@ -194,6 +209,11 @@ test('window history queries accept only one safe value for each supported filte
     { collection: ['notes'], resident: ['not safe!'] },
     { collection: ['agreements'], place_id: ['7'] },
     { collection: ['notes'], nonce: ['cache-bust'] },
+    { collection: ['notes'], context: ['place'] },
+    { collection: ['notes'], resident: ['tiny-lantern'], context: ['thread'] },
+    { collection: ['notes'], resident: ['tiny-lantern'], context: ['place', 'place'] },
+    { collection: ['things'], resident: ['tiny-lantern'], context: ['place'] },
+    { collection: ['agreements'], resident: ['tiny-lantern'], context: ['place'] },
   ]) assert.equal(parse(unsafe), null)
 })
 
@@ -233,6 +253,23 @@ test('window collection statements enforce limit plus one without client SQL ide
   assert.match(agreements.text, /AS acceded/i)
   assert.match(agreements.text, /LIMIT 32/i)
   assert.deepEqual(agreements.values, [61, 'tiny-lantern', 51])
+
+  // The context variant drives the page from the resident's own notes and
+  // carries bounded same-place neighbors on each side.
+  const context = statement({
+    collection: 'notes', beforeId: 91, limit: 25, placeId: null,
+    resident: 'tiny-lantern', context: true,
+  })
+  assert.match(context.text, /WITH resident_notes AS/i)
+  assert.match(context.text, /author\.handle = \$3::text/i)
+  assert.match(context.text, /CROSS JOIN LATERAL/i)
+  assert.match(context.text, /DISTINCT ON \(ctx\.id\)/i)
+  assert.match(context.text, /neighbor\.id < own\.id/i)
+  assert.match(context.text, /neighbor\.id > own\.id/i)
+  assert.match(context.text, /LIMIT 2\)/)
+  assert.match(context.text, /NOT IN \(SELECT own_note\.id FROM resident_notes own_note\)/i)
+  assert.match(context.text, /UNION ALL/i)
+  assert.deepEqual(context.values, [91, null, 'tiny-lantern', 26])
 })
 
 test('window histories merge immutably, dedupe by id, and stay newest first', () => {
@@ -278,9 +315,22 @@ test('every paged window view has an accessible older-history surface', () => {
 })
 
 test('all-place conversations preserve the server newest-first order', () => {
-  assert.match(WINDOW_JS, /const notes = historyEntry\('notes', filters\)\.rows/)
-  assert.match(WINDOW_JS, /notes\.map\(note => noteCard\(note, placeOf\(note\.place_id\)\)\)/)
+  assert.match(WINDOW_JS, /const notes = entry\.rows/)
+  assert.match(WINDOW_JS, /noteCard\(note, placeOf\(note\.place_id\)\)/)
   assert.doesNotMatch(WINDOW_JS, /const placeIds = \[\.\.\.new Set\(notes\.map/)
+})
+
+test('a followed resident never looks falsely silent', () => {
+  // The conversations view fetches the resident's own server-side slice with
+  // same-place context, pages it, refreshes it, and marks context notes.
+  assert.match(WINDOW_JS, /context: Boolean\(state\.resident\)/)
+  assert.match(WINDOW_JS, /autoLoadFilteredHistory\('notes', filters, historyEntry\('notes', filters\)\)/)
+  assert.match(WINDOW_JS, /url\.searchParams\.set\('context', 'place'\)/)
+  assert.match(WINDOW_JS, /filters\.context \? '25' : '50'/)
+  assert.match(WINDOW_JS, /context-note/)
+  assert.match(WINDOW_JS, /same room, said around then/)
+  assert.match(WINDOW_CSS, /\.context-note/)
+  assert.match(WINDOW_CSS, /\.context-mark/)
 })
 
 test('snapshot row shapers reject malformed public data', () => {


### PR DESCRIPTION
## What this delivers (audit item 8 — wave 4)

**Outcome:** the resident view fetches a bounded resident-specific slice with enough same-place public context to show what others said back. It stays a simple contextual view and does not introduce true reply threads.

### The failure

Following one resident filtered the newest ten city-wide notes client-side. An active resident could therefore look completely silent, and nobody's answers were ever visible.

### The fix

`GET /api/window?collection=notes&resident=<handle>&context=place` returns the resident's own notes, cursor-paged over those notes alone, with up to two same-place neighbours on either side of each so replies ride along. The conversations view fetches that slice itself, pages it, silently refreshes its newest page on each snapshot, and renders other residents' notes as visibly marked context. A place-filtered conversations view (no resident) now also fetches its real place slice instead of showing only what survived the newest city-wide page.

### Review found a HIGH defect — fixed in the second commit

Reproduced against real PostgreSQL: a followed resident's own note from an earlier page could come back as a "context" row, be counted as an own row again, and **freeze the cursor** — `next_before_id` equalled the requested `before_id`, and the real own note underneath became unreachable. Two adjacent own notes across a page boundary triggered it: the exact falsely-silent failure this view exists to fix.

- Context now excludes the followed resident outright (also matching the UI, which only marks other-author notes).
- Context anchors only to `page_notes` — the rows the page keeps — so the trimmed lookahead note never leaves orphaned neighbours behind.
- A context page is bounded to `NOTE_CONTEXT_PAGE_MAX` (derived from the public row cap) so a `limit=200` caller cannot overflow the shaper and silently lose own notes the cursor already passed.

The integration test reproduces the frozen cursor with three consecutive own notes at `limit=1`; it **fails against the old statement** and passes against this one.

## Test plan

- [x] 598/598 unit tests (parse cases incl. the context clamp, statement pins for both cursor-safety invariants)
- [x] `public-pagination` PostgreSQL integration: exact slice ordering, own-note cursor advancing across three pages, orphan-context exclusion, route rejection without a resident, page-size bound
- [x] Regression guard verified to fail against the pre-fix SQL
- [x] 20/20 Playwright e2e including a followed-resident flow
- [x] `deploy.sh --prepare` gate on the pushed branch (GATE_EXIT=0)
- [ ] Vercel preview verified before merge