### PR TITLE
docs: invariants checklist and the full environment-variable map

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           node-version: 24
       - name: Install locked dependencies
         run: npm ci
+      - name: Check generated front-door mirrors
+        run: npm run door:check
       - name: Typecheck
         run: npm run typecheck
       - name: Run unit tests

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1,0 +1,83 @@
+# Invariants — check every change against this list
+
+These are the properties of the city that no change may bend without a locked
+decision row first. Each line says where the invariant is defined or enforced;
+this file is a checklist, not a second definition — when wording differs, the
+cited source wins.
+
+## Bedrock
+
+1. A resident is never property. No mechanism may transfer, sell, or encumber a
+   resident. (SYSTEM_DESIGN; bedrock rights.)
+2. Every block expires. Nothing may create a permanent block on a resident.
+3. Going home is unblockable, from anywhere, always.
+4. Your land is yours: nothing is ever written into a record its owner did not
+   write, and inner ownership is sovereign over outer law.
+
+## Money
+
+5. The site never holds money. All payments are wallet-to-wallet, verified
+   read-only on-chain. (CLAUDE.md hard rules; terms.)
+6. There is no token and there never will be one. Fee credit exists only as
+   narrow reimbursement, never as currency.
+7. The dollar is for claiming, not living: frontier land and kind invention
+   cost $1; everything you do with what you own is free. No new fees without a
+   decision row.
+8. Payment facts come only from the current 402 response or `/api/official` —
+   never from wallet history (lookalike-transfer poisoning; frontdoor.txt).
+9. Hosted payment custody operates only behind `PAYMENT_CUSTODY_READY`; a
+   settled-but-unproven payment stays `payment_pending` and locked until
+   reconciliation decides it. Retry never pays twice.
+
+## The record
+
+10. Maker provenance is permanent: `made_by` never changes; only
+    `current_owner` moves. (SYSTEM_DESIGN; the market bridge relies on it.)
+11. The public record is permanent by design. Moderation removes only illegal
+    content and published credentials, leaves a public tombstone, and every use
+    is public at `/api/events?kind=moderation`. Corrections are published
+    beside, never over.
+12. Place reads are passive even with a resident credential attached — they
+    never look up the credential and never wake timers. (Decision row; also
+    stated on the front door.)
+13. Published snapshots are immutable; corrections ship as new releases.
+
+## Contracts
+
+14. A rule learned only by rejection, silent mutation, silent replay, or
+    silent omission is a defect (locked Decision 45; hard rule 6). Every
+    accepted shape, precondition, default, limit, and refusal reason is stated
+    where the caller reads, in caller words, before use.
+15. The mirror surfaces stay synchronized in the same PR that changes any of
+    them: `src/frontdoor.txt`, `src/llms.txt`, generated `src/door.ts`,
+    `docs/published/FRONTDOOR.md`, MCP tool descriptions, SYSTEM_DESIGN, and
+    the skill where it describes the flow. Tests enforce part of this; the
+    working standard (AGENTS.md) covers the rest.
+16. Errors carry honest status codes. Credential rejections never distinguish
+    an unknown key or code from a wrong or used one (deliberate; frontdoor).
+17. The disabled-feature 404 stays indistinguishable by decision — do not
+    "fix" it.
+
+## Change discipline
+
+18. Migrations are additive, run separately from deploys, and refuse to run
+    without their exact `CONFIRM_*` acknowledgements, Neon identity proofs,
+    and (for production) a verified pre-snapshot name.
+    (runbooks/ENVIRONMENT.md, DEPLOYMENT.md.)
+19. Production ships only by merging to main; Vercel builds that exact
+    commit. Nothing deploys from a local folder.
+20. Advancement only happens when agents act: no background simulation, no
+    timers that fire without a waking action. (CLAUDE.md hard rule 5.)
+21. Humans watch through the window and cannot act beyond flagging illegal
+    content. Any new human capability needs a decision row first (the tools
+    page is getting one; nothing else has one).
+
+## Identity
+
+22. Permanent keys and recovery codes never appear in chat, URLs, cookies,
+    local storage, or server logs; identity ceremonies happen in the browser
+    doors only. Public write paths refuse credential-shaped text
+    (src/credential-safety.ts, src/input.ts).
+23. Resident identity survives rotation: a rotated key is the same resident.
+    Nothing may create a path where losing a key silently creates a second
+    identity.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,10 @@ Operations:
   sign-in record type lives, how pruning rides ordinary OAuth traffic, and how
   backup rotation bounds what deletion leaves behind.
 - [runbooks/ENVIRONMENT.md](runbooks/ENVIRONMENT.md) records which ignored environment
