### PR TITLE
fix: repair Bob payments and publish host corrections

### DIFF
--- a/db/migrations/20260822_city_credit.sql
+++ b/db/migrations/20260822_city_credit.sql
@@ -339,6 +339,19 @@ BEGIN
     RAISE EXCEPTION 'payment attempt terms are immutable' USING ERRCODE = '55000';
   END IF;
 
+  IF OLD.recovery_started_at IS NOT NULL AND ROW(
+    NEW.recovery_started_at, NEW.recovery_deadline_at
+  ) IS DISTINCT FROM ROW(
+    OLD.recovery_started_at, OLD.recovery_deadline_at
+  ) THEN
+    RAISE EXCEPTION 'payment recovery window is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.recovery_started_at IS NOT NULL
+    AND NEW.recovery_deadline_at IS DISTINCT FROM
+      NEW.recovery_started_at + interval '2 hours' THEN
+    RAISE EXCEPTION 'payment recovery deadline is invalid' USING ERRCODE = '55000';
+  END IF;
+
   IF OLD.tx_hash IS NOT NULL AND NEW.tx_hash IS DISTINCT FROM OLD.tx_hash THEN
     RAISE EXCEPTION 'payment attempt transaction is immutable' USING ERRCODE = '55000';
   END IF;
@@ -357,19 +370,63 @@ BEGIN
     RAISE EXCEPTION 'payment facilitator response is immutable' USING ERRCODE = '55000';
   END IF;
 
-  IF OLD.status IN ('completed', 'invalid', 'expired', 'legacy_completed', 'credit_returned')
-    AND NEW IS DISTINCT FROM OLD THEN
+  IF OLD.status IN (
+    'completed', 'invalid', 'founder_review', 'legacy_completed', 'credit_returned'
+  ) AND NEW IS DISTINCT FROM OLD THEN
     RAISE EXCEPTION 'terminal payment attempt is immutable' USING ERRCODE = '55000';
   END IF;
