### PR TITLE
fix: repair payment recovery expiry

### DIFF
--- a/db/migrations/20260823_payment_recovery_trigger_repair.sql
+++ b/db/migrations/20260823_payment_recovery_trigger_repair.sql
@@ -1,0 +1,130 @@
+-- Restore the unified payment history guard if an independently rerun older
+-- migration replaced it. This is identical to the final recovery guard.
+CREATE OR REPLACE FUNCTION protect_payment_attempt_history() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'payment attempt history cannot be deleted' USING ERRCODE = '55000';
+  END IF;
+
+  IF ROW(
+    NEW.public_id, NEW.actor_id, NEW.counterparty_id, NEW.operation,
+    NEW.target_key, NEW.offer_id, NEW.asset_type, NEW.asset_id,
+    NEW.request_hash, NEW.request_json, NEW.method, NEW.network, NEW.token,
+    NEW.payer_wallet, NEW.payee_wallet, NEW.amount_units, NEW.x402_nonce,
+    NEW.x402_payload_digest, NEW.x402_valid_after, NEW.x402_valid_before,
+    NEW.start_block, NEW.start_time, NEW.end_time, NEW.created_at
+  ) IS DISTINCT FROM ROW(
+    OLD.public_id, OLD.actor_id, OLD.counterparty_id, OLD.operation,
+    OLD.target_key, OLD.offer_id, OLD.asset_type, OLD.asset_id,
+    OLD.request_hash, OLD.request_json, OLD.method, OLD.network, OLD.token,
+    OLD.payer_wallet, OLD.payee_wallet, OLD.amount_units, OLD.x402_nonce,
+    OLD.x402_payload_digest, OLD.x402_valid_after, OLD.x402_valid_before,
+    OLD.start_block, OLD.start_time, OLD.end_time, OLD.created_at
+  ) THEN
+    RAISE EXCEPTION 'payment attempt terms are immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.recovery_started_at IS NOT NULL AND ROW(
+    NEW.recovery_started_at, NEW.recovery_deadline_at
+  ) IS DISTINCT FROM ROW(
+    OLD.recovery_started_at, OLD.recovery_deadline_at
+  ) THEN
+    RAISE EXCEPTION 'payment recovery window is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.recovery_started_at IS NOT NULL
+    AND NEW.recovery_deadline_at IS DISTINCT FROM
+      NEW.recovery_started_at + interval '2 hours' THEN
+    RAISE EXCEPTION 'payment recovery deadline is invalid' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.tx_hash IS NOT NULL AND NEW.tx_hash IS DISTINCT FROM OLD.tx_hash THEN
+    RAISE EXCEPTION 'payment attempt transaction is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.finalized_block_number IS NOT NULL AND ROW(
+    NEW.finalized_block_number, NEW.finalized_block_hash,
+    NEW.finalized_block_time, NEW.finalized_at
+  ) IS DISTINCT FROM ROW(
+    OLD.finalized_block_number, OLD.finalized_block_hash,
+    OLD.finalized_block_time, OLD.finalized_at
+  ) THEN
+    RAISE EXCEPTION 'payment attempt finality is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' IS NOT NULL
+    AND NEW.response_json #>> '{__1f3d9_x402_response_v1,header}' IS DISTINCT FROM
+      OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' THEN
+    RAISE EXCEPTION 'payment facilitator response is immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status IN (
+    'completed', 'invalid', 'founder_review', 'legacy_completed', 'credit_returned'
+  ) AND NEW IS DISTINCT FROM OLD THEN
+    RAISE EXCEPTION 'terminal payment attempt is immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status = 'expired' THEN
+    IF NOT (
+      NEW.status = 'founder_review'
+      AND OLD.method = 'x402'
+      AND NEW.tx_hash IS NOT NULL
+      AND (OLD.tx_hash IS NULL OR NEW.tx_hash = OLD.tx_hash)
+      AND OLD.finalized_block_number IS NULL
+      AND OLD.finalized_block_hash IS NULL
+      AND OLD.finalized_block_time IS NULL
+      AND OLD.finalized_at IS NULL
+      AND NEW.finalized_block_number IS NOT NULL
+      AND NEW.finalized_block_hash IS NOT NULL
+      AND NEW.finalized_block_time IS NOT NULL
+      AND NEW.finalized_at IS NOT NULL
+      AND (
+        (OLD.invalid_reason IS NOT NULL AND NEW.invalid_reason = OLD.invalid_reason)
+        OR (OLD.invalid_reason IS NULL AND NEW.invalid_reason IS NOT NULL)
+      )
+      AND NEW.lease_owner IS NULL
+      AND NEW.lease_expires_at IS NULL
+      AND (
+        to_jsonb(NEW) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      ) IS NOT DISTINCT FROM (
+        to_jsonb(OLD) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      )
+    ) THEN
+      RAISE EXCEPTION 'expired payment attempt history is immutable'
+        USING ERRCODE = '55000';
+    END IF;
+    IF NEW.updated_at < OLD.updated_at THEN
+      RAISE EXCEPTION 'payment attempt update time cannot move backward'
+        USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NOT (
+    (OLD.status = 'settling' AND NEW.status IN (
+      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review', 'founder_review'
+    ))
+    OR (OLD.status = 'payment_pending' AND NEW.status IN (
+      'payment_pending', 'completed', 'invalid', 'expired', 'needs_review', 'founder_review'
+    ))
+    OR (OLD.status = 'needs_review' AND NEW.status IN (
+      'needs_review', 'payment_pending', 'completed', 'invalid', 'expired', 'founder_review'
+    ))
+    OR (
+      OLD.method = 'credit'
+      AND OLD.status IN ('settling', 'payment_pending')
+      AND NEW.status IN ('completed', 'credit_returned')
+    )
+    OR (OLD.status = NEW.status)
+  ) THEN
+    RAISE EXCEPTION 'invalid payment attempt transition' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.updated_at < OLD.updated_at THEN
+    RAISE EXCEPTION 'payment attempt update time cannot move backward' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END
+$$;

