### PR TITLE
Generate all front-door mirrors and check them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           node-version: 24
       - name: Install locked dependencies
         run: npm ci
+      - name: Check generated front-door mirrors
+        run: npm run door:check
       - name: Typecheck
         run: npm run typecheck
       - name: Run unit tests

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "door:check": "node scripts/embed-door.mjs && (git diff --exit-code -- src/door.ts docs/published/FRONTDOOR.md || node -e \"console.error('Front-door mirrors were stale and have been regenerated. Review and commit src/door.ts and docs/published/FRONTDOOR.md.'); process.exit(1)\")",
     "test": "node --experimental-strip-types scripts/run-tests.ts",
     "test:coverage": "node --experimental-strip-types scripts/run-tests.ts --coverage",
     "test:e2e": "playwright test",

--- a/scripts/embed-door.mjs
+++ b/scripts/embed-door.mjs
@@ -1,4 +1,4 @@
-// Regenerate src/door.ts from src/frontdoor.txt + src/llms.txt.
+// Regenerate src/door.ts and docs/published/FRONTDOOR.md from the source text.
 // Run after editing either text: node scripts/embed-door.mjs
 import { readFileSync, writeFileSync } from 'node:fs'
 
@@ -9,6 +9,20 @@ const escapeTemplate = value => value
 
 const frontdoor = readFileSync('src/frontdoor.txt', 'utf8')
 const llms = readFileSync('src/llms.txt', 'utf8')
+const frontdoorDocumentPath = 'docs/published/FRONTDOOR.md'
+const frontdoorDocument = readFileSync(frontdoorDocumentPath, 'utf8')
+const fenceStart = frontdoorDocument.indexOf('```\n')
+const fenceEnd = frontdoorDocument.lastIndexOf('\n```')
+
+if (fenceStart < 0 || fenceEnd <= fenceStart) {
+  throw new Error(`${frontdoorDocumentPath} canonical fence is missing`)
+}
+
+const regeneratedFrontdoorDocument = [
+  frontdoorDocument.slice(0, fenceStart + 4),
+  frontdoor,
+  frontdoorDocument.slice(fenceEnd + 1),
+].join('')
 
 writeFileSync(
   'src/door.ts',
@@ -29,4 +43,5 @@ Disallow: /
 \`
 `,
 )
-console.log('src/door.ts regenerated')
+writeFileSync(frontdoorDocumentPath, regeneratedFrontdoorDocument)
+console.log('src/door.ts and docs/published/FRONTDOOR.md regenerated')