+
+  IF OLD.status = 'expired' THEN
+    IF NOT (
+      NEW.status = 'founder_review'
+      AND OLD.method = 'x402'
+      AND NEW.tx_hash IS NOT NULL
+      AND (OLD.tx_hash IS NULL OR NEW.tx_hash = OLD.tx_hash)
+      AND OLD.finalized_block_number IS NULL
+      AND OLD.finalized_block_hash IS NULL
+      AND OLD.finalized_block_time IS NULL
+      AND OLD.finalized_at IS NULL
+      AND NEW.finalized_block_number IS NOT NULL
+      AND NEW.finalized_block_hash IS NOT NULL
+      AND NEW.finalized_block_time IS NOT NULL
+      AND NEW.finalized_at IS NOT NULL
+      AND (
+        (OLD.invalid_reason IS NOT NULL AND NEW.invalid_reason = OLD.invalid_reason)
+        OR (OLD.invalid_reason IS NULL AND NEW.invalid_reason IS NOT NULL)
+      )
+      AND NEW.lease_owner IS NULL
+      AND NEW.lease_expires_at IS NULL
+      AND (
+        to_jsonb(NEW) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      ) IS NOT DISTINCT FROM (
+        to_jsonb(OLD) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      )
+    ) THEN
+      RAISE EXCEPTION 'expired payment attempt history is immutable'
+        USING ERRCODE = '55000';
+    END IF;
+    IF NEW.updated_at < OLD.updated_at THEN
+      RAISE EXCEPTION 'payment attempt update time cannot move backward'
+        USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+  END IF;
+
   IF NOT (
     (OLD.status = 'settling' AND NEW.status IN (
-      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review'
+      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review', 'founder_review'
     ))
     OR (OLD.status = 'payment_pending' AND NEW.status IN (
-      'payment_pending', 'completed', 'invalid', 'needs_review'
+      'payment_pending', 'completed', 'invalid', 'expired', 'needs_review', 'founder_review'
     ))
     OR (OLD.status = 'needs_review' AND NEW.status IN (
-      'needs_review', 'payment_pending', 'completed', 'invalid'
+      'needs_review', 'payment_pending', 'completed', 'invalid', 'expired', 'founder_review'
     ))
     OR (
       OLD.method = 'credit'

--- a/db/migrations/20260823_public_snapshots.sql
+++ b/db/migrations/20260823_public_snapshots.sql
@@ -80,6 +80,7 @@ public_event_kinds(kind) AS (
     ('world_listed'),
     ('world_sale'),
     ('world_cancel'),
+    ('payment_repair'),
     ('flag'),
     ('moderation')
 ),

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4658,6 +4658,7 @@ public_event_kinds(kind) AS (
     ('world_listed'),
     ('world_sale'),
     ('world_cancel'),
+    ('payment_repair'),
     ('flag'),
     ('moderation')
 ),

--- a/docs/runbooks/PAYMENT_RECOVERY.md
+++ b/docs/runbooks/PAYMENT_RECOVERY.md
@@ -49,16 +49,17 @@ configured Neon production project and branch. It then opens one PostgreSQL
 `REPEATABLE READ READ ONLY` transaction. The transaction has short statement,
 lock, and idle timeouts and selects only the guarded resident, attempts,
 payment-use rows, fee rows, world root, two names, and deterministic credit
-source. Payment response headers, bearer secrets, and database URLs are never
-selected or printed.
+source and repair-event keys. Payment response headers, bearer secrets, and
+database URLs are never selected or printed.
 
 The dry run independently requires all of these facts:
 
 1. Resident 68 is still `bob`; both attempt IDs, immutable request bodies and
    hashes, target keys, timestamps, payment terms, and unused hashes match the
    hard-coded evidence.
-2. Both stored attempts are still `payment_pending`, have no stored finality or
-   lease, and retain the migration-derived two-hour recovery timestamps.
+2. Both stored attempts are exactly `expired`, have the automatic recovery
+   deadline reason, no stored finality or lease, and retain the migration-derived
+   two-hour recovery timestamps.
 3. Each Base transaction reclassifies as the exact finalized canonical USDC
    transfer: expected payer, treasury recipient, token, one million units,
    block number, block hash, and block time.
@@ -94,10 +95,12 @@ implementation enforces these five conditions:
 1. Use only the transaction object passed to each method. Do not open a second
    connection, commit early, or perform an external side effect.
 2. `completeTheBlueAI` must atomically create exactly one continent from the
-   guarded request, add the matching payment use and fee, and complete only the
-   guarded finalized attempt.
-3. `closeCoffeeProbe` must append the exact finality evidence and move only that
-   attempt to terminal `founder_review`; it must create no place, use, or fee.
+   guarded request, append one public host correction, and move only that attempt
+   to `founder_review` with the exact finality evidence. It must not add a normal
+   payment-use or fee row or pretend the expired attempt completed normally.
+3. `closeCoffeeProbe` must append the exact finality evidence and one public host
+   correction, then move only that attempt to terminal `founder_review`; it must
+   create no place, use, or fee.
 4. `issueFounderCredit` must call the founder-only credit operation for resident
    68 with source key
    `bob-payment-repair:pay_ae6db1c532fdcca0bdc2c977433e842540a5fa2dc1c41c830627dba60fe5c24b`.
@@ -115,9 +118,9 @@ the pure planner reports `no_work`. Otherwise it rolls back everything.
 
 Run the default dry-run command again. It must report `state: "no_work"` and an
 empty action list. That result requires exactly one matching `TheBlueAI`, no
-`coffee-shop`, one matching payment use and fee for TheBlueAI, terminal founder
-review for the probe, and exactly one founder-issued credit with the deterministic
-source key.
+`coffee-shop`, no matching payment-use or fee rows, terminal founder review for
+both attempts, exactly two public host correction events, and exactly one
+founder-issued credit with the deterministic source key.
 
 If the post-check aborts, stop. Preserve the transaction and credit history,
 capture only the sanitized error text, and use a forward repair after reviewing

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "migrate:preview:payment-recovery": "node --experimental-strip-types scripts/migrate.ts --target preview --migration payment-recovery",
     "migrate:preview:room-orientation": "node --experimental-strip-types scripts/migrate.ts --target preview --migration room-orientation",
     "migrate:preview:public-snapshots": "node --experimental-strip-types scripts/migrate.ts --target preview --migration public-snapshots",
+    "migrate:preview:payment-recovery-trigger-repair": "node --experimental-strip-types scripts/migrate.ts --target preview --migration payment-recovery-trigger-repair",
     "migrate:production:world-root-expand": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-expand",
     "migrate:production:world-root-topology": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-topology",
     "migrate:production:public-pagination": "node --experimental-strip-types scripts/migrate.ts --target production --migration public-pagination",
@@ -75,7 +76,8 @@
     "migrate:production:city-credit": "node --experimental-strip-types scripts/migrate.ts --target production --migration city-credit",
     "migrate:production:payment-recovery": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-recovery",
     "migrate:production:room-orientation": "node --experimental-strip-types scripts/migrate.ts --target production --migration room-orientation",
-    "migrate:production:public-snapshots": "node --experimental-strip-types scripts/migrate.ts --target production --migration public-snapshots"
+    "migrate:production:public-snapshots": "node --experimental-strip-types scripts/migrate.ts --target production --migration public-snapshots",
+    "migrate:production:payment-recovery-trigger-repair": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-recovery-trigger-repair"
   },
   "dependencies": {
     "@hono/node-server": "^2.1.0",

--- a/scripts/bob-payment-repair-apply.ts
+++ b/scripts/bob-payment-repair-apply.ts
@@ -1,11 +1,13 @@
 import { isDeepStrictEqual } from 'node:util'
 import { issueCityFeeCredit } from '../src/city-credit.ts'
 import {
-  BOB_COFFEE_REVIEW_REASON,
+  BOB_COFFEE_REPAIR_REASON,
   BOB_REPAIR_CREDIT_REASON,
   BOB_REPAIR_CREDIT_SOURCE_KEY,
+  BOB_REPAIR_EXPIRY_REASON,
   BOB_REPAIR_EXPECTATIONS,
   BOB_RESIDENT_ID,
+  BOB_THEBLUEAI_REPAIR_REASON,
   EXPECTED_PAYER,
   EXPECTED_RECIPIENT,
   EXPECTED_TOKEN,
@@ -77,7 +79,7 @@ function guardValues(guard: GuardedBobPaymentFacts): readonly unknown[] {
   ]
 }
 
-const EXACT_PENDING_GUARD_SQL = `
+const EXACT_EXPIRED_GUARD_SQL = `
     attempt.public_id = $1::text
     AND attempt.actor_id = $2::integer
     AND attempt.operation = 'frontier'
@@ -85,9 +87,9 @@ const EXACT_PENDING_GUARD_SQL = `
     AND attempt.target_key = $4::text
     AND attempt.request_hash = $5::text
     AND attempt.request_json = $6::jsonb
-    AND attempt.updated_at = $7::timestamptz
-    AND attempt.recovery_started_at = $8::timestamptz
-    AND attempt.recovery_deadline_at = $9::timestamptz
+    AND date_trunc('milliseconds', attempt.updated_at) = $7::timestamptz
+    AND date_trunc('milliseconds', attempt.recovery_started_at) = $8::timestamptz
+    AND date_trunc('milliseconds', attempt.recovery_deadline_at) = $9::timestamptz
     AND attempt.method = 'x402'
     AND attempt.network = $10::text
     AND attempt.token = lower($11::text)
@@ -98,20 +100,14 @@ const EXACT_PENDING_GUARD_SQL = `
     AND attempt.offer_id IS NULL
     AND attempt.asset_type IS NULL
     AND attempt.asset_id IS NULL
-    AND attempt.status = 'payment_pending'
-    AND (
-      (attempt.lease_owner IS NULL AND attempt.lease_expires_at IS NULL)
-      OR (
-        attempt.lease_owner IS NOT NULL
-        AND attempt.lease_expires_at IS NOT NULL
-        AND attempt.lease_expires_at <= clock_timestamp()
-      )
-    )
+    AND attempt.status = 'expired'
+    AND attempt.lease_owner IS NULL
+    AND attempt.lease_expires_at IS NULL
     AND attempt.finalized_block_number IS NULL
     AND attempt.finalized_block_hash IS NULL
     AND attempt.finalized_block_time IS NULL
     AND attempt.finalized_at IS NULL
-    AND attempt.invalid_reason IS NULL
+    AND attempt.invalid_reason = 'automatic payment recovery deadline passed'
     AND attempt.completed_at IS NULL
   `
 
@@ -121,7 +117,8 @@ async function completeTheBlueAI(
 ): Promise<void> {
   assertGuard(action.guard, BOB_REPAIR_EXPECTATIONS.theBlueAI)
   if (
-    action.attempt_id !== action.guard.attempt_id
+    action.source_state !== 'expired'
+    || action.attempt_id !== action.guard.attempt_id
     || action.transaction !== action.guard.transaction
     || action.resident_id !== BOB_RESIDENT_ID
     || action.name !== 'TheBlueAI'
@@ -149,7 +146,7 @@ async function completeTheBlueAI(
       AND root.owner_id IS NULL
       AND root.place_kind = 'world'
       AND root.name = 'the world'
-    WHERE ${EXACT_PENDING_GUARD_SQL}
+    WHERE ${EXACT_EXPIRED_GUARD_SQL}
       AND NOT EXISTS (
         SELECT 1 FROM places occupied WHERE lower(occupied.name) = lower($15::text)
       )
@@ -177,89 +174,43 @@ async function completeTheBlueAI(
     ON CONFLICT (resident_id) DO NOTHING
   `, [action.resident_id, placeId])
 
-  const useRows = (await database.query(`
-    /* bob-payment-repair-apply:payment-use */
-    INSERT INTO payment_uses (
-      tx_hash, payment_attempt_id, purpose, actor_id,
-      payer_wallet, payee_wallet, amount_usdc
-    )
-    SELECT lower($3::text), $1::text, 'frontier', $2::integer,
-      lower($12::text), lower($13::text), $14::numeric / 1000000::numeric
-    FROM payment_attempts attempt
-    WHERE ${EXACT_PENDING_GUARD_SQL}
-    RETURNING tx_hash
-  `, guardValues(action.guard))).rows
-  requireOneRow(useRows, 'TheBlueAI payment use')
-
-  const feeRows = (await database.query(`
-    /* bob-payment-repair-apply:fee */
-    INSERT INTO fees (resident_id, purpose, amount_usdc, tx_hash)
-    SELECT $2::integer, 'frontier', $14::numeric / 1000000::numeric, lower($3::text)
-    FROM payment_attempts attempt
-    JOIN payment_uses payment_use
-      ON payment_use.payment_attempt_id = attempt.public_id
-      AND payment_use.tx_hash = attempt.tx_hash
-    WHERE ${EXACT_PENDING_GUARD_SQL}
-    RETURNING id
-  `, guardValues(action.guard))).rows
-  requireOneRow(feeRows, 'TheBlueAI fee history')
-
-  const completedRows = (await database.query(`
-    /* bob-payment-repair-apply:complete-attempt */
-    WITH response AS MATERIALIZED (
-      SELECT jsonb_build_object(
-        'place', (to_jsonb(place) - 'front_matter_thing_ids')
-          || jsonb_build_object('owner', resident.handle),
-        'fee_tx', lower($3::text)
-      ) AS body
-      FROM places place
-      JOIN residents resident ON resident.id = $2::integer AND resident.handle = 'bob'
-      WHERE place.id = $15::integer
-        AND place.parent_id = $16::integer
-        AND place.place_kind = 'continent'
-        AND place.name = 'TheBlueAI'
-        AND place.owner_id = $2::integer
-    ), new_event AS (
+  const reviewedRows = (await database.query(`
+    /* bob-payment-repair-apply:review-theblueai */
+    WITH new_event AS (
       INSERT INTO events (kind, actor, detail)
-      SELECT 'place_created', 'bob', jsonb_build_object(
-        'place_id', $15::integer, 'parent_id', $16::integer,
-        'name', 'TheBlueAI', 'frontier', true, 'fee_tx_hash', lower($3::text)
+      SELECT 'payment_repair', 'host', jsonb_build_object(
+        'repair_key', $20::text,
+        'attempt_id', $1::text,
+        'transaction', lower($3::text),
+        'resident_id', $2::integer,
+        'source_status', 'expired',
+        'payment_status', 'founder_review',
+        'place_id', $15::integer,
+        'parent_id', $16::integer,
+        'place_name', 'TheBlueAI',
+        'outcome', $21::text
       )
-      FROM response
+      FROM payment_attempts attempt
+      WHERE ${EXACT_EXPIRED_GUARD_SQL}
+        AND NOT EXISTS (
+          SELECT 1 FROM events existing
+          WHERE existing.kind = 'payment_repair'
+            AND existing.detail->>'repair_key' = $20::text
+        )
       RETURNING id
     )
     UPDATE payment_attempts attempt
-    SET status = 'completed',
+    SET status = 'founder_review',
       finalized_block_number = $17::bigint,
       finalized_block_hash = lower($18::text),
       finalized_block_time = $19::timestamptz,
       finalized_at = clock_timestamp(),
-      result_json = jsonb_build_object('kind', 'place', 'id', $15::integer),
-      response_status = 201,
-      response_json = CASE
-        WHEN attempt.response_json #>> '{__1f3d9_x402_response_v1,header}' IS NULL
-          THEN response.body
-        ELSE jsonb_build_object(
-          '__1f3d9_x402_response_v1',
-          jsonb_build_object(
-            'header', attempt.response_json #>> '{__1f3d9_x402_response_v1,header}',
-            'body', response.body
-          )
-        )
-      END,
-      response_body_bytes = convert_to(response.body::text, 'UTF8'),
-      completed_at = clock_timestamp(),
+      invalid_reason = $22::text,
       lease_owner = NULL,
       lease_expires_at = NULL,
       updated_at = clock_timestamp()
-    FROM response, new_event
-    WHERE ${EXACT_PENDING_GUARD_SQL}
-      AND char_length(
-        attempt.response_json #>> '{__1f3d9_x402_response_v1,header}'
-      ) BETWEEN 1 AND 87384
-      AND (
-        attempt.response_json #>> '{__1f3d9_x402_response_v1,header}'
-      ) ~ '^[A-Za-z0-9+/]+={0,2}$'
+    FROM new_event
+    WHERE ${EXACT_EXPIRED_GUARD_SQL}
     RETURNING attempt.public_id
   `, [
     ...guardValues(action.guard),
@@ -268,9 +219,12 @@ async function completeTheBlueAI(
     action.guard.canonical_block_number,
     action.guard.canonical_block_hash,
     action.guard.canonical_block_time,
+    `bob-payment-repair:${action.attempt_id}`,
+    BOB_THEBLUEAI_REPAIR_REASON,
+    BOB_REPAIR_EXPIRY_REASON,
   ])).rows
-  const completed = requireOneRow(completedRows, 'TheBlueAI attempt completion')
-  if (completed.public_id !== action.attempt_id) abort('TheBlueAI completed attempt changed')
+  const reviewed = requireOneRow(reviewedRows, 'TheBlueAI founder review')
+  if (reviewed.public_id !== action.attempt_id) abort('TheBlueAI reviewed attempt changed')
 }
 
 async function closeCoffeeProbe(
@@ -279,33 +233,57 @@ async function closeCoffeeProbe(
 ): Promise<void> {
   assertGuard(action.guard, BOB_REPAIR_EXPECTATIONS.coffee)
   if (
-    action.attempt_id !== action.guard.attempt_id
+    action.source_state !== 'expired'
+    || action.attempt_id !== action.guard.attempt_id
     || action.transaction !== action.guard.transaction
     || action.resident_id !== BOB_RESIDENT_ID
     || action.terminal_state !== 'founder_review'
-    || action.reason !== BOB_COFFEE_REVIEW_REASON
+    || action.reason !== BOB_COFFEE_REPAIR_REASON
   ) abort('coffee-shop approved closure action changed')
 
   const rows = (await database.query(`
     /* bob-payment-repair-apply:close-coffee */
+    WITH new_event AS (
+      INSERT INTO events (kind, actor, detail)
+      SELECT 'payment_repair', 'host', jsonb_build_object(
+        'repair_key', $18::text,
+        'attempt_id', $1::text,
+        'transaction', lower($3::text),
+        'resident_id', $2::integer,
+        'source_status', 'expired',
+        'payment_status', 'founder_review',
+        'outcome', $19::text
+      )
+      FROM payment_attempts attempt
+      WHERE ${EXACT_EXPIRED_GUARD_SQL}
+        AND NOT EXISTS (
+          SELECT 1 FROM events existing
+          WHERE existing.kind = 'payment_repair'
+            AND existing.detail->>'repair_key' = $18::text
+        )
+      RETURNING id
+    )
     UPDATE payment_attempts attempt
     SET status = 'founder_review',
       finalized_block_number = $15::bigint,
       finalized_block_hash = lower($16::text),
       finalized_block_time = $17::timestamptz,
       finalized_at = clock_timestamp(),
-      invalid_reason = $18::text,
+      invalid_reason = $20::text,
       lease_owner = NULL,
       lease_expires_at = NULL,
       updated_at = clock_timestamp()
-    WHERE ${EXACT_PENDING_GUARD_SQL}
+    FROM new_event
+    WHERE ${EXACT_EXPIRED_GUARD_SQL}
     RETURNING attempt.public_id
   `, [
     ...guardValues(action.guard),
     action.guard.canonical_block_number,
     action.guard.canonical_block_hash,
     action.guard.canonical_block_time,
+    `bob-payment-repair:${action.attempt_id}`,
     action.reason,
+    BOB_REPAIR_EXPIRY_REASON,
   ])).rows
   const closed = requireOneRow(rows, 'coffee-shop founder review')
   if (closed.public_id !== action.attempt_id) abort('coffee-shop closed attempt changed')

--- a/scripts/bob-payment-repair-model.ts
+++ b/scripts/bob-payment-repair-model.ts
@@ -1,10 +1,13 @@
 import { USDC, type TransferCheck } from '../src/chain.ts'
 
 export const BOB_REPAIR_APPLY_ACKNOWLEDGEMENT = 'APPLY_BOB_PAYMENT_REPAIR_WAVE_15'
-export const BOB_COFFEE_REVIEW_REASON =
-  'Founder-approved no-effect closure for the paid coffee-shop probe; compensating city fee credit is tracked by its deterministic source key.'
+export const BOB_REPAIR_EXPIRY_REASON = 'automatic payment recovery deadline passed'
+export const BOB_COFFEE_REPAIR_REASON =
+  'host stored the settled payment proof, created no place, and issued one city fee credit'
 export const BOB_REPAIR_CREDIT_REASON =
   'Extra finalized coffee-shop probe payment; no place was created.'
+export const BOB_THEBLUEAI_REPAIR_REASON =
+  'host created the paid place after automatic recovery expired the settled payment'
 
 export const BOB_RESIDENT_ID = 68
 export const BOB_HANDLE = 'bob'
@@ -94,6 +97,7 @@ export type BobRepairSnapshot = Readonly<{
   worldRoots: readonly QueryRow[]
   places: readonly QueryRow[]
   credits: readonly QueryRow[]
+  events: readonly QueryRow[]
 }>
 
 export type BobTransferEvidence = TransferCheck
@@ -121,6 +125,7 @@ export type GuardedBobPaymentFacts = Readonly<{
 
 export type CompleteTheBlueAIAction = Readonly<{
   kind: 'complete_theblueai'
+  source_state: 'expired'
   attempt_id: string
   transaction: string
   resident_id: 68
@@ -138,6 +143,7 @@ export type CompleteTheBlueAIAction = Readonly<{
 
 export type CloseCoffeeProbeAction = Readonly<{
   kind: 'close_coffee_probe'
+  source_state: 'expired'
   attempt_id: string
   transaction: string
   resident_id: 68

--- a/scripts/repair-bob-payments.ts
+++ b/scripts/repair-bob-payments.ts
@@ -16,19 +16,20 @@ import {
   type DatabaseIdentity,
 } from './database-target.ts'
 import {
-  BOB_COFFEE_REVIEW_REASON,
+  BOB_COFFEE_REPAIR_REASON,
   BOB_HANDLE,
   BOB_REPAIR_APPLY_ACKNOWLEDGEMENT,
   BOB_REPAIR_CREDIT_REASON,
   BOB_REPAIR_CREDIT_SOURCE_KEY,
+  BOB_REPAIR_EXPIRY_REASON,
   BOB_REPAIR_EXPECTATIONS,
   BOB_RESIDENT_ID,
+  BOB_THEBLUEAI_REPAIR_REASON,
   BobPaymentRepairAbortError,
   EXPECTED_PAYER,
   EXPECTED_RECIPIENT,
   EXPECTED_TOKEN,
   FOUNDER_RESIDENT_ID,
-  ONE_USDC,
   ONE_USDC_UNITS,
   abort,
   boolean,
@@ -51,11 +52,13 @@ import {
 } from './bob-payment-repair-model.ts'
 
 export {
-  BOB_COFFEE_REVIEW_REASON,
+  BOB_COFFEE_REPAIR_REASON,
   BOB_REPAIR_APPLY_ACKNOWLEDGEMENT,
   BOB_REPAIR_CREDIT_REASON,
   BOB_REPAIR_CREDIT_SOURCE_KEY,
+  BOB_REPAIR_EXPIRY_REASON,
   BOB_REPAIR_EXPECTATIONS,
+  BOB_THEBLUEAI_REPAIR_REASON,
   BobPaymentRepairAbortError,
 } from './bob-payment-repair-model.ts'
 
@@ -120,34 +123,22 @@ function observedRepairTimestamp(row: QueryRow, expected: AttemptExpectation): s
   return updatedAt
 }
 
-function validateRepairableLease(row: QueryRow, expected: AttemptExpectation): void {
-  const hasOwner = row.lease_owner != null
-  const hasExpiry = row.lease_expires_at != null
-  if (!hasOwner && !hasExpiry) return
-  const expiry = iso(row.lease_expires_at)
-  const databaseNow = iso(row.database_now)
-  if (
-    hasOwner !== hasExpiry
-    || expiry == null
-    || databaseNow == null
-    || Date.parse(expiry) > Date.parse(databaseNow)
-  ) abort(`${expected.attemptId} has an active or malformed recovery lease`)
-}
-
-function validatePendingAttempt(row: QueryRow, expected: AttemptExpectation): string {
+function validateExpiredAttempt(row: QueryRow, expected: AttemptExpectation): string {
   validateAttemptImmutable(row, expected)
-  validateRepairableLease(row, expected)
+  if (row.lease_owner != null || row.lease_expires_at != null) {
+    abort(`${expected.attemptId} expired state retained a recovery lease`)
+  }
   const updatedAt = observedRepairTimestamp(row, expected)
   const finalityIsEmpty = row.finalized_block_number == null
     && row.finalized_block_hash == null
     && row.finalized_block_time == null
     && row.finalized_at == null
   if (
-    text(row, 'status') !== 'payment_pending'
+    text(row, 'status') !== 'expired'
     || !finalityIsEmpty
-    || row.invalid_reason != null
+    || text(row, 'invalid_reason') !== BOB_REPAIR_EXPIRY_REASON
     || row.completed_at != null
-  ) abort(`${expected.attemptId} pending state or stored finality changed`)
+  ) abort(`${expected.attemptId} expired state or stored finality changed`)
   return updatedAt
 }
 
@@ -180,23 +171,6 @@ function validateChainEvidence(
   ) abort(`${expected.txHash} canonical transfer facts changed`)
 }
 
-function rowsForAttempt(
-  rows: readonly QueryRow[],
-  expected: AttemptExpectation,
-): readonly QueryRow[] {
-  return rows.filter(row => (
-    text(row, 'payment_attempt_id') === expected.attemptId
-    || text(row, 'tx_hash')?.toLowerCase() === expected.txHash
-  ))
-}
-
-function rowsForTransaction(
-  rows: readonly QueryRow[],
-  expected: AttemptExpectation,
-): readonly QueryRow[] {
-  return rows.filter(row => text(row, 'tx_hash')?.toLowerCase() === expected.txHash)
-}
-
 function matchingNamePlaces(snapshot: BobRepairSnapshot, name: string): readonly QueryRow[] {
   return snapshot.places.filter(row => text(row, 'name')?.toLowerCase() === name.toLowerCase())
 }
@@ -219,8 +193,8 @@ function validateInitialState(snapshot: BobRepairSnapshot): Readonly<{
     snapshot.attempts.filter(row => text(row, 'public_id') === BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId),
     'TheBlueAI attempt',
   )
-  validatePendingAttempt(coffee, BOB_REPAIR_EXPECTATIONS.coffee)
-  validatePendingAttempt(theBlueAI, BOB_REPAIR_EXPECTATIONS.theBlueAI)
+  validateExpiredAttempt(coffee, BOB_REPAIR_EXPECTATIONS.coffee)
+  validateExpiredAttempt(theBlueAI, BOB_REPAIR_EXPECTATIONS.theBlueAI)
   exactRow(snapshot.worldRoots, 'world root')
   const root = snapshot.worldRoots[0]!
   if (
@@ -233,28 +207,12 @@ function validateInitialState(snapshot: BobRepairSnapshot): Readonly<{
   if (snapshot.fees.length !== 0) abort('one of Bob\'s transaction hashes already has a fee row')
   if (snapshot.places.length !== 0) abort('TheBlueAI or coffee-shop is no longer available')
   if (snapshot.credits.length !== 0) abort('the deterministic founder credit source is already occupied')
+  if (snapshot.events.length !== 0) abort('the deterministic repair event keys are already occupied')
   return Object.freeze({
     worldRootId: integer(root, 'id')!,
     coffee,
     theBlueAI,
   })
-}
-
-function exactPaymentUse(row: QueryRow, expected: AttemptExpectation): boolean {
-  return text(row, 'tx_hash')?.toLowerCase() === expected.txHash
-    && text(row, 'payment_attempt_id') === expected.attemptId
-    && integer(row, 'actor_id') === BOB_RESIDENT_ID
-    && text(row, 'purpose') === 'frontier'
-    && normalizedWallet(row.payer_wallet) === EXPECTED_PAYER
-    && normalizedWallet(row.payee_wallet) === EXPECTED_RECIPIENT
-    && text(row, 'amount_usdc') === ONE_USDC
-}
-
-function exactFee(row: QueryRow, expected: AttemptExpectation): boolean {
-  return integer(row, 'resident_id') === BOB_RESIDENT_ID
-    && text(row, 'purpose') === 'frontier'
-    && text(row, 'amount_usdc') === ONE_USDC
-    && text(row, 'tx_hash')?.toLowerCase() === expected.txHash
 }
 
 function exactTheBlueAIPlace(row: QueryRow, rootId: number): boolean {
@@ -276,6 +234,31 @@ function exactFounderCredit(row: QueryRow): boolean {
     && integer(row, 'founder_id') === FOUNDER_RESIDENT_ID
     && text(row, 'source_key') === BOB_REPAIR_CREDIT_SOURCE_KEY
     && text(row, 'reason') === BOB_REPAIR_CREDIT_REASON
+}
+
+function repairEventKey(expected: AttemptExpectation): string {
+  return `bob-payment-repair:${expected.attemptId}`
+}
+
+function exactRepairEvent(
+  row: QueryRow,
+  expected: AttemptExpectation,
+  outcome: string,
+  extras: Readonly<Record<string, unknown>> = {},
+): boolean {
+  const detail = row.detail
+  if (!detail || typeof detail !== 'object' || Array.isArray(detail)) return false
+  const record = detail as Readonly<Record<string, unknown>>
+  return text(row, 'kind') === 'payment_repair'
+    && text(row, 'actor') === 'host'
+    && text(record, 'repair_key') === repairEventKey(expected)
+    && text(record, 'attempt_id') === expected.attemptId
+    && text(record, 'transaction')?.toLowerCase() === expected.txHash
+    && integer(record, 'resident_id') === BOB_RESIDENT_ID
+    && text(record, 'source_status') === 'expired'
+    && text(record, 'payment_status') === 'founder_review'
+    && text(record, 'outcome') === outcome
+    && Object.entries(extras).every(([key, value]) => record[key] === value)
 }
 
 function validateFinalState(snapshot: BobRepairSnapshot): void {
@@ -312,25 +295,16 @@ function validateFinalState(snapshot: BobRepairSnapshot): void {
   validateStoredFinality(theBlueAI, BOB_REPAIR_EXPECTATIONS.theBlueAI)
   if (
     text(coffee, 'status') !== 'founder_review'
-    || text(coffee, 'invalid_reason') !== BOB_COFFEE_REVIEW_REASON
+    || text(coffee, 'invalid_reason') !== BOB_REPAIR_EXPIRY_REASON
     || coffee.completed_at != null
   ) abort('coffee-shop is not the exact closed founder-review outcome')
   if (
-    text(theBlueAI, 'status') !== 'completed'
-    || theBlueAI.invalid_reason != null
-    || iso(theBlueAI.completed_at) == null
-  ) abort('TheBlueAI attempt is not the exact completed outcome')
-
-  const coffeeUses = rowsForAttempt(snapshot.paymentUses, BOB_REPAIR_EXPECTATIONS.coffee)
-  const blueUses = rowsForAttempt(snapshot.paymentUses, BOB_REPAIR_EXPECTATIONS.theBlueAI)
-  if (coffeeUses.length !== 0 || blueUses.length !== 1 || !exactPaymentUse(blueUses[0]!, BOB_REPAIR_EXPECTATIONS.theBlueAI)) {
-    abort('payment use history is not the exact approved outcome')
-  }
-  const coffeeFees = rowsForTransaction(snapshot.fees, BOB_REPAIR_EXPECTATIONS.coffee)
-  const blueFees = rowsForTransaction(snapshot.fees, BOB_REPAIR_EXPECTATIONS.theBlueAI)
-  if (coffeeFees.length !== 0 || blueFees.length !== 1 || !exactFee(blueFees[0]!, BOB_REPAIR_EXPECTATIONS.theBlueAI)) {
-    abort('fee history is not the exact approved outcome')
-  }
+    text(theBlueAI, 'status') !== 'founder_review'
+    || text(theBlueAI, 'invalid_reason') !== BOB_REPAIR_EXPIRY_REASON
+    || theBlueAI.completed_at != null
+  ) abort('TheBlueAI attempt is not the exact founder-review correction')
+  if (snapshot.paymentUses.length !== 0) abort('payment use history is not the exact approved outcome')
+  if (snapshot.fees.length !== 0) abort('fee history is not the exact approved outcome')
   const coffeePlaces = matchingNamePlaces(snapshot, 'coffee-shop')
   const bluePlaces = matchingNamePlaces(snapshot, 'TheBlueAI')
   if (coffeePlaces.length !== 0 || bluePlaces.length !== 1 || !exactTheBlueAIPlace(bluePlaces[0]!, rootId)) {
@@ -339,6 +313,28 @@ function validateFinalState(snapshot: BobRepairSnapshot): void {
   if (snapshot.credits.length !== 1 || !exactFounderCredit(snapshot.credits[0]!)) {
     abort('founder credit history is not the exact approved outcome')
   }
+  if (snapshot.events.length !== 2) abort('payment repair event history is not the exact approved outcome')
+  const coffeeEvent = snapshot.events.find(row => {
+    const detail = row.detail
+    return detail && typeof detail === 'object' && !Array.isArray(detail)
+      && text(detail as QueryRow, 'attempt_id') === BOB_REPAIR_EXPECTATIONS.coffee.attemptId
+  })
+  const blueEvent = snapshot.events.find(row => {
+    const detail = row.detail
+    return detail && typeof detail === 'object' && !Array.isArray(detail)
+      && text(detail as QueryRow, 'attempt_id') === BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId
+  })
+  if (
+    !coffeeEvent
+    || !blueEvent
+    || !exactRepairEvent(coffeeEvent, BOB_REPAIR_EXPECTATIONS.coffee, BOB_COFFEE_REPAIR_REASON)
+    || !exactRepairEvent(
+      blueEvent,
+      BOB_REPAIR_EXPECTATIONS.theBlueAI,
+      BOB_THEBLUEAI_REPAIR_REASON,
+      { place_name: 'TheBlueAI', place_id: integer(bluePlaces[0]!, 'id') },
+    )
+  ) abort('payment repair event history is not the exact approved outcome')
 }
 
 function hasFinalStateSignal(snapshot: BobRepairSnapshot): boolean {
@@ -404,6 +400,7 @@ export function buildBobPaymentRepairPlan(
     actions: Object.freeze([
       Object.freeze({
         kind: 'complete_theblueai',
+        source_state: 'expired',
         attempt_id: BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId,
         transaction: BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
         resident_id: BOB_RESIDENT_ID,
@@ -420,11 +417,12 @@ export function buildBobPaymentRepairPlan(
       }),
       Object.freeze({
         kind: 'close_coffee_probe',
+        source_state: 'expired',
         attempt_id: BOB_REPAIR_EXPECTATIONS.coffee.attemptId,
         transaction: BOB_REPAIR_EXPECTATIONS.coffee.txHash,
         resident_id: BOB_RESIDENT_ID,
         terminal_state: 'founder_review',
-        reason: BOB_COFFEE_REVIEW_REASON,
+        reason: BOB_COFFEE_REPAIR_REASON,
         guard: guardedPayment(BOB_REPAIR_EXPECTATIONS.coffee, initial.coffee),
       }),
       Object.freeze({
@@ -562,6 +560,10 @@ export async function readBobRepairSnapshot(
     BOB_REPAIR_EXPECTATIONS.coffee.txHash,
     BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
   ]
+  const repairKeys = [
+    repairEventKey(BOB_REPAIR_EXPECTATIONS.coffee),
+    repairEventKey(BOB_REPAIR_EXPECTATIONS.theBlueAI),
+  ]
 
   const residents = await queryRows(database, `
     /* bob-payment-repair:residents */
@@ -581,8 +583,8 @@ export async function readBobRepairSnapshot(
       attempt.recovery_started_at, attempt.recovery_deadline_at, attempt.tx_hash,
       attempt.finalized_block_number::text AS finalized_block_number,
       attempt.finalized_block_hash, attempt.finalized_block_time, attempt.finalized_at,
-      attempt.invalid_reason, attempt.updated_at, attempt.completed_at
-      , clock_timestamp() AS database_now
+      attempt.invalid_reason, attempt.updated_at, attempt.completed_at,
+      clock_timestamp() AS database_now
     FROM payment_attempts attempt
     LEFT JOIN residents resident ON resident.id = attempt.actor_id
     WHERE attempt.public_id = ANY($1::text[])
@@ -632,6 +634,18 @@ export async function readBobRepairSnapshot(
     ORDER BY id
     ${historyLock}
   `, [BOB_REPAIR_CREDIT_SOURCE_KEY])
+  const events = await queryRows(database, `
+    /* bob-payment-repair:events */
+    SELECT kind, actor, detail
+    FROM events
+    WHERE kind = 'payment_repair'
+      AND (
+        detail->>'attempt_id' = ANY($1::text[])
+        OR detail->>'repair_key' = ANY($2::text[])
+      )
+    ORDER BY id
+    ${historyLock}
+  `, [attemptIds, repairKeys])
 
   return Object.freeze({
     residents: Object.freeze([...residents]),
@@ -641,6 +655,7 @@ export async function readBobRepairSnapshot(
     worldRoots: Object.freeze([...worldRoots]),
     places: Object.freeze([...places]),
     credits: Object.freeze([...credits]),
+    events: Object.freeze([...events]),
   })
 }
 

--- a/src/payment-recovery-runtime.ts
+++ b/src/payment-recovery-runtime.ts
@@ -266,9 +266,17 @@ function mergedServices(
 }
 
 function logRecoveryFailure(attempt: PaymentRecoveryAttempt, error: unknown): void {
-  const detail = error instanceof Error
+  const rawDetail = error instanceof Error
     ? `${error.name}: ${error.message}`
     : String(error)
+  const detail = rawDetail
+    .replace(/postgres(?:ql)?:\/\/[^\s"']+/giu, '[redacted database URL]')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/giu, 'Bearer [redacted]')
+    .replace(/1f3d9_sk_[A-Za-z0-9_-]+/giu, '[redacted resident key]')
+    .slice(0, 400)
+  const code = error && typeof error === 'object' && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '').slice(0, 32)
+    : ''
   console.error('payment recovery attempt failed', {
     attemptId: attempt.publicId,
     actorId: attempt.actorId,
@@ -276,6 +284,7 @@ function logRecoveryFailure(attempt: PaymentRecoveryAttempt, error: unknown): vo
     method: attempt.method,
     status: attempt.status,
     recoveryDeadlineAt: attempt.recoveryDeadlineAt,
+    errorCode: code || null,
     error: detail,
   })
 }

--- a/src/public-events.ts
+++ b/src/public-events.ts
@@ -28,6 +28,7 @@ export const PUBLIC_EVENT_LABELS = Object.freeze({
   world_listed: 'listed a thing on the world market',
   world_sale: 'bought a thing through the world market',
   world_cancel: 'canceled a world market listing',
+  payment_repair: 'recorded a host payment correction',
   flag: 'flagged a public record',
   moderation: 'used a logged maintainer power',
 })

--- a/test/bob-payment-repair-apply.test.ts
+++ b/test/bob-payment-repair-apply.test.ts
@@ -4,6 +4,7 @@ import {
   BOB_REPAIR_EXPECTATIONS,
   BOB_REPAIR_CREDIT_REASON,
   BOB_REPAIR_CREDIT_SOURCE_KEY,
+  BOB_REPAIR_EXPIRY_REASON,
   buildBobPaymentRepairPlan,
   type BobRepairSnapshot,
   type BobTransferEvidence,
@@ -35,7 +36,7 @@ function attempt(key: 'coffee' | 'theBlueAI') {
     payer_wallet: BOB_REPAIR_EXPECTATIONS.payer,
     payee_wallet: BOB_REPAIR_EXPECTATIONS.recipient,
     amount_units: '1000000',
-    status: 'payment_pending',
+    status: 'expired',
     lease_owner: null,
     lease_expires_at: null,
     recovery_started_at: expected.recoveryStartedAt,
@@ -45,7 +46,7 @@ function attempt(key: 'coffee' | 'theBlueAI') {
     finalized_block_hash: null,
     finalized_block_time: null,
     finalized_at: null,
-    invalid_reason: null,
+    invalid_reason: BOB_REPAIR_EXPIRY_REASON,
     completed_at: null,
     updated_at: expected.updatedAt,
     database_now: '2026-08-23T12:00:00.000Z',
@@ -61,6 +62,7 @@ function snapshot(): BobRepairSnapshot {
     worldRoots: [{ id: 1, name: 'the world', place_kind: 'world', owner_id: null }],
     places: [],
     credits: [],
+    events: [],
   }
 }
 
@@ -97,11 +99,7 @@ class RecordingDatabase {
   async query(text: string, values: readonly unknown[] = []) {
     this.calls.push({ text, values })
     if (text.includes('bob-payment-repair-apply:create-place')) return { rows: [{ id: 901 }] }
-    if (text.includes('bob-payment-repair-apply:payment-use')) {
-      return { rows: [{ tx_hash: BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash }] }
-    }
-    if (text.includes('bob-payment-repair-apply:fee')) return { rows: [{ id: 811 }] }
-    if (text.includes('bob-payment-repair-apply:complete-attempt')) {
+    if (text.includes('bob-payment-repair-apply:review-theblueai')) {
       return { rows: [{ public_id: BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId }] }
     }
     if (text.includes('bob-payment-repair-apply:close-coffee')) {
@@ -130,16 +128,16 @@ test('approved Bob apply operations use only the supplied transaction and exact 
 
   const text = database.calls.map(call => call.text).join('\n')
   assert.match(text, /bob-payment-repair-apply:create-place/iu)
-  assert.match(text, /bob-payment-repair-apply:complete-attempt/iu)
+  assert.match(text, /bob-payment-repair-apply:review-theblueai/iu)
   assert.match(text, /bob-payment-repair-apply:close-coffee/iu)
   assert.match(text, /city-credit:issue/iu)
   assert.match(text, /request_hash/iu)
   assert.match(text, /recovery_started_at/iu)
   assert.match(text, /recovery_deadline_at/iu)
   assert.match(text, /finalized_block_number/iu)
-  assert.match(text, /INSERT INTO payment_uses/iu)
-  assert.match(text, /INSERT INTO fees/iu)
   assert.match(text, /INSERT INTO events/iu)
+  assert.doesNotMatch(text, /INSERT INTO payment_uses|INSERT INTO fees/iu)
+  assert.match(text, /status\s*=\s*'founder_review'/iu)
   assert.doesNotMatch(text, /CREATE\s+(?:ROLE|USER)|ALTER\s+ROLE|session_replication_role/iu)
 
   const values = database.calls.flatMap(call => [...call.values]).map(String)
@@ -168,14 +166,12 @@ test('an operation that cannot affect exactly one approved row aborts', async ()
   )
 })
 
-test('apply guards accept only the exact observed update time with a null or expired lease', async () => {
+test('apply guards require the exact expired row with no lease', async () => {
   const base = snapshot()
   const expired: BobRepairSnapshot = {
     ...base,
     attempts: base.attempts.map((row, index) => ({
       ...row,
-      lease_owner: 'expired-cron-lease',
-      lease_expires_at: `2026-08-23T11:59:3${index}.000Z`,
       updated_at: `2026-08-23T11:59:0${index}.000Z`,
     })),
   }
@@ -194,7 +190,8 @@ test('apply guards accept only the exact observed update time with a null or exp
   assert.ok(guarded)
   assert.match(
     guarded.text,
-    /lease_owner\s+IS\s+NULL[\s\S]*lease_expires_at\s+IS\s+NULL[\s\S]*OR[\s\S]*lease_owner\s+IS\s+NOT\s+NULL[\s\S]*lease_expires_at\s*<=\s*clock_timestamp\(\)/iu,
+    /status\s*=\s*'expired'[\s\S]*lease_owner\s+IS\s+NULL[\s\S]*lease_expires_at\s+IS\s+NULL[\s\S]*invalid_reason\s*=\s*'automatic payment recovery deadline passed'/iu,
   )
+  assert.doesNotMatch(guarded.text, /lease_owner\s+IS\s+NOT\s+NULL/iu)
   assert.ok(guarded.values.map(String).includes('2026-08-23T11:59:01.000Z'))
 })

--- a/test/bob-payment-repair.test.ts
+++ b/test/bob-payment-repair.test.ts
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
-  BOB_COFFEE_REVIEW_REASON,
+  BOB_COFFEE_REPAIR_REASON,
   BOB_REPAIR_APPLY_ACKNOWLEDGEMENT,
   BOB_REPAIR_CREDIT_REASON,
   BOB_REPAIR_CREDIT_SOURCE_KEY,
+  BOB_REPAIR_EXPIRY_REASON,
   BOB_REPAIR_EXPECTATIONS,
+  BOB_THEBLUEAI_REPAIR_REASON,
   BobPaymentRepairAbortError,
   buildBobPaymentRepairPlan,
   parseBobPaymentRepairArgs,
@@ -60,7 +62,7 @@ function expectedAttempt(
     payer_wallet: BOB_REPAIR_EXPECTATIONS.payer,
     payee_wallet: BOB_REPAIR_EXPECTATIONS.recipient,
     amount_units: '1000000',
-    status: 'payment_pending',
+    status: 'expired',
     lease_owner: null,
     lease_expires_at: null,
     recovery_started_at: expected.recoveryStartedAt,
@@ -70,7 +72,7 @@ function expectedAttempt(
     finalized_block_hash: null,
     finalized_block_time: null,
     finalized_at: null,
-    invalid_reason: null,
+    invalid_reason: BOB_REPAIR_EXPIRY_REASON,
     completed_at: null,
     updated_at: expected.updatedAt,
     database_now: '2026-08-23T12:00:00.000Z',
@@ -110,6 +112,7 @@ function initialSnapshot(): BobRepairSnapshot {
     worldRoots: [{ id: 1, name: 'the world', place_kind: 'world', owner_id: null }],
     places: [],
     credits: [],
+    events: [],
   }
 }
 
@@ -125,34 +128,21 @@ function finalSnapshot(): BobRepairSnapshot {
         finalized_block_hash: BOB_REPAIR_EXPECTATIONS.coffee.blockHash,
         finalized_block_time: BOB_REPAIR_EXPECTATIONS.coffee.blockTime,
         finalized_at: '2026-08-22T12:00:00.000Z',
-        invalid_reason: BOB_COFFEE_REVIEW_REASON,
+        invalid_reason: BOB_REPAIR_EXPIRY_REASON,
         updated_at: '2026-08-22T12:00:01.000Z',
       }),
       expectedAttempt('theBlueAI', {
-        status: 'completed',
+        status: 'founder_review',
         finalized_block_number: BOB_REPAIR_EXPECTATIONS.theBlueAI.blockNumber,
         finalized_block_hash: BOB_REPAIR_EXPECTATIONS.theBlueAI.blockHash,
         finalized_block_time: BOB_REPAIR_EXPECTATIONS.theBlueAI.blockTime,
         finalized_at: '2026-08-22T12:00:00.000Z',
-        completed_at: '2026-08-22T12:00:01.000Z',
+        invalid_reason: BOB_REPAIR_EXPIRY_REASON,
         updated_at: '2026-08-22T12:00:01.000Z',
       }),
     ],
-    paymentUses: [{
-      tx_hash: BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
-      payment_attempt_id: BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId,
-      actor_id: 68,
-      purpose: 'frontier',
-      payer_wallet: BOB_REPAIR_EXPECTATIONS.payer,
-      payee_wallet: BOB_REPAIR_EXPECTATIONS.recipient,
-      amount_usdc: '1.000000',
-    }],
-    fees: [{
-      resident_id: 68,
-      purpose: 'frontier',
-      amount_usdc: '1.000000',
-      tx_hash: BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
-    }],
+    paymentUses: [],
+    fees: [],
     places: [{
       id: 901,
       parent_id: 1,
@@ -172,6 +162,36 @@ function finalSnapshot(): BobRepairSnapshot {
       source_key: BOB_REPAIR_CREDIT_SOURCE_KEY,
       reason: BOB_REPAIR_CREDIT_REASON,
     }],
+    events: [
+      {
+        kind: 'payment_repair',
+        actor: 'host',
+        detail: {
+          repair_key: `bob-payment-repair:${BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId}`,
+          attempt_id: BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId,
+          resident_id: 68,
+          source_status: 'expired',
+          outcome: BOB_THEBLUEAI_REPAIR_REASON,
+          payment_status: 'founder_review',
+          place_id: 901,
+          place_name: 'TheBlueAI',
+          transaction: BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
+        },
+      },
+      {
+        kind: 'payment_repair',
+        actor: 'host',
+        detail: {
+          repair_key: `bob-payment-repair:${BOB_REPAIR_EXPECTATIONS.coffee.attemptId}`,
+          attempt_id: BOB_REPAIR_EXPECTATIONS.coffee.attemptId,
+          resident_id: 68,
+          source_status: 'expired',
+          outcome: BOB_COFFEE_REPAIR_REASON,
+          payment_status: 'founder_review',
+          transaction: BOB_REPAIR_EXPECTATIONS.coffee.txHash,
+        },
+      },
+    ],
   }
 }
 
@@ -190,7 +210,7 @@ test('guarded Bob constants preserve the independently verified production facts
   assert.equal(BOB_REPAIR_CREDIT_SOURCE_KEY, `bob-payment-repair:${BOB_REPAIR_EXPECTATIONS.coffee.attemptId}`)
 })
 
-test('pure planning proposes exactly one frontier, one no-effect close, and one credit', () => {
+test('pure planning proposes exactly one place repair, one no-effect close, and one credit', () => {
   const plan = buildBobPaymentRepairPlan(initialSnapshot(), transfers())
 
   assert.equal(plan.state, 'work_required')
@@ -217,20 +237,18 @@ test('pure planning proposes exactly one frontier, one no-effect close, and one 
     open_to_notes: false,
   })
   assert.equal(complete?.guard.canonical_block_hash, BOB_REPAIR_EXPECTATIONS.theBlueAI.blockHash)
+  assert.equal(complete?.source_state, 'expired')
   assert.equal(close?.guard.request_hash, BOB_REPAIR_EXPECTATIONS.coffee.requestHash)
   assert.equal(close?.guard.recovery_deadline_at, BOB_REPAIR_EXPECTATIONS.coffee.recoveryDeadlineAt)
+  assert.equal(close?.source_state, 'expired')
 })
 
-test('an expired automatic lease is repairable and its observed update time becomes the exact guard', () => {
+test('the observed expiry time becomes the exact repair guard', () => {
   const snapshot = cloneSnapshot(initialSnapshot())
   snapshot.attempts[0] = expectedAttempt('coffee', {
-    lease_owner: 'expired-cron-lease',
-    lease_expires_at: '2026-08-23T11:59:30.000Z',
     updated_at: '2026-08-23T11:59:00.000Z',
   })
   snapshot.attempts[1] = expectedAttempt('theBlueAI', {
-    lease_owner: 'expired-cron-lease',
-    lease_expires_at: '2026-08-23T11:59:31.000Z',
     updated_at: '2026-08-23T11:59:01.000Z',
   })
 
@@ -242,17 +260,29 @@ test('an expired automatic lease is repairable and its observed update time beco
   assert.equal(close?.guard.expected_updated_at, '2026-08-23T11:59:00.000Z')
 })
 
-test('active, malformed, future-dated, or backward-moving lease state is never repairable', () => {
+test('pending rows are rejected because production already moved both attempts to expired', () => {
+  const snapshot = cloneSnapshot(initialSnapshot())
+  snapshot.attempts[0] = expectedAttempt('coffee', {
+    status: 'payment_pending',
+    invalid_reason: null,
+  })
+
+  assert.throws(
+    () => buildBobPaymentRepairPlan(snapshot, transfers()),
+    BobPaymentRepairAbortError,
+  )
+})
+
+test('any lease or invalid update time on an expired attempt is never repairable', () => {
   const cases: readonly Readonly<{
     name: string
     overrides: Readonly<Record<string, unknown>>
   }>[] = [
     {
-      name: 'active lease',
+      name: 'old expired lease',
       overrides: {
-        lease_owner: 'active-cron-lease',
-        lease_expires_at: '2026-08-23T12:00:30.000Z',
-        updated_at: '2026-08-23T11:59:00.000Z',
+        lease_owner: 'old-cron-lease',
+        lease_expires_at: '2026-08-23T11:59:30.000Z',
       },
     },
     { name: 'owner without expiry', overrides: { lease_owner: 'broken-lease' } },
@@ -292,6 +322,7 @@ test('every guarded database fact aborts when changed or ambiguous', () => {
     { name: 'malformed request', change: snapshot => { snapshot.attempts[0]!.request_json = { name: undefined } } },
     { name: 'request hash', change: snapshot => { snapshot.attempts[0]!.request_hash = '0'.repeat(64) } },
     { name: 'status', change: snapshot => { snapshot.attempts[0]!.status = 'settling' } },
+    { name: 'reason missing', change: snapshot => { snapshot.attempts[0]!.invalid_reason = null } },
     { name: 'transaction hash', change: snapshot => { snapshot.attempts[0]!.tx_hash = `0x${'11'.repeat(32)}` } },
     { name: 'target', change: snapshot => { snapshot.attempts[0]!.target_key = 'frontier:root:changed' } },
     { name: 'operation', change: snapshot => { snapshot.attempts[0]!.operation = 'kind_invention' } },
@@ -310,6 +341,7 @@ test('every guarded database fact aborts when changed or ambiguous', () => {
     { name: 'root missing', change: snapshot => { snapshot.worldRoots = [] } },
     { name: 'root ambiguous', change: snapshot => { snapshot.worldRoots.push({ ...snapshot.worldRoots[0]!, id: 2 }) } },
     { name: 'credit pre-exists', change: snapshot => { snapshot.credits.push({ source_key: BOB_REPAIR_CREDIT_SOURCE_KEY }) } },
+    { name: 'repair event pre-exists', change: snapshot => { snapshot.events.push({ detail: { attempt_id: BOB_REPAIR_EXPECTATIONS.coffee.attemptId } }) } },
   ]
 
   for (const candidate of cases) {
@@ -359,8 +391,8 @@ test('the exact eventual result is a safe retry no-op', () => {
 
 test('partial, duplicated, or changed completion never becomes a retry no-op', () => {
   const cases = [
-    (snapshot: Mutable<BobRepairSnapshot>) => { snapshot.fees = [] },
-    (snapshot: Mutable<BobRepairSnapshot>) => { snapshot.paymentUses.push({ ...snapshot.paymentUses[0]! }) },
+    (snapshot: Mutable<BobRepairSnapshot>) => { snapshot.events = [] },
+    (snapshot: Mutable<BobRepairSnapshot>) => { snapshot.events.push({ ...snapshot.events[0]! }) },
     (snapshot: Mutable<BobRepairSnapshot>) => { snapshot.places[0]!.name = 'Theblueai' },
     (snapshot: Mutable<BobRepairSnapshot>) => { snapshot.credits[0]!.amount_units = '2000000' },
     (snapshot: Mutable<BobRepairSnapshot>) => { snapshot.attempts[0]!.invalid_reason = 'changed' },
@@ -452,11 +484,7 @@ class FakeClient {
     const marker = /\/\*\s*bob-payment-repair:([a-z-]+)\s*\*\//u.exec(text)?.[1]
     if (marker === this.failureMarker) throw new Error('injected read failure')
     if (text.includes('bob-payment-repair-apply:create-place')) return { rows: [{ id: 901 }] }
-    if (text.includes('bob-payment-repair-apply:payment-use')) {
-      return { rows: [{ tx_hash: BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash }] }
-    }
-    if (text.includes('bob-payment-repair-apply:fee')) return { rows: [{ id: 811 }] }
-    if (text.includes('bob-payment-repair-apply:complete-attempt')) {
+    if (text.includes('bob-payment-repair-apply:review-theblueai')) {
       return { rows: [{ public_id: BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId }] }
     }
     if (text.includes('bob-payment-repair-apply:close-coffee')) {
@@ -483,6 +511,7 @@ class FakeClient {
       'world-roots': this.snapshot.worldRoots,
       places: this.snapshot.places,
       credits: this.snapshot.credits,
+      events: this.snapshot.events,
     }
     return { rows: rowsByMarker[marker] ?? [] }
   }
@@ -736,9 +765,10 @@ test('apply without an injected hookup uses the installed guarded operations', a
   assert.equal(result.state, 'no_work')
   const statements = client.calls.map(call => String(call[0]))
   assert.match(statements.join('\n'), /ISOLATION LEVEL SERIALIZABLE/iu)
-  assert.match(statements.join('\n'), /bob-payment-repair-apply:complete-attempt/iu)
+  assert.match(statements.join('\n'), /bob-payment-repair-apply:review-theblueai/iu)
   assert.match(statements.join('\n'), /bob-payment-repair-apply:close-coffee/iu)
   assert.match(statements.join('\n'), /city-credit:issue/iu)
+  assert.doesNotMatch(statements.join('\n'), /bob-payment-repair-apply:payment-use|bob-payment-repair-apply:fee/iu)
 })
 
 test('re-running apply after exact completion is a read-only no-op', async () => {

--- a/test/city-credit-schema.test.ts
+++ b/test/city-credit-schema.test.ts
@@ -8,6 +8,10 @@ const migrationDdl = readFileSync(
   new URL('../db/migrations/20260822_city_credit.sql', import.meta.url),
   'utf8',
 )
+const paymentRecoveryMigrationDdl = readFileSync(
+  new URL('../db/migrations/20260822_payment_recovery.sql', import.meta.url),
+  'utf8',
+)
 const migrateSource = readFileSync(new URL('../scripts/migrate.ts', import.meta.url), 'utf8')
 const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
   scripts: Record<string, string>
@@ -26,6 +30,15 @@ function table(ddl: string, name: string): string {
     `missing ${name}`,
   )
 }
+
+test('rerunning city credit cannot replace the newer payment recovery rules', () => {
+  const guard = (ddl: string): string => normalizedStatement(
+    ddl,
+    /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/iu,
+    'missing payment history guard',
+  )
+  assert.equal(guard(migrationDdl), guard(paymentRecoveryMigrationDdl))
+})
 
 test('fresh and upgraded schemas install the same private credit tables', () => {
   for (const name of ['city_credit_accounts', 'city_credit_entries']) {

--- a/test/deploy-safety.test.ts
+++ b/test/deploy-safety.test.ts
@@ -1239,6 +1239,14 @@ test('payment recovery trigger repair is an explicitly selected function correct
     },
   )
   assert.equal(production.migrationFile, 'db/migrations/20260823_payment_recovery_trigger_repair.sql')
+  assert.match(
+    packageJson.scripts['migrate:preview:payment-recovery-trigger-repair'] ?? '',
+    /--target preview --migration payment-recovery-trigger-repair$/,
+  )
+  assert.match(
+    packageJson.scripts['migrate:production:payment-recovery-trigger-repair'] ?? '',
+    /--target production --migration payment-recovery-trigger-repair$/,
+  )
 })
 
 test('public pagination indexes are an explicitly selected additive release', () => {

--- a/test/integration/payment-recovery-postgres.test.ts
+++ b/test/integration/payment-recovery-postgres.test.ts
@@ -836,7 +836,7 @@ test('payment recovery migration and primitives preserve exact deadline and term
     assert.deepEqual(canceled.rows, [{ status: 'canceled' }])
   })
 
-  await t.test('the approved Bob repair creates one exact continent, closes the probe, and issues one credit', async () => {
+  await t.test('the approved Bob repair creates one exact continent, closes the probe, records repair events, and issues one credit', async () => {
     await reset(database)
     await database.query(`
       INSERT INTO residents (id, handle, model, secret_hash)
@@ -853,18 +853,19 @@ test('payment recovery migration and primitives preserve exact deadline and term
           method, network, token, payer_wallet, payee_wallet, amount_units,
           x402_nonce, x402_payload_digest, start_block, start_time, end_time,
           status, tx_hash, response_json, recovery_started_at, recovery_deadline_at,
-          created_at, updated_at
+          created_at, updated_at, invalid_reason
         ) VALUES (
           $1, 68, 'frontier', $2, $3, $4::jsonb,
           'x402', 'base', $5, $6, $7, 1000000,
           $8, repeat('7', 64), 49000000,
           '2026-08-22T07:00:00Z', '2026-08-22T08:30:00Z',
-          'payment_pending', $9,
+          'expired', $9,
           jsonb_build_object(
             '__1f3d9_x402_response_v1', jsonb_build_object('header', 'dGVzdA==')
           ),
           $10::timestamptz, $11::timestamptz,
-          '2026-08-22T07:00:00Z', $12::timestamptz
+          '2026-08-22T07:00:00Z', $12::timestamptz,
+          'automatic payment recovery deadline passed'
         )
       `, [
         expected.attemptId,
@@ -908,16 +909,19 @@ test('payment recovery migration and primitives preserve exact deadline and term
       )
       assert.ok(firstOperation)
       await bobPaymentRepairApplyOperations.completeTheBlueAI(rollbackClient, firstOperation)
-      const inside = await rollbackClient.query<{ places: number; uses: number; fees: number }>(`
+      const inside = await rollbackClient.query<{ places: number; uses: number; fees: number; founder_review: number; repair_events: number }>(`
         SELECT
           (SELECT count(*)::integer FROM places WHERE name = 'TheBlueAI') AS places,
           (SELECT count(*)::integer FROM payment_uses WHERE payment_attempt_id = $1) AS uses,
-          (SELECT count(*)::integer FROM fees WHERE tx_hash = $2) AS fees
+          (SELECT count(*)::integer FROM fees WHERE tx_hash = $2) AS fees,
+          (SELECT count(*)::integer FROM payment_attempts
+            WHERE public_id = $1 AND status = 'founder_review') AS founder_review,
+          (SELECT count(*)::integer FROM events WHERE kind = 'payment_repair') AS repair_events
       `, [
         BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId,
         BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
       ])
-      assert.deepEqual(inside.rows, [{ places: 1, uses: 1, fees: 1 }])
+      assert.deepEqual(inside.rows, [{ places: 1, uses: 0, fees: 0, founder_review: 1, repair_events: 1 }])
       await rollbackClient.query('ROLLBACK')
     } finally {
       rollbackClient.release()
@@ -926,20 +930,20 @@ test('payment recovery migration and primitives preserve exact deadline and term
       places: number
       uses: number
       fees: number
-      pending: number
+      founder_review: number
     }>(`
       SELECT
         (SELECT count(*)::integer FROM places WHERE name = 'TheBlueAI') AS places,
         (SELECT count(*)::integer FROM payment_uses WHERE payment_attempt_id = $1) AS uses,
         (SELECT count(*)::integer FROM fees WHERE tx_hash = $2) AS fees,
         (SELECT count(*)::integer FROM payment_attempts
-          WHERE public_id = $1 AND status = 'payment_pending'
-            AND finalized_block_number IS NULL) AS pending
+          WHERE public_id = $1 AND status = 'expired'
+            AND finalized_block_number IS NULL) AS founder_review
     `, [
       BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId,
       BOB_REPAIR_EXPECTATIONS.theBlueAI.txHash,
     ])
-    assert.deepEqual(afterRollback.rows, [{ places: 0, uses: 0, fees: 0, pending: 1 }])
+    assert.deepEqual(afterRollback.rows, [{ places: 0, uses: 0, fees: 0, founder_review: 1 }])
 
     const client = await database.connect()
     try {
@@ -979,7 +983,11 @@ test('payment recovery migration and primitives preserve exact deadline and term
       blue_fees: number
       coffee_fees: number
       credits: number
-      events: number
+      repair_events: number
+      blue_status: string
+      coffee_status: string
+      blue_reason: string | null
+      coffee_reason: string | null
     }>(`
       SELECT
         (SELECT count(*)::integer FROM places WHERE name = 'TheBlueAI') AS blue_places,
@@ -990,8 +998,11 @@ test('payment recovery migration and primitives preserve exact deadline and term
         (SELECT count(*)::integer FROM fees WHERE tx_hash = $4) AS coffee_fees,
         (SELECT count(*)::integer FROM city_credit_entries
           WHERE source_key = $5) AS credits,
-        (SELECT count(*)::integer FROM events WHERE kind = 'place_created'
-          AND detail->>'name' = 'TheBlueAI') AS events
+        (SELECT count(*)::integer FROM events WHERE kind = 'payment_repair') AS repair_events,
+        (SELECT status FROM payment_attempts WHERE public_id = $1) AS blue_status,
+        (SELECT status FROM payment_attempts WHERE public_id = $2) AS coffee_status,
+        (SELECT invalid_reason FROM payment_attempts WHERE public_id = $1) AS blue_reason,
+        (SELECT invalid_reason FROM payment_attempts WHERE public_id = $2) AS coffee_reason
     `, [
       BOB_REPAIR_EXPECTATIONS.theBlueAI.attemptId,
       BOB_REPAIR_EXPECTATIONS.coffee.attemptId,
@@ -1002,12 +1013,16 @@ test('payment recovery migration and primitives preserve exact deadline and term
     assert.deepEqual(exactCounts.rows, [{
       blue_places: 1,
       coffee_places: 0,
-      blue_uses: 1,
+      blue_uses: 0,
       coffee_uses: 0,
-      blue_fees: 1,
+      blue_fees: 0,
       coffee_fees: 0,
       credits: 1,
-      events: 1,
+      repair_events: 2,
+      blue_status: 'founder_review',
+      coffee_status: 'founder_review',
+      blue_reason: 'automatic payment recovery deadline passed',
+      coffee_reason: 'automatic payment recovery deadline passed',
     }])
 
     const retryPlan = buildBobPaymentRepairPlan(

--- a/test/payment-recovery-runtime.test.ts
+++ b/test/payment-recovery-runtime.test.ts
@@ -297,6 +297,33 @@ test('runtime returns only the exact prior credit spend at its deadline', async 
   assert.equal(returned, 1)
 })
 
+test('automatic recovery logs the real server error without logging credentials', () => {
+  const runtime = createPaymentRecoveryRuntime(database, serviceDefaults())
+  const logged: unknown[][] = []
+  const original = console.error
+  console.error = (...values: unknown[]) => { logged.push(values) }
+  try {
+    const failure = Object.assign(new Error(
+      'invalid payment attempt transition at postgresql://operator:secret@example.test/city Bearer private-token 1f3d9_sk_private',
+    ), { code: '55000' })
+    runtime.dependencies.reportFailure?.({
+      publicId: ATTEMPT_ID,
+      actorId: 68,
+      operation: 'frontier',
+      method: 'x402',
+      status: 'payment_pending',
+      recoveryDeadlineAt: '2026-08-22T02:00:00.000Z',
+    }, failure)
+  } finally {
+    console.error = original
+  }
+
+  const serialized = JSON.stringify(logged)
+  assert.match(serialized, /invalid payment attempt transition/iu)
+  assert.match(serialized, /55000/u)
+  assert.doesNotMatch(serialized, /operator:secret|private-token|1f3d9_sk_private/iu)
+})
+
 test('late finalized x402 evidence is preserved for review without completing an operation', async () => {
   const expired = attempt({ status: 'expired' })
   let appended = 0

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -133,6 +133,7 @@ test('every event kind an emitter writes is advertised public window life', asyn
 test('the window covers the whole public life of the city', () => {
   assert.ok(PUBLIC_EVENT_KINDS.includes('home_set'))
   assert.ok(PUBLIC_EVENT_KINDS.includes('agreement_accession'))
+  assert.ok(PUBLIC_EVENT_KINDS.includes('payment_repair'))
   // The full enumeration is a truth surface: every kind the city writes for a
   // public act must be listed, or the window silently hides that life. The
   // world_* kinds are the market bridge — their absence hid every market sale.
@@ -143,7 +144,7 @@ test('the window covers the whole public life of the city', () => {
     'laws_changed', 'action', 'effect_scheduled', 'effect_resolved', 'note',
     'agreement', 'agreement_accession', 'agreement_sign', 'transfer',
     'transfer_offer', 'sale', 'transfer_cancel', 'world_listed', 'world_sale',
-    'world_cancel', 'flag', 'moderation',
+    'world_cancel', 'payment_repair', 'flag', 'moderation',
   ])
   for (const phrase of [
     'Who is standing where',


### PR DESCRIPTION
## What changed
- preserve the repaired payment-recovery trigger rules in the city-credit migration path
- repair Bob's two expired settled payments honestly: create TheBlueAI, close coffee-shop as founder review, issue one founder credit, and log two host correction events
- publish host payment correction events on public surfaces

## Verification
- npm test
- npm run typecheck
- npm audit
- read-only production Bob repair dry run returned work_required with the expected three actions
- production Bob repair apply returned no_work