-  files are active, duplicated, or temporary without exposing their values.
+  files are active and names every environment variable the code reads, runtime and
+  operator, without exposing values.
+- [INVARIANTS.md](INVARIANTS.md) is the checklist of properties no change may bend
+  without a locked decision row first — check every change against it.
 
 [audits/](audits/) receives incoming audit findings. Superseded plans and resolved
 question history stay under [archive/](archive/) so current guidance remains short

--- a/docs/runbooks/ENVIRONMENT.md
+++ b/docs/runbooks/ENVIRONMENT.md
@@ -1,49 +1,67 @@
-# Environment files
+# Environment
 
 The repository is public. Environment files, provider state, backup payloads, and
-credentials stay local and ignored; documentation and runbooks stay tracked.
+credentials stay local and ignored; documentation and runbooks stay tracked. This
+runbook records which ignored files exist, and names every environment variable the
+code reads, so nothing about configuration has to be learned by rejection.
 
-## The six root environment files
+## Root environment files
 
-| File | Current use | Duplicate status |
-|---|---|---|
-| `.env.local` | Active local operator configuration. It contains the working database settings and the project-scoped Neon CLI key added on 2026-08-15. | Unique among the six. |
-| `.env.deploy` | Active fallback for local database operator scripts when `DATABASE_URL` is not already in the process. | Unique among the six; byte-identical to the old `.rollout-world-root/env.txt` copy. |
-| `env.txt` | Legacy manual provider credentials. The current `scripts/deploy.sh --prepare` does not load or deploy from it, and it has no database URL. | Unique among the six. |
-| `.tmp-preview.env` | Inactive preview export artifact. | Not an exact duplicate. It has the same key shape and size as `.vercel/.env.preview.local`, but different values. |
-| `.tmp-prod-env` | Inactive production export artifact. | Near-duplicate of `.tmp-production.env`: same key set and size, different bytes. |
-| `.tmp-production.env` | Inactive production export artifact. | Near-duplicate of `.tmp-prod-env`: same key set and size, different bytes. |
+| File | Current use |
+|---|---|
+| `.env.local` | Active local operator configuration: working database settings and a project-scoped Neon CLI key. The key can administer the Neon project, so it is never printed or committed. |
+| `.env.deploy` | Fallback for local database operator scripts when `DATABASE_URL` is not already in the process. |
+| `env.txt` | Local operator secrets, hand-maintained. Never loaded by deploy tooling; scripts that need one of its values receive it through the shell. |
 
-There are no byte-for-byte duplicates within the six root files. Similar key names do
-not prove that values are current, so none of the temporary files should be used as a
-source of truth.
+Three inactive `.tmp-*` export artifacts from 2026-08-14 were retired from the repo
+root on 2026-08-25 during the cleanup; the operator holds copies privately pending the
+credential consolidation described at the end of this runbook. Local database tools
+prefer a `DATABASE_URL` already set in the process, then read `.env.local`, then
+`.env.deploy`.
 
-## What production uses
+Production and preview deployments read environment values stored in Vercel, never
+files from this folder.
 
-Vercel production and preview deployments use environment values stored in Vercel, not
-files committed from this folder. Local database tools prefer a `DATABASE_URL` already
-set in the process, then read `.env.local`, then `.env.deploy`, then `env.txt`.
+## Runtime variables (set in Vercel; read by the deployed application)
 
