### PR TITLE
fix: tolerate sparse snapshot upload replies

### DIFF
--- a/scripts/publish-public-snapshot.ts
+++ b/scripts/publish-public-snapshot.ts
@@ -190,12 +190,7 @@ export async function publishSnapshot(input: Readonly<{
       contentType: file.path.endsWith('.json') ? 'application/json' : 'application/x-ndjson',
       uploadName: file.path,
     })
-    const uploadedAsset = object(uploaded.body)
-    if (
-      uploaded.status !== 201 ||
-      uploadedAsset?.name !== file.path ||
-      uploadedAsset.size !== bytes.byteLength
-    ) {
+    if (uploaded.status !== 201) {
       throw new Error(`GitHub did not upload ${file.path}; draft release left unpublished`)
     }
   }

--- a/test/public-snapshot-publication.test.ts
+++ b/test/public-snapshot-publication.test.ts
@@ -140,3 +140,52 @@ test('publication creates a draft, uploads every new asset, then publishes witho
     await rm(directory, { force: true, recursive: true })
   }
 })
+
+test('publication accepts a sparse upload reply when the later exact asset list matches', async () => {
+  const { directory, bundle } = await fixture()
+  const uploadedAssets: Array<{ name: string; size: number }> = []
+  let uploadCount = 0
+  try {
+    const result = await publishSnapshot({
+      directory,
+      repository: 'onetapstudiogames/1f3d9',
+      token: 'test-token',
+      dryRun: false,
+      request: async request => {
+        if (request.path.endsWith('/releases/77/assets?per_page=100')) {
+          return { status: 200, body: uploadedAssets }
+        }
+        if (request.path.includes('/releases?')) return { status: 200, body: [] }
+        if (request.method === 'GET') return { status: 404, body: {} }
+        if (request.path.endsWith('/releases')) {
+          return {
+            status: 201,
+            body: {
+              id: 77,
+              tag_name: bundle.tag,
+              draft: true,
+              upload_url: 'https://uploads.github.test/releases/77/assets{?name,label}',
+              assets: [],
+            },
+          }
+        }
+        if (request.path.endsWith('/releases/77')) {
+          return { status: 200, body: { tag_name: bundle.tag, draft: false } }
+        }
+        const size = request.body instanceof Uint8Array
+          ? request.body.byteLength
+          : Buffer.byteLength(request.body ?? '')
+        const asset = { name: request.uploadName!, size }
+        uploadedAssets.push(asset)
+        uploadCount += 1
+        return uploadCount === 1
+          ? { status: 201, body: { state: 'uploaded' } }
+          : { status: 201, body: asset }
+      },
+    })
+    assert.equal(result.published, true)
+    assert.equal(result.tag, bundle.tag)
+  } finally {
+    await rm(directory, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
## What changed
- stop failing on a sparse per-file GitHub upload reply during snapshot publication
- keep the exact safety check on the later full draft asset list
- add a regression test for the upload seam seen in the first real publish run

## Verification
- node --test --experimental-strip-types test/public-snapshot-publication.test.ts
- npm test
- npm run typecheck