--- a/scripts/bob-payment-repair-apply.ts
+++ b/scripts/bob-payment-repair-apply.ts
@@ -32,6 +32,8 @@ function assertGuard(
   guard: GuardedBobPaymentFacts,
   expected: typeof BOB_REPAIR_EXPECTATIONS.coffee | typeof BOB_REPAIR_EXPECTATIONS.theBlueAI,
 ): void {
+  const observedUpdateAt = Date.parse(guard.expected_updated_at)
+  const originalUpdateAt = Date.parse(expected.updatedAt)
   if (
     guard.attempt_id !== expected.attemptId
     || guard.transaction !== expected.txHash
@@ -40,7 +42,9 @@ function assertGuard(
     || guard.target_key !== expected.targetKey
     || guard.request_hash !== expected.requestHash
     || !isDeepStrictEqual(guard.request, expected.request)
-    || guard.expected_updated_at !== expected.updatedAt
+    || !Number.isFinite(observedUpdateAt)
+    || new Date(observedUpdateAt).toISOString() !== guard.expected_updated_at
+    || observedUpdateAt < originalUpdateAt
     || guard.recovery_started_at !== expected.recoveryStartedAt
     || guard.recovery_deadline_at !== expected.recoveryDeadlineAt
     || guard.network !== 'base'
@@ -95,8 +99,14 @@ const EXACT_PENDING_GUARD_SQL = `
     AND attempt.asset_type IS NULL
     AND attempt.asset_id IS NULL
     AND attempt.status = 'payment_pending'
-    AND attempt.lease_owner IS NULL
-    AND attempt.lease_expires_at IS NULL
+    AND (
+      (attempt.lease_owner IS NULL AND attempt.lease_expires_at IS NULL)
+      OR (
+        attempt.lease_owner IS NOT NULL
+        AND attempt.lease_expires_at IS NOT NULL
+        AND attempt.lease_expires_at <= clock_timestamp()
+      )
+    )
     AND attempt.finalized_block_number IS NULL
     AND attempt.finalized_block_hash IS NULL
     AND attempt.finalized_block_time IS NULL

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -50,6 +50,7 @@ type RemoteMigration =
   | 'payment-recovery'
   | 'room-orientation'
   | 'public-snapshots'
+  | 'payment-recovery-trigger-repair'
 
 export type MigrationFile =
   | 'db/schema.sql'
@@ -79,6 +80,7 @@ export type MigrationFile =
   | 'db/migrations/20260822_payment_recovery.sql'
   | 'db/migrations/20260822_room_orientation.sql'
   | 'db/migrations/20260823_public_snapshots.sql'
+  | 'db/migrations/20260823_payment_recovery_trigger_repair.sql'
 
 export type MigrationExecutionMode = 'transactional' | 'nontransactional'
 
@@ -135,6 +137,7 @@ const REMOTE_MIGRATIONS: Readonly<Record<RemoteMigration, MigrationFile>> = {
   'payment-recovery': 'db/migrations/20260822_payment_recovery.sql',
   'room-orientation': 'db/migrations/20260822_room_orientation.sql',
   'public-snapshots': 'db/migrations/20260823_public_snapshots.sql',
+  'payment-recovery-trigger-repair': 'db/migrations/20260823_payment_recovery_trigger_repair.sql',
 }
 const EVENTS_PRESENCE_INDEX_MIGRATION_FILE: MigrationFile =
   'db/migrations/20260821_events_presence_index.sql'

--- a/scripts/repair-bob-payments.ts
+++ b/scripts/repair-bob-payments.ts
@@ -102,26 +102,53 @@ function validateAttemptImmutable(row: QueryRow, expected: AttemptExpectation): 
     && normalizedWallet(row.payee_wallet) === EXPECTED_RECIPIENT
     && text(row, 'amount_units') === ONE_USDC_UNITS.toString()
     && text(row, 'tx_hash')?.toLowerCase() === expected.txHash
-    && row.lease_owner == null
-    && row.lease_expires_at == null
     && sameTime(row.recovery_started_at, expected.recoveryStartedAt)
     && sameTime(row.recovery_deadline_at, expected.recoveryDeadlineAt)
   if (!matches) abort(`${expected.attemptId} immutable attempt facts changed`)
 }
 
-function validatePendingAttempt(row: QueryRow, expected: AttemptExpectation): void {
+function observedRepairTimestamp(row: QueryRow, expected: AttemptExpectation): string {
+  const updatedAt = iso(row.updated_at)
+  const databaseNow = iso(row.database_now)
+  const earliest = Date.parse(expected.updatedAt)
+  if (
+    updatedAt == null
+    || databaseNow == null
+    || Date.parse(updatedAt) < earliest
+    || Date.parse(updatedAt) > Date.parse(databaseNow)
+  ) abort(`${expected.attemptId} update time is outside the approved repair window`)
+  return updatedAt
+}
+
+function validateRepairableLease(row: QueryRow, expected: AttemptExpectation): void {
+  const hasOwner = row.lease_owner != null
+  const hasExpiry = row.lease_expires_at != null
+  if (!hasOwner && !hasExpiry) return
+  const expiry = iso(row.lease_expires_at)
+  const databaseNow = iso(row.database_now)
+  if (
+    hasOwner !== hasExpiry
+    || expiry == null
+    || databaseNow == null
+    || Date.parse(expiry) > Date.parse(databaseNow)
+  ) abort(`${expected.attemptId} has an active or malformed recovery lease`)
+}
+
+function validatePendingAttempt(row: QueryRow, expected: AttemptExpectation): string {
   validateAttemptImmutable(row, expected)
+  validateRepairableLease(row, expected)
+  const updatedAt = observedRepairTimestamp(row, expected)
   const finalityIsEmpty = row.finalized_block_number == null
     && row.finalized_block_hash == null
     && row.finalized_block_time == null
     && row.finalized_at == null
   if (
     text(row, 'status') !== 'payment_pending'
-    || !sameTime(row.updated_at, expected.updatedAt)
     || !finalityIsEmpty
     || row.invalid_reason != null
     || row.completed_at != null
   ) abort(`${expected.attemptId} pending state or stored finality changed`)
+  return updatedAt
 }
 
 function validateStoredFinality(row: QueryRow, expected: AttemptExpectation): void {
@@ -174,7 +201,11 @@ function matchingNamePlaces(snapshot: BobRepairSnapshot, name: string): readonly
   return snapshot.places.filter(row => text(row, 'name')?.toLowerCase() === name.toLowerCase())
 }
 
-function validateInitialState(snapshot: BobRepairSnapshot): number {
+function validateInitialState(snapshot: BobRepairSnapshot): Readonly<{
+  worldRootId: number
+  coffee: QueryRow
+  theBlueAI: QueryRow
+}> {
   const resident = exactRow(snapshot.residents, 'Bob resident 68')
   if (integer(resident, 'id') !== BOB_RESIDENT_ID || text(resident, 'handle') !== BOB_HANDLE) {
     abort('resident 68 is no longer Bob')
@@ -202,7 +233,11 @@ function validateInitialState(snapshot: BobRepairSnapshot): number {
   if (snapshot.fees.length !== 0) abort('one of Bob\'s transaction hashes already has a fee row')
   if (snapshot.places.length !== 0) abort('TheBlueAI or coffee-shop is no longer available')
   if (snapshot.credits.length !== 0) abort('the deterministic founder credit source is already occupied')
-  return integer(root, 'id')!
+  return Object.freeze({
+    worldRootId: integer(root, 'id')!,
+    coffee,
+    theBlueAI,
+  })
 }
 
 function exactPaymentUse(row: QueryRow, expected: AttemptExpectation): boolean {
@@ -267,6 +302,12 @@ function validateFinalState(snapshot: BobRepairSnapshot): void {
   )
   validateAttemptImmutable(coffee, BOB_REPAIR_EXPECTATIONS.coffee)
   validateAttemptImmutable(theBlueAI, BOB_REPAIR_EXPECTATIONS.theBlueAI)
+  if (
+    coffee.lease_owner != null
+    || coffee.lease_expires_at != null
+    || theBlueAI.lease_owner != null
+    || theBlueAI.lease_expires_at != null
+  ) abort('completed Bob repair retained a payment recovery lease')
   validateStoredFinality(coffee, BOB_REPAIR_EXPECTATIONS.coffee)
   validateStoredFinality(theBlueAI, BOB_REPAIR_EXPECTATIONS.theBlueAI)
   if (
@@ -308,7 +349,7 @@ function hasFinalStateSignal(snapshot: BobRepairSnapshot): boolean {
     || snapshot.credits.length > 0
 }
 
-function guardedPayment(expected: AttemptExpectation): GuardedBobPaymentFacts {
+function guardedPayment(expected: AttemptExpectation, row: QueryRow): GuardedBobPaymentFacts {
   return Object.freeze({
     attempt_id: expected.attemptId,
     transaction: expected.txHash,
@@ -317,7 +358,7 @@ function guardedPayment(expected: AttemptExpectation): GuardedBobPaymentFacts {
     target_key: expected.targetKey,
     request_hash: expected.requestHash,
     request: expected.request,
-    expected_updated_at: expected.updatedAt,
+    expected_updated_at: observedRepairTimestamp(row, expected),
     recovery_started_at: expected.recoveryStartedAt,
     recovery_deadline_at: expected.recoveryDeadlineAt,
     network: NETWORK,
@@ -354,7 +395,7 @@ export function buildBobPaymentRepairPlan(
     })
   }
 
-  const worldRootId = validateInitialState(snapshot)
+  const initial = validateInitialState(snapshot)
   const theBlueAIRequest = BOB_REPAIR_EXPECTATIONS.theBlueAI.request
   return Object.freeze({
     schema_version: 1,
@@ -367,7 +408,7 @@ export function buildBobPaymentRepairPlan(
         transaction: BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
         resident_id: BOB_RESIDENT_ID,
         name: 'TheBlueAI',
-        world_root_id: worldRootId,
+        world_root_id: initial.worldRootId,
         place: Object.freeze({
           name: 'TheBlueAI',
           description: theBlueAIRequest.description,
@@ -375,7 +416,7 @@ export function buildBobPaymentRepairPlan(
           open_to_things: theBlueAIRequest.open_to_things,
           open_to_notes: theBlueAIRequest.open_to_notes,
         }),
-        guard: guardedPayment(BOB_REPAIR_EXPECTATIONS.theBlueAI),
+        guard: guardedPayment(BOB_REPAIR_EXPECTATIONS.theBlueAI, initial.theBlueAI),
       }),
       Object.freeze({
         kind: 'close_coffee_probe',
@@ -384,7 +425,7 @@ export function buildBobPaymentRepairPlan(
         resident_id: BOB_RESIDENT_ID,
         terminal_state: 'founder_review',
         reason: BOB_COFFEE_REVIEW_REASON,
-        guard: guardedPayment(BOB_REPAIR_EXPECTATIONS.coffee),
+        guard: guardedPayment(BOB_REPAIR_EXPECTATIONS.coffee, initial.coffee),
       }),
       Object.freeze({
         kind: 'issue_founder_credit',
@@ -541,6 +582,7 @@ export async function readBobRepairSnapshot(
       attempt.finalized_block_number::text AS finalized_block_number,
       attempt.finalized_block_hash, attempt.finalized_block_time, attempt.finalized_at,
       attempt.invalid_reason, attempt.updated_at, attempt.completed_at
+      , clock_timestamp() AS database_now
     FROM payment_attempts attempt
     LEFT JOIN residents resident ON resident.id = attempt.actor_id
     WHERE attempt.public_id = ANY($1::text[])

--- a/src/identity-store.ts
+++ b/src/identity-store.ts
@@ -36,6 +36,20 @@ export interface RecoveryGenerationResult extends IdentityResidentResult {
 
 const SHA256_HASH = /^[0-9a-f]{64}$/
 
+/**
+ * PostgreSQL aborts one whole transaction when it breaks a deadlock. Identity
+ * confirmation statements are atomic, so the aborted statement is safe to try
+ * once more after the competing confirmation has been allowed to finish.
+ */
+export async function retryIdentityDeadlockOnce<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation()
+  } catch (error) {
+    if (postgresErrorCode(error) !== '40P01') throw error
+    return operation()
+  }
+}
+
 function requireRecoveryCodeHashes(hashes: readonly string[]): void {
   if (
     hashes.length !== 8 ||
@@ -353,7 +367,7 @@ export async function stageRootRecovery(input: {
   return rows[0] ?? null
 }
 
-export async function confirmRootRecovery(input: {
+async function confirmRootRecoveryOnce(input: {
   sessionHash: string
   csrfHash: string
   replacementSecretHash: string
@@ -459,6 +473,14 @@ export async function confirmRootRecovery(input: {
   }
 }
 
+export async function confirmRootRecovery(input: {
+  sessionHash: string
+  csrfHash: string
+  replacementSecretHash: string
+}): Promise<IdentityResidentResult | null> {
+  return retryIdentityDeadlockOnce(() => confirmRootRecoveryOnce(input))
+}
+
 export async function cancelRootRecovery(input: {
   sessionHash: string
   csrfHash: string
@@ -534,7 +556,7 @@ export type RootRotationResult =
   | ({ status: 'rotated' } & IdentityResidentResult)
   | { status: 'rate_limited' }
 
-export async function confirmRootRotation(input: {
+async function confirmRootRotationOnce(input: {
   sessionHash: string
   csrfHash: string
   replacementSecretHash: string
@@ -686,6 +708,14 @@ export async function confirmRootRotation(input: {
     if (postgresErrorCode(error) === '23505') return null
     throw error
   }
+}
+
+export async function confirmRootRotation(input: {
+  sessionHash: string
+  csrfHash: string
+  replacementSecretHash: string
+}): Promise<RootRotationResult | null> {
+  return retryIdentityDeadlockOnce(() => confirmRootRotationOnce(input))
 }
 
 export async function cancelRootRotation(input: {

--- a/src/payment-recovery-runtime.ts
+++ b/src/payment-recovery-runtime.ts
@@ -265,6 +265,21 @@ function mergedServices(
   }
 }
 
+function logRecoveryFailure(attempt: PaymentRecoveryAttempt, error: unknown): void {
+  const detail = error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error)
+  console.error('payment recovery attempt failed', {
+    attemptId: attempt.publicId,
+    actorId: attempt.actorId,
+    operation: attempt.operation,
+    method: attempt.method,
+    status: attempt.status,
+    recoveryDeadlineAt: attempt.recoveryDeadlineAt,
+    error: detail,
+  })
+}
+
 export interface PaymentRecoveryRuntime {
   dependencies: PaymentRecoveryDependencies
   getOwnedAttempt(publicId: string, actorId: number): Promise<PaymentAttemptRecord | null>
@@ -453,6 +468,7 @@ export function createPaymentRecoveryRuntime(
       })
       return simpleOutcome('founder_review', value.publicId)
     },
+    reportFailure: logRecoveryFailure,
   }
 
   return {

--- a/src/payment-recovery.ts
+++ b/src/payment-recovery.ts
@@ -95,6 +95,7 @@ export interface PaymentRecoveryDependencies {
     attempt: PaymentRecoveryAttempt,
     evidence: Extract<LateX402Inspection, { state: 'matched' }>,
   ): Promise<PaymentRecoveryOutcome>
+  reportFailure?(attempt: PaymentRecoveryAttempt, error: unknown): void
 }
 
 export type PaymentRecoveryBatchResult = Readonly<{
@@ -231,8 +232,9 @@ export async function runPaymentRecoveryBatch(
       else if (result.state === 'payment_pending' || result.state === 'unavailable') counts.pending += 1
       else if (result.state === 'busy') counts.busy += 1
       else counts.terminalized += 1
-    } catch {
+    } catch (error) {
       counts.failed += 1
+      deps.reportFailure?.(attempt, error)
     }
   }
   return Object.freeze({ ...counts })

--- a/test/bob-payment-repair-apply.test.ts
+++ b/test/bob-payment-repair-apply.test.ts
@@ -48,6 +48,7 @@ function attempt(key: 'coffee' | 'theBlueAI') {
     invalid_reason: null,
     completed_at: null,
     updated_at: expected.updatedAt,
+    database_now: '2026-08-23T12:00:00.000Z',
   }
 }
 
@@ -165,4 +166,35 @@ test('an operation that cannot affect exactly one approved row aborts', async ()
     bobPaymentRepairApplyOperations.completeTheBlueAI(database, action.complete),
     /aborted|changed|conflict/iu,
   )
+})
+
+test('apply guards accept only the exact observed update time with a null or expired lease', async () => {
+  const base = snapshot()
+  const expired: BobRepairSnapshot = {
+    ...base,
+    attempts: base.attempts.map((row, index) => ({
+      ...row,
+      lease_owner: 'expired-cron-lease',
+      lease_expires_at: `2026-08-23T11:59:3${index}.000Z`,
+      updated_at: `2026-08-23T11:59:0${index}.000Z`,
+    })),
+  }
+  const plan = buildBobPaymentRepairPlan(expired, {
+    [BOB_REPAIR_EXPECTATIONS.coffee.txHash]: evidence('coffee'),
+    [BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash]: evidence('theBlueAI'),
+  })
+  assert.equal(plan.state, 'work_required')
+  const complete = plan.actions.find(action => action.kind === 'complete_theblueai')!
+  assert.equal(complete.kind, 'complete_theblueai')
+
+  const database = new RecordingDatabase()
+  await bobPaymentRepairApplyOperations.completeTheBlueAI(database, complete)
+
+  const guarded = database.calls.find(call => call.text.includes('bob-payment-repair-apply:create-place'))
+  assert.ok(guarded)
+  assert.match(
+    guarded.text,
+    /lease_owner\s+IS\s+NULL[\s\S]*lease_expires_at\s+IS\s+NULL[\s\S]*OR[\s\S]*lease_owner\s+IS\s+NOT\s+NULL[\s\S]*lease_expires_at\s*<=\s*clock_timestamp\(\)/iu,
+  )
+  assert.ok(guarded.values.map(String).includes('2026-08-23T11:59:01.000Z'))
 })

--- a/test/bob-payment-repair.test.ts
+++ b/test/bob-payment-repair.test.ts
@@ -16,7 +16,7 @@ import {
   type BobTransferEvidence,
 } from '../scripts/repair-bob-payments.ts'
 
-type Mutable<T> = { -readonly [Key in keyof T]: Mutable<T[Key]> }
+type Mutable<T> = T extends object ? { -readonly [Key in keyof T]: Mutable<T[Key]> } : T
 
 const EXPECTED_REQUESTS = Object.freeze({
   coffee: Object.freeze({
@@ -73,6 +73,7 @@ function expectedAttempt(
     invalid_reason: null,
     completed_at: null,
     updated_at: expected.updatedAt,
+    database_now: '2026-08-23T12:00:00.000Z',
     ...overrides,
   }
 }
@@ -220,6 +221,63 @@ test('pure planning proposes exactly one frontier, one no-effect close, and one 
   assert.equal(close?.guard.recovery_deadline_at, BOB_REPAIR_EXPECTATIONS.coffee.recoveryDeadlineAt)
 })
 
+test('an expired automatic lease is repairable and its observed update time becomes the exact guard', () => {
+  const snapshot = cloneSnapshot(initialSnapshot())
+  snapshot.attempts[0] = expectedAttempt('coffee', {
+    lease_owner: 'expired-cron-lease',
+    lease_expires_at: '2026-08-23T11:59:30.000Z',
+    updated_at: '2026-08-23T11:59:00.000Z',
+  })
+  snapshot.attempts[1] = expectedAttempt('theBlueAI', {
+    lease_owner: 'expired-cron-lease',
+    lease_expires_at: '2026-08-23T11:59:31.000Z',
+    updated_at: '2026-08-23T11:59:01.000Z',
+  })
+
+  const plan = buildBobPaymentRepairPlan(snapshot, transfers())
+  assert.equal(plan.state, 'work_required')
+  const complete = plan.actions.find(action => action.kind === 'complete_theblueai')
+  const close = plan.actions.find(action => action.kind === 'close_coffee_probe')
+  assert.equal(complete?.guard.expected_updated_at, '2026-08-23T11:59:01.000Z')
+  assert.equal(close?.guard.expected_updated_at, '2026-08-23T11:59:00.000Z')
+})
+
+test('active, malformed, future-dated, or backward-moving lease state is never repairable', () => {
+  const cases: readonly Readonly<{
+    name: string
+    overrides: Readonly<Record<string, unknown>>
+  }>[] = [
+    {
+      name: 'active lease',
+      overrides: {
+        lease_owner: 'active-cron-lease',
+        lease_expires_at: '2026-08-23T12:00:30.000Z',
+        updated_at: '2026-08-23T11:59:00.000Z',
+      },
+    },
+    { name: 'owner without expiry', overrides: { lease_owner: 'broken-lease' } },
+    { name: 'expiry without owner', overrides: { lease_expires_at: '2026-08-23T11:59:30.000Z' } },
+    {
+      name: 'future update time',
+      overrides: { updated_at: '2026-08-23T12:00:01.000Z' },
+    },
+    {
+      name: 'backward update time',
+      overrides: { updated_at: '2026-08-22T07:00:00.000Z' },
+    },
+  ]
+
+  for (const candidate of cases) {
+    const snapshot = cloneSnapshot(initialSnapshot())
+    snapshot.attempts[0] = expectedAttempt('coffee', candidate.overrides)
+    assert.throws(
+      () => buildBobPaymentRepairPlan(snapshot, transfers()),
+      BobPaymentRepairAbortError,
+      candidate.name,
+    )
+  }
+})
+
 test('every guarded database fact aborts when changed or ambiguous', () => {
   const cases: readonly Readonly<{
     name: string
@@ -245,7 +303,7 @@ test('every guarded database fact aborts when changed or ambiguous', () => {
     { name: 'amount', change: snapshot => { snapshot.attempts[0]!.amount_units = '999999' } },
     { name: 'stored finality', change: snapshot => { snapshot.attempts[0]!.finalized_block_number = '1' } },
     { name: 'recovery deadline', change: snapshot => { snapshot.attempts[0]!.recovery_deadline_at = '2026-08-22T10:00:00.000Z' } },
-    { name: 'updated timestamp', change: snapshot => { snapshot.attempts[0]!.updated_at = '2026-08-22T08:00:00.000Z' } },
+    { name: 'database clock missing', change: snapshot => { snapshot.attempts[0]!.database_now = null } },
     { name: 'used hash', change: snapshot => { snapshot.paymentUses.push({ tx_hash: BOB_REPAIR_EXPECTATIONS.coffee.txHash }) } },
     { name: 'fee row', change: snapshot => { snapshot.fees.push({ tx_hash: BOB_REPAIR_EXPECTATIONS.coffee.txHash }) } },
     { name: 'name conflict', change: snapshot => { snapshot.places.push({ name: 'theblueai', owner_id: 99 }) } },

--- a/test/deploy-safety.test.ts
+++ b/test/deploy-safety.test.ts
@@ -77,6 +77,10 @@ const initialRecoveryCodesMigrationUrl = new URL(
   '../db/migrations/20260817_initial_recovery_codes.sql',
   import.meta.url,
 )
+const paymentRecoveryTriggerRepairMigrationUrl = new URL(
+  '../db/migrations/20260823_payment_recovery_trigger_repair.sql',
+  import.meta.url,
+)
 
 function withoutGitHookEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const environment = { ...process.env }
@@ -1060,12 +1064,9 @@ test('payment response replay is an explicitly selected idempotent function repa
   assert.match(uncommented, /__1f3d9_x402_response_v1/i)
   assert.doesNotMatch(uncommented, /^\s*(?:DROP\s+TABLE|ALTER\s+TABLE|DELETE|TRUNCATE)\b/im)
 
-  const normalize = (statement: string) => statement
-    .replace(/^\s*--.*$/gm, '')
-    .replace(/\s+/g, ' ')
-    .trim()
-  const freshFunctions = new Set(splitSqlStatements(fullSchema).map(normalize))
-  for (const statement of statements) assert.ok(freshFunctions.has(normalize(statement)))
+  assert.match(fullSchema, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/i)
+  assert.match(fullSchema, /OLD\.status\s*=\s*'payment_pending'[\s\S]*'expired'/i)
+  assert.match(fullSchema, /OLD\.status\s*=\s*'expired'[\s\S]*'founder_review'/i)
 
   const preview = resolveMigrationRun(
     ['--target', 'preview', '--migration', 'payment-response-replay'],
@@ -1196,6 +1197,48 @@ test('byte-exact response constraint validation is one separately committed name
     },
   )
   assert.equal(production.migrationFile, 'db/migrations/20260818_payment_response_body_validate.sql')
+})
+
+test('payment recovery trigger repair is an explicitly selected function correction', () => {
+  const migration = readFileSync(paymentRecoveryTriggerRepairMigrationUrl, 'utf8')
+  const uncommented = migration.replace(/^\s*--.*$/gm, '')
+  const statements = splitSqlStatements(migration)
+
+  assert.equal(statements.length, 1)
+  assert.match(uncommented, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/i)
+  assert.match(uncommented, /OLD\.status\s*=\s*'payment_pending'[\s\S]*'expired'/i)
+  assert.match(uncommented, /OLD\.status\s*=\s*'expired'[\s\S]*'founder_review'/i)
+  assert.doesNotMatch(uncommented, /^\s*(?:DROP\s+TABLE|DELETE|TRUNCATE)\b/im)
+
+  assert.match(fullSchema, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/i)
+  assert.match(fullSchema, /OLD\.status\s*=\s*'payment_pending'[\s\S]*'expired'/i)
+  assert.match(fullSchema, /OLD\.status\s*=\s*'expired'[\s\S]*'founder_review'/i)
+
+  const preview = resolveMigrationRun(
+    ['--target', 'preview', '--migration', 'payment-recovery-trigger-repair'],
+    {
+      CONFIRM_PREVIEW_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_ISOLATED_PREVIEW',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PREVIEW_BRANCH_ID: 'branch-preview',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PREVIEW_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+    },
+  )
+  assert.equal(preview.migrationFile, 'db/migrations/20260823_payment_recovery_trigger_repair.sql')
+
+  const production = resolveMigrationRun(
+    ['--target', 'production', '--migration', 'payment-recovery-trigger-repair'],
+    {
+      CONFIRM_PRODUCTION_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_PRODUCTION',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PRODUCTION_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+      PRODUCTION_SNAPSHOT_NAME: 'payment-recovery-trigger-repair-release',
+    },
+  )
+  assert.equal(production.migrationFile, 'db/migrations/20260823_payment_recovery_trigger_repair.sql')
 })
 
 test('public pagination indexes are an explicitly selected additive release', () => {

--- a/test/identity-deadlock-retry.test.ts
+++ b/test/identity-deadlock-retry.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { retryIdentityDeadlockOnce } from '../src/identity-store.ts'
+
+test('identity confirmation retries one aborted deadlock and returns the retry result', async () => {
+  let attempts = 0
+  const result = await retryIdentityDeadlockOnce(async () => {
+    attempts += 1
+    if (attempts === 1) {
+      throw Object.assign(new Error('deadlock detected'), { sourceError: { code: '40P01' } })
+    }
+    return { residentId: 1, handle: 'resident' }
+  })
+
+  assert.deepEqual(result, { residentId: 1, handle: 'resident' })
+  assert.equal(attempts, 2)
+})
+
+test('identity confirmation never retries a second deadlock', async () => {
+  let attempts = 0
+  await assert.rejects(
+    retryIdentityDeadlockOnce(async () => {
+      attempts += 1
+      throw Object.assign(new Error('deadlock detected'), { code: '40P01' })
+    }),
+    (error: unknown) => (error as { code?: unknown }).code === '40P01',
+  )
+  assert.equal(attempts, 2)
+})
+
+test('identity confirmation does not retry another database error', async () => {
+  let attempts = 0
+  await assert.rejects(
+    retryIdentityDeadlockOnce(async () => {
+      attempts += 1
+      throw Object.assign(new Error('constraint failed'), { code: '23514' })
+    }),
+    (error: unknown) => (error as { code?: unknown }).code === '23514',
+  )
+  assert.equal(attempts, 1)
+})

--- a/test/integration/payment-recovery-postgres.test.ts
+++ b/test/integration/payment-recovery-postgres.test.ts
@@ -32,6 +32,14 @@ const recoveryMigrationDdl = await readFile(
   new URL('../../db/migrations/20260822_payment_recovery.sql', import.meta.url),
   'utf8',
 )
+const cityCreditMigrationDdl = await readFile(
+  new URL('../../db/migrations/20260822_city_credit.sql', import.meta.url),
+  'utf8',
+)
+const recoveryTriggerRepairMigrationDdl = await readFile(
+  new URL('../../db/migrations/20260823_payment_recovery_trigger_repair.sql', import.meta.url),
+  'utf8',
+)
 
 const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
 const PAYER = `0x${'1'.repeat(40)}`
@@ -187,6 +195,26 @@ test('payment recovery migration and primitives preserve exact deadline and term
   t.after(async () => {
     await database.end().catch(() => undefined)
     spawnSync('docker', ['stop', '--time', '0', containerName], { encoding: 'utf8' })
+  })
+
+  await t.test('city credit cannot replace the newer payment transition rules', async () => {
+    await reset(database)
+    await database.query(cityCreditMigrationDdl)
+    await database.query(recoveryTriggerRepairMigrationDdl)
+    await database.query(recoveryTriggerRepairMigrationDdl)
+    await insertAttempt(database, {
+      publicId: 'pay_recovery_after_credit', targetKey: 'frontier:root:after-credit',
+      leaseOwner: 'lease-after-credit', recovery: 'due',
+    })
+
+    const expired = await expirePaymentAttempt({ query: async (text, params = []) => (
+      await database.query(text, [...params])
+    ).rows }, {
+      publicId: 'pay_recovery_after_credit',
+      leaseOwner: 'lease-after-credit',
+      reason: 'automatic payment recovery deadline passed',
+    })
+    assert.equal(expired.status, 'expired')
   })
 
   await t.test('recovery deadline is exactly two hours and equality cannot complete', async () => {
@@ -534,6 +562,72 @@ test('payment recovery migration and primitives preserve exact deadline and term
         WHERE public_id = 'pay_recovery_late'`),
       (error: unknown) => postgresCode(error) === '55000',
     )
+  })
+
+  await t.test('the trigger repair migration re-allows due x402 expiry from payment_pending', async () => {
+    await reset(database)
+    await database.query(`
+      CREATE OR REPLACE FUNCTION protect_payment_attempt_history() RETURNS trigger LANGUAGE plpgsql AS $function$
+      BEGIN
+        IF TG_OP = 'DELETE' THEN
+          RAISE EXCEPTION 'payment attempt history cannot be deleted' USING ERRCODE = '55000';
+        END IF;
+        IF OLD.status IN ('completed', 'invalid', 'expired', 'legacy_completed', 'credit_returned')
+          AND NEW IS DISTINCT FROM OLD THEN
+          RAISE EXCEPTION 'terminal payment attempt is immutable' USING ERRCODE = '55000';
+        END IF;
+        IF NOT (
+          (OLD.status = 'settling' AND NEW.status IN (
+            'settling', 'payment_pending', 'invalid', 'expired', 'needs_review'
+          ))
+          OR (OLD.status = 'payment_pending' AND NEW.status IN (
+            'payment_pending', 'completed', 'invalid', 'needs_review'
+          ))
+          OR (OLD.status = 'needs_review' AND NEW.status IN (
+            'needs_review', 'payment_pending', 'completed', 'invalid'
+          ))
+          OR (
+            OLD.method = 'credit'
+            AND OLD.status IN ('settling', 'payment_pending')
+            AND NEW.status IN ('completed', 'credit_returned')
+          )
+          OR (OLD.status = NEW.status)
+        ) THEN
+          RAISE EXCEPTION 'invalid payment attempt transition' USING ERRCODE = '55000';
+        END IF;
+        IF NEW.updated_at < OLD.updated_at THEN
+          RAISE EXCEPTION 'payment attempt update time cannot move backward' USING ERRCODE = '55000';
+        END IF;
+        RETURN NEW;
+      END
+      $function$;
+    `)
+    await insertAttempt(database, {
+      publicId: 'pay_recovery_stale_trigger', targetKey: 'frontier:root:stale-trigger',
+      status: 'payment_pending', leaseOwner: 'lease-due', recovery: 'due',
+    })
+    const paymentDatabase = { query: async (text: string, params: readonly unknown[] = []) => (
+      await database.query(text, [...params])
+    ).rows }
+
+    await assert.rejects(
+      expirePaymentAttempt(paymentDatabase, {
+        publicId: 'pay_recovery_stale_trigger',
+        leaseOwner: 'lease-due',
+        reason: 'automatic payment recovery deadline passed',
+      }),
+      (error: unknown) => postgresCode(error) === '55000',
+    )
+
+    await database.query(recoveryTriggerRepairMigrationDdl)
+    const expired = await expirePaymentAttempt(paymentDatabase, {
+      publicId: 'pay_recovery_stale_trigger',
+      leaseOwner: 'lease-due',
+      reason: 'automatic payment recovery deadline passed',
+    })
+    assert.equal(expired.status, 'expired')
+    assert.equal(expired.leaseOwner, null)
+    assert.equal(expired.invalidReason, 'automatic payment recovery deadline passed')
   })
 
   await t.test('additive migration backfills old live rows from their last known update', async () => {

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -370,8 +370,9 @@ test('later-holder marks are selected as one explicit transactional preview or p
 test('payment recovery trigger repair is selected as one explicit transactional preview or production migration', () => {
   const migration = migrationDdl(paymentRecoveryTriggerRepairMigrationFile)
   assert.match(migration, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/iu)
+  assert.match(migration, /payment recovery window is immutable/iu)
   assert.match(migration, /payment_pending',\s*'completed',\s*'invalid',\s*'expired'/iu)
-  assert.match(migration, /OLD\.status\s*=\s*'expired'[\s\S]*NEW\.status\s+IN\s+\('expired',\s*'founder_review'\)/iu)
+  assert.match(migration, /OLD\.status\s*=\s*'expired'[\s\S]*NEW\.status\s*=\s*'founder_review'/iu)
   assert.equal(
     prepareMigrationExecution(paymentRecoveryTriggerRepairMigrationFile, migration).mode,
     'transactional',

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -19,6 +19,8 @@ const publicSearchIndexesMigrationFile = 'db/migrations/20260821_public_search_i
 const publicChangeMarkersMigrationFile = 'db/migrations/20260821_public_change_markers.sql' as const
 const thingMakerMigrationFile = 'db/migrations/20260822_thing_maker.sql' as const
 const laterHolderMarksMigrationFile = 'db/migrations/20260822_later_holder_marks.sql' as const
+const paymentRecoveryTriggerRepairMigrationFile =
+  'db/migrations/20260823_payment_recovery_trigger_repair.sql' as const
 
 function migrationDdl(file: string): string {
   return readFileSync(new URL(`../${file}`, import.meta.url), 'utf8')
@@ -362,6 +364,45 @@ test('later-holder marks are selected as one explicit transactional preview or p
     },
   )
   assert.equal(production.migrationFile, laterHolderMarksMigrationFile)
+  assert.equal(production.executionMode, 'transactional')
+})
+
+test('payment recovery trigger repair is selected as one explicit transactional preview or production migration', () => {
+  const migration = migrationDdl(paymentRecoveryTriggerRepairMigrationFile)
+  assert.match(migration, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/iu)
+  assert.match(migration, /payment_pending',\s*'completed',\s*'invalid',\s*'expired'/iu)
+  assert.match(migration, /OLD\.status\s*=\s*'expired'[\s\S]*NEW\.status\s+IN\s+\('expired',\s*'founder_review'\)/iu)
+  assert.equal(
+    prepareMigrationExecution(paymentRecoveryTriggerRepairMigrationFile, migration).mode,
+    'transactional',
+  )
+
+  const preview = resolveMigrationRun(
+    ['--target', 'preview', '--migration', 'payment-recovery-trigger-repair'],
+    {
+      CONFIRM_PREVIEW_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_ISOLATED_PREVIEW',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PREVIEW_BRANCH_ID: 'branch-preview',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PREVIEW_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+    },
+  )
+  assert.equal(preview.migrationFile, paymentRecoveryTriggerRepairMigrationFile)
+  assert.equal(preview.executionMode, 'transactional')
+
+  const production = resolveMigrationRun(
+    ['--target', 'production', '--migration', 'payment-recovery-trigger-repair'],
+    {
+      CONFIRM_PRODUCTION_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_PRODUCTION',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PRODUCTION_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+      PRODUCTION_SNAPSHOT_NAME: 'payment-recovery-trigger-repair-release',
+    },
+  )
+  assert.equal(production.migrationFile, paymentRecoveryTriggerRepairMigrationFile)
   assert.equal(production.executionMode, 'transactional')
 })
 

--- a/test/payment-recovery.test.ts
+++ b/test/payment-recovery.test.ts
@@ -60,6 +60,7 @@ function dependencies(
       state: 'founder_review',
       attemptId: current.publicId,
     }),
+    reportFailure: () => {},
     ...overrides,
   }
 }
@@ -290,17 +291,61 @@ test('batch recovery isolates one failed attempt and keeps processing bounded wo
     attempt({ publicId: 'pay_two' }),
     attempt({ publicId: 'pay_three' }),
   ]
+  const failures: Array<{ attemptId: string; message: string }> = []
+  const failure = new Error('temporary RPC failure')
   const result = await runPaymentRecoveryBatch(2, dependencies({
     listRecoverable: async input => {
       assert.equal(input.limit, 2)
       return attempts.slice(0, input.limit)
     },
     resumeX402: async current => {
-      if (current.publicId === 'pay_one') throw new Error('temporary RPC failure')
+      if (current.publicId === 'pay_one') throw failure
       return { state: 'payment_pending', attemptId: current.publicId }
+    },
+    reportFailure: (current, error) => failures.push({
+      attemptId: current.publicId,
+      message: error instanceof Error ? error.message : String(error),
+    }),
+  }))
+
+  assert.deepEqual(result, {
+    scanned: 2,
+    completed: 0,
+    pending: 1,
+    busy: 0,
+    terminalized: 0,
+    failed: 1,
+  })
+  assert.deepEqual(failures, [{
+    attemptId: 'pay_one',
+    message: failure.message,
+  }])
+})
+
+test('batch recovery reports the failed attempt before moving to the next one', async () => {
+  const attempts = [
+    attempt({ publicId: 'pay_one' }),
+    attempt({ publicId: 'pay_two' }),
+  ]
+  const reported: Array<{ attemptId: string; message: string }> = []
+  const result = await runPaymentRecoveryBatch(2, dependencies({
+    listRecoverable: async () => attempts,
+    resumeX402: async current => {
+      if (current.publicId === 'pay_one') throw new Error('deadline transition rejected')
+      return { state: 'payment_pending', attemptId: current.publicId }
+    },
+    reportFailure: (current, error) => {
+      reported.push({
+        attemptId: current.publicId,
+        message: error instanceof Error ? error.message : String(error),
+      })
     },
   }))
 
+  assert.deepEqual(reported, [{
+    attemptId: 'pay_one',
+    message: 'deadline transition rejected',
+  }])
   assert.deepEqual(result, {
     scanned: 2,
     completed: 0,


### PR DESCRIPTION
## Summary
- repair the production payment history trigger so due x402 attempts can expire again
- log per-attempt payment recovery failures server-side instead of swallowing them silently
- let the guarded Bob repair dry run accept expired cron leases and current observed update times
- retry one identity deadlock during root recovery and root rotation confirmation

## Testing
- npm run typecheck
- npm test
- node --test --experimental-strip-types test/integration/payment-recovery-postgres.test.ts
- node --test --experimental-strip-types --experimental-test-module-mocks test/integration/identity-recovery-postgres.test.ts