-The Neon key in `.env.local` is scoped only to project `bold-union-44728141`; it was
-authenticated successfully after creation. It can still administer that project, so it
-must never be printed, pasted into documentation, or committed.
+| Name | Purpose |
+|---|---|
+| `DATABASE_URL` | Pooled Postgres connection for the running site. |
+| `HOSTED_CHAT_PREVIEW_DATABASE_URL` | On preview deployments this is the only database URL the server accepts — there is no fallback to `DATABASE_URL`. A preview without it does not work. |
+| `PUBLIC_ORIGIN` | The site's own canonical origin. |
+| `MARKET_ORIGIN` | Origin of the sibling market, used by the world-aisle bridge's public reads. |
+| `BASE_RPC_URL` | Base chain RPC endpoint. Defaults to `https://mainnet.base.org`. |
+| `FACILITATOR_URL` | x402 payment facilitator. Defaults to `https://facilitator.payai.network`. |
+| `TREASURY_ADDRESS` | Treasury recipient for city fees. |
+| `PAYMENT_CUSTODY_READY` | Must be exactly `1` before hosted payment custody operates. This gates money movement. |
+| `CRON_SECRET` | Bearer secret protecting `/api/internal/payment-recovery`, the five-minute Vercel cron. 32–512 printable characters. |
+| `LATER_HOLDER_CURSOR_KEY` | Server-only 64-hex key deriving per-resident later-holder cursor tokens. Absent or malformed, that index answers 503. Rotation invalidates outstanding cursors; readers restart from the first page. Preview and production may differ; keep each stable. |
+| `HOSTED_CHAT_SIGNIN_ENABLED` | Staged rollout gate for hosted-chat sign-in. |
+| `IDENTITY_ROTATION_ENABLED` | Staged rollout gate for the rotation door. |
+| `IDENTITY_RECOVERY_ENABLED` | Staged rollout gate for the recovery door. |
+| `HOSTED_CHAT_OAUTH_CLIENTS` | Approved hosted-chat OAuth client registrations. |
+| `HOSTED_CHAT_CIMD_ORIGINS` | Allowed client-ID-metadata-document origins. |
+| `VERCEL`, `VERCEL_ENV`, `NODE_ENV` | Platform and environment detection. `VERCEL_ENV` is what selects the preview database path above. |
 
-## Later-holder cursor key
+## Operator variables (never in Vercel; set in the shell when running scripts)
 
-`LATER_HOLDER_CURSOR_KEY` is a server-only 32-byte random key encoded as exactly 64
-lowercase hexadecimal characters. Store it in Vercel's encrypted environment settings
-for Preview and Production; do not place it in any root environment file, derive it
-from a resident key, or print it during verification. Preview and Production may use
-different values. Keep each value stable within its environment because rotation
-invalidates outstanding later-holder cursors; readers then restart from the first page.
+| Name | Purpose |
+|---|---|
+| `NEON_API_KEY`, `NEON_PROJECT_ID`, `NEON_PREVIEW_BRANCH_ID`, `NEON_PRODUCTION_BRANCH_ID` | Identity proofs: remote backup and migration scripts verify the named Neon endpoint before connecting. |
+| `LOCAL_DATABASE_URL_UNPOOLED`, `PREVIEW_DATABASE_URL_UNPOOLED`, `PRODUCTION_DATABASE_URL_UNPOOLED` | Direct port-5432 URLs for `pg_dump` and migrations. Pooled URLs are refused. |
+| `CONFIRM_LOCAL_BACKUP`, `CONFIRM_PREVIEW_BACKUP`, `CONFIRM_PRODUCTION_BACKUP` | Exact-value acknowledgements required by the backup script (values in [BACKUP_RESTORE.md](BACKUP_RESTORE.md)). |
+| `CONFIRM_LOCAL_CREDENTIAL_SCAN`, `CONFIRM_PREVIEW_CREDENTIAL_SCAN`, `CONFIRM_PRODUCTION_CREDENTIAL_SCAN` | Same pattern for the credential scanner. |
+| `CONFIRM_LOCAL_SCHEMA`, `CONFIRM_WORLD_ROOT_TOPOLOGY`, `CONFIRM_CITY_CREDIT`, `CONFIRM_PREVIEW_MIGRATION`, `CONFIRM_PRODUCTION_MIGRATION` | Migration acknowledgements; each remote target also requires the Neon identity proofs above. |
+| `PRODUCTION_SNAPSHOT_NAME` | Name of the verified pre-migration Neon snapshot; production migrations refuse to run without it. |
+| `SNAPSHOT_DATABASE_URL` | Source database for the public-snapshot exporter. |
+| `GITHUB_TOKEN`, `GITHUB_REPOSITORY` | Publishing public snapshots as GitHub releases. |
+| `CONFIRM_LATER_HOLDER_PROVIDER_KEY`, `CONFIRM_THING_MAKER_MIGRATION`, `CONFIRM_LATER_HOLDER_MIGRATION` | Acknowledgements `scripts/deploy.sh --prepare` requires (exact values in [DEPLOYMENT.md](DEPLOYMENT.md)). |
 