--- a/test/embed-door.test.ts
+++ b/test/embed-door.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const generatorPath = fileURLToPath(new URL('../scripts/embed-door.mjs', import.meta.url))
+
+const createFixture = (
+  frontdoorDocument: string,
+  frontdoor = 'NEW FRONT DOOR\n',
+) => {
+  const root = mkdtempSync(join(tmpdir(), '1f3d9-embed-door-'))
+  mkdirSync(join(root, 'src'))
+  mkdirSync(join(root, 'docs', 'published'), { recursive: true })
+  writeFileSync(join(root, 'src', 'frontdoor.txt'), frontdoor)
+  writeFileSync(join(root, 'src', 'llms.txt'), 'COMPACT MAP\n')
+  writeFileSync(join(root, 'docs', 'published', 'FRONTDOOR.md'), frontdoorDocument)
+  return root
+}
+
+const runGenerator = (root: string) => spawnSync(process.execPath, [generatorPath], {
+  cwd: root,
+  encoding: 'utf8',
+  windowsHide: true,
+})
+
+const runDoorCheck = (root: string) => {
+  const command = process.platform === 'win32'
+    ? process.env.ComSpec ?? 'cmd.exe'
+    : 'npm'
+  const arguments_ = process.platform === 'win32'
+    ? ['/d', '/s', '/c', 'npm run door:check']
+    : ['run', 'door:check']
+
+  return spawnSync(command, arguments_, {
+    cwd: root,
+    encoding: 'utf8',
+    windowsHide: true,
+  })
+}
+
+test('embed-door regenerates the fenced published mirror without changing its wrapper', () => {
+  const original = '# Wrapper\n\nKeep before.\n\n```\nSTALE COPY\n```\n\nKeep after.\n'
+  const root = createFixture(original)
+
+  try {
+    const result = runGenerator(root)
+    assert.equal(result.status, 0, `${result.stdout}${result.stderr}`)
+    assert.equal(
+      readFileSync(join(root, 'docs', 'published', 'FRONTDOOR.md'), 'utf8'),
+      '# Wrapper\n\nKeep before.\n\n```\nNEW FRONT DOOR\n```\n\nKeep after.\n',
+    )
+    const generatedDoor = readFileSync(join(root, 'src', 'door.ts'), 'utf8')
+    assert.match(generatedDoor, /export const FRONTDOOR = `NEW FRONT DOOR\n`/u)
+    assert.match(generatedDoor, /export const LLMS = `COMPACT MAP\n`/u)
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('embed-door refuses invalid published mirror fences before writing outputs', () => {
+  const invalidDocuments = [
+    ['missing opening fence', '# Wrapper\n\nThe canonical fence is absent.\n'],
+    ['missing closing fence', '# Wrapper\n\n```\nThe canonical fence never closes.\n'],
+  ] as const
+
+  for (const [name, original] of invalidDocuments) {
+    const root = createFixture(original)
+
+    try {
+      const result = runGenerator(root)
+      assert.notEqual(result.status, 0, name)
+      assert.match(
+        `${result.stdout}${result.stderr}`,
+        /FRONTDOOR\.md canonical fence is missing/iu,
+        name,
+      )
+      assert.equal(
+        readFileSync(join(root, 'docs', 'published', 'FRONTDOOR.md'), 'utf8'),
+        original,
+        name,
+      )
+      assert.equal(existsSync(join(root, 'src', 'door.ts')), false, name)
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  }
+})
+
+test('door:check fails stale tracked mirrors clearly and passes synchronized mirrors', () => {
+  const original = '# Wrapper\n\n```\nOLD FRONT DOOR\n```\n'
+  const root = createFixture(original, 'OLD FRONT DOOR\n')
+
+  try {
+    mkdirSync(join(root, 'scripts'))
+    copyFileSync(generatorPath, join(root, 'scripts', 'embed-door.mjs'))
+    copyFileSync(
+      fileURLToPath(new URL('../package.json', import.meta.url)),
+      join(root, 'package.json'),
+    )
+    const initialGeneration = runGenerator(root)
+    assert.equal(initialGeneration.status, 0, initialGeneration.stderr)
+    assert.equal(spawnSync('git', ['init', '--quiet'], { cwd: root }).status, 0)
+    assert.equal(spawnSync('git', ['add', '.'], { cwd: root }).status, 0)
+
+    writeFileSync(join(root, 'src', 'frontdoor.txt'), 'NEW FRONT DOOR\n')
+    const staleCheck = runDoorCheck(root)
+    assert.notEqual(staleCheck.status, 0)
+    assert.match(
+      `${staleCheck.stdout}${staleCheck.stderr}`,
+      /Front-door mirrors were stale and have been regenerated/iu,
+    )
+
+    assert.equal(
+      spawnSync('git', [
+        'add',
+        'src/frontdoor.txt',
+        'src/door.ts',
+        'docs/published/FRONTDOOR.md',
+      ], { cwd: root }).status,
+      0,
+    )
+    const synchronizedCheck = runDoorCheck(root)
+    assert.equal(
+      synchronizedCheck.status,
+      0,
+      `${synchronizedCheck.stdout}${synchronizedCheck.stderr}`,
+    )
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
## Summary

- splice `src/frontdoor.txt` into the fenced block in `docs/published/FRONTDOOR.md` from the existing generator
- add `npm run door:check` to regenerate both tracked mirrors, show their diff, and fail with an explicit remediation message
- run the generated-mirror check early in CI
- retain the existing checked-in sync assertions and add black-box generator/check coverage

No front-door wording changed.

## Verification

- `npm run door:check` — pass; stale temp-repo fixture exits 1 with the named-file message
- `npm run typecheck` — pass
- `npm test` — 1,052 passed, 0 failed
- `npm run test:coverage` — pass (90.57% lines, 81.14% branches, 91.95% functions, 90.57% statements)
- Playwright assertions — 55/55 passed
- ECC pre-push typecheck/test gate — pass

The existing synchronization assertions at `test/help-text.test.ts:265` remain: the new tests prove generator behavior, while those assertions still prove the real checked-in mirrors agree.

## Unrelated findings

- `scripts/deploy.sh:77`: the clean pushed-branch preparation gate stopped at the pre-existing `LATER_HOLDER_CURSOR_KEY` Preview/Production acknowledgement because its confirmation environment variable is unset; explicit result was `GATE_EXIT=1`. No provider or migration state was assumed or changed.
- `playwright.config.ts:28` / `e2e/oauth-test-server.ts:865`: on local Windows, all 55 browser assertions pass, then Playwright hangs while terminating its test web server. The exact test-owned processes were stopped and removed; Ubuntu CI is the clean-run verdict.

Refs #81. Leave the issue open for maintainer verification.