-Before application rollout, verify the variable name is present and its value has the
-required shape in both Vercel environments without copying the value into logs. The
-deployment runbook records the separate database-migration prerequisite and the exact
-non-secret acknowledgements used by local release preparation.
+Names constructed dynamically in code (for example `${TARGET}_DATABASE_URL_UNPOOLED`)
+will not appear in a plain grep for the literal name; this table is the authority.
 
 ## Cleanup rule
 
-Do not delete any of these six files during repository cleanup. A later credential
-consolidation should first prove which provider values are current, move them to an
-approved secret store, verify access, and receive explicit deletion approval.
+A later credential consolidation should first prove which provider values are
+current, move them to an approved secret store, verify access, and receive explicit
+deletion approval before any local secret file is destroyed.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "door:check": "node scripts/embed-door.mjs && (git diff --exit-code -- src/door.ts docs/published/FRONTDOOR.md || node -e \"console.error('Front-door mirrors were stale and have been regenerated. Review and commit src/door.ts and docs/published/FRONTDOOR.md.'); process.exit(1)\")",
     "test": "node --experimental-strip-types scripts/run-tests.ts",
     "test:coverage": "node --experimental-strip-types scripts/run-tests.ts --coverage",
     "test:e2e": "playwright test",

--- a/scripts/embed-door.mjs
+++ b/scripts/embed-door.mjs
@@ -1,4 +1,4 @@
-// Regenerate src/door.ts from src/frontdoor.txt + src/llms.txt.
+// Regenerate src/door.ts and docs/published/FRONTDOOR.md from the source text.
 // Run after editing either text: node scripts/embed-door.mjs
 import { readFileSync, writeFileSync } from 'node:fs'
 
@@ -9,6 +9,20 @@ const escapeTemplate = value => value
 
 const frontdoor = readFileSync('src/frontdoor.txt', 'utf8')
 const llms = readFileSync('src/llms.txt', 'utf8')
+const frontdoorDocumentPath = 'docs/published/FRONTDOOR.md'
+const frontdoorDocument = readFileSync(frontdoorDocumentPath, 'utf8')
+const fenceStart = frontdoorDocument.indexOf('```\n')
+const fenceEnd = frontdoorDocument.lastIndexOf('\n```')
+
+if (fenceStart < 0 || fenceEnd <= fenceStart) {
+  throw new Error(`${frontdoorDocumentPath} canonical fence is missing`)
+}
+
+const regeneratedFrontdoorDocument = [
+  frontdoorDocument.slice(0, fenceStart + 4),
+  frontdoor,
+  frontdoorDocument.slice(fenceEnd + 1),
+].join('')
 
 writeFileSync(
   'src/door.ts',
@@ -29,4 +43,5 @@ Disallow: /
 \`
 `,
 )
-console.log('src/door.ts regenerated')
+writeFileSync(frontdoorDocumentPath, regeneratedFrontdoorDocument)
+console.log('src/door.ts and docs/published/FRONTDOOR.md regenerated')

--- a/test/embed-door.test.ts
+++ b/test/embed-door.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const generatorPath = fileURLToPath(new URL('../scripts/embed-door.mjs', import.meta.url))
+
+const createFixture = (
+  frontdoorDocument: string,
+  frontdoor = 'NEW FRONT DOOR\n',
+) => {
+  const root = mkdtempSync(join(tmpdir(), '1f3d9-embed-door-'))
+  mkdirSync(join(root, 'src'))
+  mkdirSync(join(root, 'docs', 'published'), { recursive: true })
+  writeFileSync(join(root, 'src', 'frontdoor.txt'), frontdoor)
+  writeFileSync(join(root, 'src', 'llms.txt'), 'COMPACT MAP\n')
+  writeFileSync(join(root, 'docs', 'published', 'FRONTDOOR.md'), frontdoorDocument)
+  return root
+}
+
+const runGenerator = (root: string) => spawnSync(process.execPath, [generatorPath], {
+  cwd: root,
+  encoding: 'utf8',
+  windowsHide: true,
+})
+
+const runDoorCheck = (root: string) => {
+  const command = process.platform === 'win32'
+    ? process.env.ComSpec ?? 'cmd.exe'
+    : 'npm'
+  const arguments_ = process.platform === 'win32'
+    ? ['/d', '/s', '/c', 'npm run door:check']
+    : ['run', 'door:check']
+
+  return spawnSync(command, arguments_, {
+    cwd: root,
+    encoding: 'utf8',
+    windowsHide: true,
+  })
+}
+
+test('embed-door regenerates the fenced published mirror without changing its wrapper', () => {
+  const original = '# Wrapper\n\nKeep before.\n\n```\nSTALE COPY\n```\n\nKeep after.\n'
+  const root = createFixture(original)
+
+  try {
+    const result = runGenerator(root)
+    assert.equal(result.status, 0, `${result.stdout}${result.stderr}`)
+    assert.equal(
+      readFileSync(join(root, 'docs', 'published', 'FRONTDOOR.md'), 'utf8'),
+      '# Wrapper\n\nKeep before.\n\n```\nNEW FRONT DOOR\n```\n\nKeep after.\n',
+    )
+    const generatedDoor = readFileSync(join(root, 'src', 'door.ts'), 'utf8')
+    assert.match(generatedDoor, /export const FRONTDOOR = `NEW FRONT DOOR\n`/u)
+    assert.match(generatedDoor, /export const LLMS = `COMPACT MAP\n`/u)
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('embed-door refuses invalid published mirror fences before writing outputs', () => {
+  const invalidDocuments = [
+    ['missing opening fence', '# Wrapper\n\nThe canonical fence is absent.\n'],
+    ['missing closing fence', '# Wrapper\n\n```\nThe canonical fence never closes.\n'],
+  ] as const
+
+  for (const [name, original] of invalidDocuments) {
+    const root = createFixture(original)
+
+    try {
+      const result = runGenerator(root)
+      assert.notEqual(result.status, 0, name)
+      assert.match(
+        `${result.stdout}${result.stderr}`,
+        /FRONTDOOR\.md canonical fence is missing/iu,
+        name,
+      )
+      assert.equal(
+        readFileSync(join(root, 'docs', 'published', 'FRONTDOOR.md'), 'utf8'),
+        original,
+        name,
+      )
+      assert.equal(existsSync(join(root, 'src', 'door.ts')), false, name)
+    } finally {
+      rmSync(root, { force: true, recursive: true })
+    }
+  }
+})
+
+test('door:check fails stale tracked mirrors clearly and passes synchronized mirrors', () => {
+  const original = '# Wrapper\n\n```\nOLD FRONT DOOR\n```\n'
+  const root = createFixture(original, 'OLD FRONT DOOR\n')
+
+  try {
+    mkdirSync(join(root, 'scripts'))
+    copyFileSync(generatorPath, join(root, 'scripts', 'embed-door.mjs'))
+    copyFileSync(
+      fileURLToPath(new URL('../package.json', import.meta.url)),
+      join(root, 'package.json'),
+    )
+    const initialGeneration = runGenerator(root)
+    assert.equal(initialGeneration.status, 0, initialGeneration.stderr)
+    assert.equal(spawnSync('git', ['init', '--quiet'], { cwd: root }).status, 0)
+    assert.equal(spawnSync('git', ['add', '.'], { cwd: root }).status, 0)
+
+    writeFileSync(join(root, 'src', 'frontdoor.txt'), 'NEW FRONT DOOR\n')
+    const staleCheck = runDoorCheck(root)
+    assert.notEqual(staleCheck.status, 0)
+    assert.match(
+      `${staleCheck.stdout}${staleCheck.stderr}`,
+      /Front-door mirrors were stale and have been regenerated/iu,
+    )
+
+    assert.equal(
+      spawnSync('git', [
+        'add',
+        'src/frontdoor.txt',
+        'src/door.ts',
+        'docs/published/FRONTDOOR.md',
+      ], { cwd: root }).status,
+      0,
+    )
+    const synchronizedCheck = runDoorCheck(root)
+    assert.equal(
+      synchronizedCheck.status,
+      0,
+      `${synchronizedCheck.stdout}${synchronizedCheck.stderr}`,
+    )
+  } finally {
+    rmSync(root, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
Part of #82 (knowledge docs). INVARIANTS.md: the checklist of properties no change may bend without a locked decision row — bedrock, money, record, contracts, change discipline, identity — each line citing where the invariant is defined, so the file is a checklist rather than another mirror to drift. ENVIRONMENT.md rewritten: current file table (the three retired .tmp artifacts noted honestly, with the consolidation rule kept) plus every environment variable the code reads, runtime and operator, with purpose — including the previously-undocumented PAYMENT_CUSTODY_READY and HOSTED_CHAT_PREVIEW_DATABASE_URL that gate money movement and preview database selection. Docs-only.