### PR TITLE
fix: repair late payment finality rechecks

### DIFF
--- a/db/migrations/20260816_payment_attempts.sql
+++ b/db/migrations/20260816_payment_attempts.sql
@@ -463,6 +463,19 @@ BEGIN
     RAISE EXCEPTION 'payment attempt terms are immutable' USING ERRCODE = '55000';
   END IF;
 
+  IF OLD.recovery_started_at IS NOT NULL AND ROW(
+    NEW.recovery_started_at, NEW.recovery_deadline_at
+  ) IS DISTINCT FROM ROW(
+    OLD.recovery_started_at, OLD.recovery_deadline_at
+  ) THEN
+    RAISE EXCEPTION 'payment recovery window is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.recovery_started_at IS NOT NULL
+    AND NEW.recovery_deadline_at IS DISTINCT FROM
+      NEW.recovery_started_at + interval '2 hours' THEN
+    RAISE EXCEPTION 'payment recovery deadline is invalid' USING ERRCODE = '55000';
+  END IF;
+
   IF OLD.tx_hash IS NOT NULL AND NEW.tx_hash IS DISTINCT FROM OLD.tx_hash THEN
     RAISE EXCEPTION 'payment attempt transaction is immutable' USING ERRCODE = '55000';
   END IF;
@@ -476,20 +489,85 @@ BEGIN
     RAISE EXCEPTION 'payment attempt finality is immutable' USING ERRCODE = '55000';
   END IF;
 
-  IF OLD.status IN ('completed', 'invalid', 'expired', 'legacy_completed')
-    AND NEW IS DISTINCT FROM OLD THEN
+  IF OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' IS NOT NULL
+    AND NEW.response_json #>> '{__1f3d9_x402_response_v1,header}' IS DISTINCT FROM
+      OLD.response_json #>> '{__1f3d9_x402_response_v1,header}' THEN
+    RAISE EXCEPTION 'payment facilitator response is immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status IN (
+    'completed', 'invalid', 'founder_review', 'legacy_completed', 'credit_returned'
+  ) AND NEW IS DISTINCT FROM OLD THEN
     RAISE EXCEPTION 'terminal payment attempt is immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status = 'expired' THEN
+    IF NOT (
+      NEW.status = 'founder_review'
+      AND OLD.method = 'x402'
+      AND NEW.tx_hash IS NOT NULL
+      AND (OLD.tx_hash IS NULL OR NEW.tx_hash = OLD.tx_hash)
+      AND NEW.finalized_block_number IS NOT NULL
+      AND NEW.finalized_block_hash IS NOT NULL
+      AND NEW.finalized_block_time IS NOT NULL
+      AND NEW.finalized_at IS NOT NULL
+      AND (
+        (
+          OLD.finalized_block_number IS NULL
+          AND OLD.finalized_block_hash IS NULL
+          AND OLD.finalized_block_time IS NULL
+          AND OLD.finalized_at IS NULL
+        )
+        OR ROW(
+          NEW.finalized_block_number, NEW.finalized_block_hash,
+          NEW.finalized_block_time, NEW.finalized_at
+        ) IS NOT DISTINCT FROM ROW(
+          OLD.finalized_block_number, OLD.finalized_block_hash,
+          OLD.finalized_block_time, OLD.finalized_at
+        )
+      )
+      AND (
+        (OLD.invalid_reason IS NOT NULL AND NEW.invalid_reason = OLD.invalid_reason)
+        OR (OLD.invalid_reason IS NULL AND NEW.invalid_reason IS NOT NULL)
+      )
+      AND NEW.lease_owner IS NULL
+      AND NEW.lease_expires_at IS NULL
+      AND (
+        to_jsonb(NEW) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      ) IS NOT DISTINCT FROM (
+        to_jsonb(OLD) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      )
+    ) THEN
+      RAISE EXCEPTION 'expired payment attempt history is immutable'
+        USING ERRCODE = '55000';
+    END IF;
+    IF NEW.updated_at < OLD.updated_at THEN
+      RAISE EXCEPTION 'payment attempt update time cannot move backward'
+        USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
   END IF;
   IF NOT (
     (OLD.status = 'settling' AND NEW.status IN (
-      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review'
+      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review', 'founder_review'
     ))
     OR (OLD.status = 'payment_pending' AND NEW.status IN (
-      'payment_pending', 'completed', 'invalid', 'needs_review'
+      'payment_pending', 'completed', 'invalid', 'expired', 'needs_review', 'founder_review'
     ))
     OR (OLD.status = 'needs_review' AND NEW.status IN (
-      'needs_review', 'payment_pending', 'completed', 'invalid'
+      'needs_review', 'payment_pending', 'completed', 'invalid', 'expired', 'founder_review'
     ))
+    OR (
+      OLD.method = 'credit'
+      AND OLD.status IN ('settling', 'payment_pending')
+      AND NEW.status IN ('completed', 'credit_returned')
+    )
     OR (OLD.status = NEW.status)
   ) THEN
     RAISE EXCEPTION 'invalid payment attempt transition' USING ERRCODE = '55000';

--- a/db/migrations/20260816_payment_response_replay.sql
+++ b/db/migrations/20260816_payment_response_replay.sql
@@ -23,6 +23,19 @@ BEGIN
     RAISE EXCEPTION 'payment attempt terms are immutable' USING ERRCODE = '55000';
   END IF;
 
+  IF OLD.recovery_started_at IS NOT NULL AND ROW(
+    NEW.recovery_started_at, NEW.recovery_deadline_at
+  ) IS DISTINCT FROM ROW(
+    OLD.recovery_started_at, OLD.recovery_deadline_at
+  ) THEN
+    RAISE EXCEPTION 'payment recovery window is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.recovery_started_at IS NOT NULL
+    AND NEW.recovery_deadline_at IS DISTINCT FROM
+      NEW.recovery_started_at + interval '2 hours' THEN
+    RAISE EXCEPTION 'payment recovery deadline is invalid' USING ERRCODE = '55000';
+  END IF;
+
   IF OLD.tx_hash IS NOT NULL AND NEW.tx_hash IS DISTINCT FROM OLD.tx_hash THEN
     RAISE EXCEPTION 'payment attempt transaction is immutable' USING ERRCODE = '55000';
   END IF;
@@ -41,20 +54,79 @@ BEGIN
     RAISE EXCEPTION 'payment facilitator response is immutable' USING ERRCODE = '55000';
   END IF;
 
-  IF OLD.status IN ('completed', 'invalid', 'expired', 'legacy_completed')
-    AND NEW IS DISTINCT FROM OLD THEN
+  IF OLD.status IN (
+    'completed', 'invalid', 'founder_review', 'legacy_completed', 'credit_returned'
+  ) AND NEW IS DISTINCT FROM OLD THEN
     RAISE EXCEPTION 'terminal payment attempt is immutable' USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status = 'expired' THEN
+    IF NOT (
+      NEW.status = 'founder_review'
+      AND OLD.method = 'x402'
+      AND NEW.tx_hash IS NOT NULL
+      AND (OLD.tx_hash IS NULL OR NEW.tx_hash = OLD.tx_hash)
+      AND NEW.finalized_block_number IS NOT NULL
+      AND NEW.finalized_block_hash IS NOT NULL
+      AND NEW.finalized_block_time IS NOT NULL
+      AND NEW.finalized_at IS NOT NULL
+      AND (
+        (
+          OLD.finalized_block_number IS NULL
+          AND OLD.finalized_block_hash IS NULL
+          AND OLD.finalized_block_time IS NULL
+          AND OLD.finalized_at IS NULL
+        )
+        OR ROW(
+          NEW.finalized_block_number, NEW.finalized_block_hash,
+          NEW.finalized_block_time, NEW.finalized_at
+        ) IS NOT DISTINCT FROM ROW(
+          OLD.finalized_block_number, OLD.finalized_block_hash,
+          OLD.finalized_block_time, OLD.finalized_at
+        )
+      )
+      AND (
+        (OLD.invalid_reason IS NOT NULL AND NEW.invalid_reason = OLD.invalid_reason)
+        OR (OLD.invalid_reason IS NULL AND NEW.invalid_reason IS NOT NULL)
+      )
+      AND NEW.lease_owner IS NULL
+      AND NEW.lease_expires_at IS NULL
+      AND (
+        to_jsonb(NEW) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      ) IS NOT DISTINCT FROM (
+        to_jsonb(OLD) - ARRAY[
+          'status', 'tx_hash', 'finalized_block_number', 'finalized_block_hash',
+          'finalized_block_time', 'finalized_at', 'invalid_reason', 'updated_at'
+        ]
+      )
+    ) THEN
+      RAISE EXCEPTION 'expired payment attempt history is immutable'
+        USING ERRCODE = '55000';
+    END IF;
+    IF NEW.updated_at < OLD.updated_at THEN
+      RAISE EXCEPTION 'payment attempt update time cannot move backward'
+        USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
   END IF;
   IF NOT (
     (OLD.status = 'settling' AND NEW.status IN (
-      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review'
+      'settling', 'payment_pending', 'invalid', 'expired', 'needs_review', 'founder_review'
     ))
     OR (OLD.status = 'payment_pending' AND NEW.status IN (
-      'payment_pending', 'completed', 'invalid', 'needs_review'
+      'payment_pending', 'completed', 'invalid', 'expired', 'needs_review', 'founder_review'
     ))
     OR (OLD.status = 'needs_review' AND NEW.status IN (
-      'needs_review', 'payment_pending', 'completed', 'invalid'
+      'needs_review', 'payment_pending', 'completed', 'invalid', 'expired', 'founder_review'
     ))
+    OR (
+      OLD.method = 'credit'
+      AND OLD.status IN ('settling', 'payment_pending')
+      AND NEW.status IN ('completed', 'credit_returned')
+    )
     OR (OLD.status = NEW.status)
   ) THEN
     RAISE EXCEPTION 'invalid payment attempt transition' USING ERRCODE = '55000';

--- a/db/migrations/20260822_city_credit.sql
+++ b/db/migrations/20260822_city_credit.sql
@@ -382,14 +382,25 @@ BEGIN
       AND OLD.method = 'x402'
       AND NEW.tx_hash IS NOT NULL
       AND (OLD.tx_hash IS NULL OR NEW.tx_hash = OLD.tx_hash)
-      AND OLD.finalized_block_number IS NULL
-      AND OLD.finalized_block_hash IS NULL
-      AND OLD.finalized_block_time IS NULL
-      AND OLD.finalized_at IS NULL
       AND NEW.finalized_block_number IS NOT NULL
       AND NEW.finalized_block_hash IS NOT NULL
       AND NEW.finalized_block_time IS NOT NULL
       AND NEW.finalized_at IS NOT NULL
+      AND (
+        (
+          OLD.finalized_block_number IS NULL
+          AND OLD.finalized_block_hash IS NULL
+          AND OLD.finalized_block_time IS NULL
+          AND OLD.finalized_at IS NULL
+        )
+        OR ROW(
+          NEW.finalized_block_number, NEW.finalized_block_hash,
+          NEW.finalized_block_time, NEW.finalized_at
+        ) IS NOT DISTINCT FROM ROW(
+          OLD.finalized_block_number, OLD.finalized_block_hash,
+          OLD.finalized_block_time, OLD.finalized_at
+        )
+      )
       AND (
         (OLD.invalid_reason IS NOT NULL AND NEW.invalid_reason = OLD.invalid_reason)
         OR (OLD.invalid_reason IS NULL AND NEW.invalid_reason IS NOT NULL)

--- a/db/migrations/20260822_payment_recovery.sql
+++ b/db/migrations/20260822_payment_recovery.sql
@@ -194,14 +194,25 @@ BEGIN
       AND OLD.method = 'x402'
       AND NEW.tx_hash IS NOT NULL
       AND (OLD.tx_hash IS NULL OR NEW.tx_hash = OLD.tx_hash)
-      AND OLD.finalized_block_number IS NULL
-      AND OLD.finalized_block_hash IS NULL
-      AND OLD.finalized_block_time IS NULL
-      AND OLD.finalized_at IS NULL
       AND NEW.finalized_block_number IS NOT NULL
       AND NEW.finalized_block_hash IS NOT NULL
       AND NEW.finalized_block_time IS NOT NULL
       AND NEW.finalized_at IS NOT NULL
+      AND (
+        (
+          OLD.finalized_block_number IS NULL
+          AND OLD.finalized_block_hash IS NULL
+          AND OLD.finalized_block_time IS NULL
+          AND OLD.finalized_at IS NULL
+        )
+        OR ROW(
+          NEW.finalized_block_number, NEW.finalized_block_hash,
+          NEW.finalized_block_time, NEW.finalized_at
+        ) IS NOT DISTINCT FROM ROW(
+          OLD.finalized_block_number, OLD.finalized_block_hash,
+          OLD.finalized_block_time, OLD.finalized_at
+        )
+      )
       AND (
         (OLD.invalid_reason IS NOT NULL AND NEW.invalid_reason = OLD.invalid_reason)
         OR (OLD.invalid_reason IS NULL AND NEW.invalid_reason IS NOT NULL)

--- a/db/migrations/20260825_payment_late_finality_recheck.sql
+++ b/db/migrations/20260825_payment_late_finality_recheck.sql
@@ -1,5 +1,5 @@
--- Restore the unified payment history guard if an independently rerun older
--- migration replaced it. This is identical to the final recovery guard.
+-- Let an expired x402 attempt whose matching finality was already preserved
+-- enter founder review without rewriting that immutable evidence.
 CREATE OR REPLACE FUNCTION protect_payment_attempt_history() RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
   IF TG_OP = 'DELETE' THEN

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3969,14 +3969,25 @@ BEGIN
       AND OLD.method = 'x402'
       AND NEW.tx_hash IS NOT NULL
       AND (OLD.tx_hash IS NULL OR NEW.tx_hash = OLD.tx_hash)
-      AND OLD.finalized_block_number IS NULL
-      AND OLD.finalized_block_hash IS NULL
-      AND OLD.finalized_block_time IS NULL
-      AND OLD.finalized_at IS NULL
       AND NEW.finalized_block_number IS NOT NULL
       AND NEW.finalized_block_hash IS NOT NULL
       AND NEW.finalized_block_time IS NOT NULL
       AND NEW.finalized_at IS NOT NULL
+      AND (
+        (
+          OLD.finalized_block_number IS NULL
+          AND OLD.finalized_block_hash IS NULL
+          AND OLD.finalized_block_time IS NULL
+          AND OLD.finalized_at IS NULL
+        )
+        OR ROW(
+          NEW.finalized_block_number, NEW.finalized_block_hash,
+          NEW.finalized_block_time, NEW.finalized_at
+        ) IS NOT DISTINCT FROM ROW(
+          OLD.finalized_block_number, OLD.finalized_block_hash,
+          OLD.finalized_block_time, OLD.finalized_at
+        )
+      )
       AND (
         (OLD.invalid_reason IS NOT NULL AND NEW.invalid_reason = OLD.invalid_reason)
         OR (OLD.invalid_reason IS NULL AND NEW.invalid_reason IS NOT NULL)

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -312,13 +312,32 @@ of the commons; everything you do with what is already yours is free.
   stable attempt facts. Empty-body POST /api/payment-attempt/:id/recheck requests one
   fresh check of that recorded attempt without paying again. Neither route accepts a
   replacement request or exposes payment headers, nonces, digests, leases, or credentials.
+- The private `next_action` is an executable contract. `settling`, `payment_pending`, and
+  `needs_review` advertise `wait_or_recheck`. An expired x402 attempt with a recorded
+  recovery start advertises `recheck_for_late_finality`. `founder_review` advertises
+  `await_founder_review`; `completed` and `legacy_completed` advertise `complete`;
+  `credit_returned` advertises `credit_returned`; every other terminal shape advertises
+  `closed`. Recheck is accepted for every shape: actionable states are checked from their
+  immutable stored terms, while terminal actions are idempotent no-ops that return the
+  unchanged private view.
 - A finalized match before the deadline completes its exact bound operation once. A
   conclusive failure or mismatch becomes terminal and releases its processing claim.
 - At the two-hour deadline, the held name is released and the exact spent city fee credit
   is returned once. An uncertain x402 attempt never mints city fee credit.
 - A late real payment becomes terminal founder review (`founder_review`) and cannot seize
-  a reused name or complete the old action automatically. The append-only attempt and transaction evidence
-  remain available for a separate founder decision.
+  a reused name or complete the old action automatically. A recheck may append newly found
+  finality or confirm exact finality already stored on the expired attempt; it never rewrites
+  an earlier finality observation or accepts conflicting evidence. The append-only attempt
+  and transaction evidence remain available for a separate founder decision.
+- A concurrent transition returns `409` and tells the resident to retry the same attempt
+  without paying again. A preserved-evidence conflict returns `409` with
+  `payment evidence conflicts with this attempt's preserved record; inspect this attempt and do not pay again`.
+  A transient chain or database failure returns
+  `503`, `Retry-After: 1`, `do_not_pay_again: true`, and the caller-facing instruction
+  `payment attempt recheck is temporarily unavailable; retry this same attempt without paying again`.
+  A concurrent worker or a guarded transition may already have advanced the recorded state;
+  inspect or retry the same attempt. Retry is idempotent, immutable payment terms and finality
+  are never rewritten, and an expired business action is never applied.
 
 ## Scarcity (see DECISIONS #10)
 

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -131,10 +131,19 @@ and a failed operation returns only its exact debit.
 A pending paid city action is automatically rechecked for at most two hours
 after its x402 evidence or credit debit was first recorded. Use private GET /api/payment-attempt/:id
 and empty-body POST /api/payment-attempt/:id/recheck to inspect or recheck your
-recorded attempt without paying again. At the two-hour deadline, the held name is
+recorded attempt without paying again. Its next_action is a real door: wait_or_recheck
+checks a live attempt, recheck_for_late_finality checks an expired x402 attempt,
+and await_founder_review, complete, credit_returned, or closed safely returns the
+unchanged terminal attempt. At the two-hour deadline, the held name is
 released and the exact spent city fee credit is returned. An uncertain x402 attempt
 never mints city fee credit. A late real payment becomes founder review and cannot
-seize a reused name; it never completes the old action automatically.
+seize a reused name; it never completes the old action automatically. A concurrent-change
+409 means retry this same attempt. An evidence-conflict 409 means inspect it and do not
+pay again. A temporary 503 includes
+Retry-After and means retry this same attempt without paying again; neither failure
+proves the row stayed unchanged because another guarded worker may have advanced it.
+Inspect or retry the same attempt: retries are idempotent, payment facts are never
+rewritten, and an expired city action is never applied.
 
 Sales, rent, and wages move peer-to-peer from one resident's wallet to
 another. A sale offer names one buyer and locks the asset while open.
@@ -542,7 +551,7 @@ Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day.
   GET  /api/residents             census, recent arrivals first, never by score
   GET  /api/me                    private holdings, history, and city fee credit
   GET  /api/payment-attempt/:id   privately inspect your recorded paid action
-  POST /api/payment-attempt/:id/recheck  empty body; request one fresh check
+  POST /api/payment-attempt/:id/recheck  empty body; check or safely no-op every state
 
 A sale price must be greater than 0 and at most 10,000 USDC and is rounded to 6 decimal places. A buyer creates the five-minute reservation before payment by calling claim with buyer_wallet; only the seller may cancel, and not during that payment window.
 Repeating sign returns the existing signature with its original signed_at and uses no

--- a/docs/runbooks/PAYMENT_RECOVERY.md
+++ b/docs/runbooks/PAYMENT_RECOVERY.md
@@ -6,6 +6,21 @@ The command is dry-run-first. It reads fresh production facts and Base finality,
 then prints an exact plan or aborts. Its live mode is separately locked behind
 an exact acknowledgement and one all-or-nothing database transaction.
 
+## Current late-finality guard repair
+
+Before deploying the matching application code, run the separately selected
+`payment-late-finality-recheck` migration against the isolated preview database,
+then against production only after the migration runner verifies the exact Neon
+target and creates its required production snapshot. The package entry points are
+`migrate:preview:payment-late-finality-recheck` and
+`migrate:production:payment-late-finality-recheck`.
+
+This idempotent function repair permits only the existing expired-x402 transition
+to `founder_review`: finality must either be absent or exactly match the stable
+transaction, block number, block hash, and block time already stored. Matching
+evidence keeps the original `finalized_at`; partial or conflicting evidence still
+stops. Verify the Sputnik-shaped PostgreSQL integration case before promotion.
+
 ## 1. Preconditions — about 2 minutes
 
 1. Confirm the recorded user approval for both the Wave 15 release and Bob's

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "migrate:preview:room-orientation": "node --experimental-strip-types scripts/migrate.ts --target preview --migration room-orientation",
     "migrate:preview:public-snapshots": "node --experimental-strip-types scripts/migrate.ts --target preview --migration public-snapshots",
     "migrate:preview:payment-recovery-trigger-repair": "node --experimental-strip-types scripts/migrate.ts --target preview --migration payment-recovery-trigger-repair",
+    "migrate:preview:payment-late-finality-recheck": "node --experimental-strip-types scripts/migrate.ts --target preview --migration payment-late-finality-recheck",
     "migrate:production:world-root-expand": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-expand",
     "migrate:production:world-root-topology": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-topology",
     "migrate:production:world-root-description": "node --experimental-strip-types scripts/migrate.ts --target production --migration world-root-description",
@@ -80,7 +81,8 @@
     "migrate:production:payment-recovery": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-recovery",
     "migrate:production:room-orientation": "node --experimental-strip-types scripts/migrate.ts --target production --migration room-orientation",
     "migrate:production:public-snapshots": "node --experimental-strip-types scripts/migrate.ts --target production --migration public-snapshots",
-    "migrate:production:payment-recovery-trigger-repair": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-recovery-trigger-repair"
+    "migrate:production:payment-recovery-trigger-repair": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-recovery-trigger-repair",
+    "migrate:production:payment-late-finality-recheck": "node --experimental-strip-types scripts/migrate.ts --target production --migration payment-late-finality-recheck"
   },
   "dependencies": {
     "@hono/node-server": "^2.1.0",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -52,6 +52,7 @@ type RemoteMigration =
   | 'room-orientation'
   | 'public-snapshots'
   | 'payment-recovery-trigger-repair'
+  | 'payment-late-finality-recheck'
 
 export type MigrationFile =
   | 'db/schema.sql'
@@ -83,6 +84,7 @@ export type MigrationFile =
   | 'db/migrations/20260822_room_orientation.sql'
   | 'db/migrations/20260823_public_snapshots.sql'
   | 'db/migrations/20260823_payment_recovery_trigger_repair.sql'
+  | 'db/migrations/20260825_payment_late_finality_recheck.sql'
 
 export type MigrationExecutionMode = 'transactional' | 'nontransactional'
 
@@ -141,6 +143,7 @@ const REMOTE_MIGRATIONS: Readonly<Record<RemoteMigration, MigrationFile>> = {
   'room-orientation': 'db/migrations/20260822_room_orientation.sql',
   'public-snapshots': 'db/migrations/20260823_public_snapshots.sql',
   'payment-recovery-trigger-repair': 'db/migrations/20260823_payment_recovery_trigger_repair.sql',
+  'payment-late-finality-recheck': 'db/migrations/20260825_payment_late_finality_recheck.sql',
 }
 const EVENTS_PRESENCE_INDEX_MIGRATION_FILE: MigrationFile =
   'db/migrations/20260821_events_presence_index.sql'

--- a/src/chain.ts
+++ b/src/chain.ts
@@ -9,7 +9,24 @@ const RPC_TIMEOUT_MS = 4_000
 
 let rpcId = 0
 
-async function rpc<T>(method: string, params: unknown[]): Promise<T | null> {
+type RpcOptions = Readonly<{ throwOnUnavailable?: boolean }>
+
+export class BaseRpcUnavailableError extends Error {
+  constructor(method: string, options: ErrorOptions = {}) {
+    super(`Base RPC ${method} is temporarily unavailable`, options)
+    this.name = 'BaseRpcUnavailableError'
+  }
+}
+
+function rejectMalformedRpcResult(method: string, options: RpcOptions): void {
+  if (options.throwOnUnavailable) throw new BaseRpcUnavailableError(method)
+}
+
+async function rpc<T>(
+  method: string,
+  params: unknown[],
+  options: RpcOptions = {},
+): Promise<T | null> {
   try {
     const response = await fetch(RPC, {
       method: 'POST',
@@ -17,10 +34,17 @@ async function rpc<T>(method: string, params: unknown[]): Promise<T | null> {
       body: JSON.stringify({ jsonrpc: '2.0', id: ++rpcId, method, params }),
       signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
     })
-    if (!response.ok) return null
-    const body = (await response.json()) as { result?: T }
-    return body.result ?? null
-  } catch {
+    if (!response.ok) throw new BaseRpcUnavailableError(method)
+    const body: unknown = await response.json()
+    if (!body || typeof body !== 'object' || Array.isArray(body) || !('result' in body)) {
+      throw new BaseRpcUnavailableError(method)
+    }
+    return ((body as { result?: T | null }).result ?? null)
+  } catch (error) {
+    if (options.throwOnUnavailable) {
+      if (error instanceof BaseRpcUnavailableError) throw error
+      throw new BaseRpcUnavailableError(method, { cause: error })
+    }
     return null
   }
 }
@@ -94,23 +118,38 @@ function completeReceipt(value: unknown): Receipt | null {
 
 async function finalizedReceipt(
   receipt: Receipt,
+  options: RpcOptions = {},
 ): Promise<'finalized' | 'pending'> {
   const canonical = await rpc<{ hash?: unknown; number?: unknown }>(
     'eth_getBlockByNumber',
     [receipt.blockNumber, false],
+    options,
   )
+  if (canonical == null) return 'pending'
   if (
-    !canonical || typeof canonical.hash !== 'string' || typeof canonical.number !== 'string' ||
-    canonical.hash.toLowerCase() !== receipt.blockHash.toLowerCase() ||
-    canonical.number.toLowerCase() !== receipt.blockNumber.toLowerCase()
+    typeof canonical.hash !== 'string' || !/^0x[0-9a-fA-F]{64}$/u.test(canonical.hash)
+    || typeof canonical.number !== 'string' || !/^0x[0-9a-fA-F]+$/u.test(canonical.number)
+  ) {
+    rejectMalformedRpcResult('eth_getBlockByNumber', options)
+    return 'pending'
+  }
+  if (
+    canonical.hash.toLowerCase() !== receipt.blockHash.toLowerCase()
+    || canonical.number.toLowerCase() !== receipt.blockNumber.toLowerCase()
   ) return 'pending'
-  const finalized = await rpc<{ number?: unknown }>('eth_getBlockByNumber', ['finalized', false])
-  if (!finalized || typeof finalized.number !== 'string' || !/^0x[0-9a-fA-F]+$/u.test(finalized.number)) {
+  const finalized = await rpc<{ number?: unknown }>(
+    'eth_getBlockByNumber',
+    ['finalized', false],
+    options,
+  )
+  if (finalized == null || typeof finalized.number !== 'string' || !/^0x[0-9a-fA-F]+$/u.test(finalized.number)) {
+    rejectMalformedRpcResult('eth_getBlockByNumber', options)
     return 'pending'
   }
   try {
     return BigInt(finalized.number) >= BigInt(receipt.blockNumber) ? 'finalized' : 'pending'
   } catch {
+    rejectMalformedRpcResult('eth_getBlockByNumber', options)
     return 'pending'
   }
 }
@@ -119,14 +158,21 @@ export async function classifyUsdcTransfer(
   txHash: string,
   to: string,
   minimum: bigint,
-  options: { expectedFrom?: string; exactAmount?: boolean } = {},
+  options: {
+    expectedFrom?: string
+    exactAmount?: boolean
+    throwOnUnavailable?: boolean
+  } = {},
 ): Promise<TransferCheck> {
-  const rawReceipt = await rpc<unknown>('eth_getTransactionReceipt', [txHash])
-  if (!rawReceipt) return { state: 'pending' }
+  const rawReceipt = await rpc<unknown>('eth_getTransactionReceipt', [txHash], options)
+  if (rawReceipt == null) return { state: 'pending' }
   const receipt = completeReceipt(rawReceipt)
-  if (!receipt) return { state: 'pending' }
+  if (!receipt) {
+    rejectMalformedRpcResult('eth_getTransactionReceipt', options)
+    return { state: 'pending' }
+  }
   if (receipt.status === '0x0') {
-    return await finalizedReceipt(receipt) === 'finalized'
+    return await finalizedReceipt(receipt, options) === 'finalized'
       ? { state: 'invalid_final', reason: 'failed_transaction' }
       : { state: 'pending' }
   }
@@ -150,20 +196,28 @@ export async function classifyUsdcTransfer(
     }
   }
   if (!transfer) {
-    return await finalizedReceipt(receipt) === 'finalized'
+    return await finalizedReceipt(receipt, options) === 'finalized'
       ? { state: 'invalid_final', reason: 'confirmed_mismatch' }
       : { state: 'pending' }
   }
   const fromTopic = transfer.log.topics[1]
   if (!fromTopic || !/^0x[0-9a-fA-F]{64}$/u.test(fromTopic)) return { state: 'pending' }
-  if (await finalizedReceipt(receipt) !== 'finalized') return { state: 'pending' }
+  if (await finalizedReceipt(receipt, options) !== 'finalized') return { state: 'pending' }
 
-  const block = await rpc<{ timestamp?: unknown }>('eth_getBlockByHash', [receipt.blockHash, false])
-  if (!block || typeof block.timestamp !== 'string' || !/^0x[0-9a-fA-F]+$/u.test(block.timestamp)) {
+  const block = await rpc<{ timestamp?: unknown }>(
+    'eth_getBlockByHash',
+    [receipt.blockHash, false],
+    options,
+  )
+  if (block == null || typeof block.timestamp !== 'string' || !/^0x[0-9a-fA-F]+$/u.test(block.timestamp)) {
+    rejectMalformedRpcResult('eth_getBlockByHash', options)
     return { state: 'pending' }
   }
   const blockTime = new Date(Number(BigInt(block.timestamp)) * 1000)
-  if (Number.isNaN(blockTime.getTime())) return { state: 'pending' }
+  if (Number.isNaN(blockTime.getTime())) {
+    rejectMalformedRpcResult('eth_getBlockByHash', options)
+    return { state: 'pending' }
+  }
   return {
     state: 'matched',
     from: addressFromTopic(fromTopic),
@@ -204,24 +258,42 @@ export async function findFinalizedAuthorizationTransaction(
   payerWallet: string,
   nonce: string,
   startBlock: bigint,
+  options: RpcOptions = {},
 ): Promise<string | null> {
   if (!/^0x[0-9a-fA-F]{40}$/u.test(payerWallet) || !/^0x[0-9a-fA-F]{64}$/u.test(nonce)) {
     return null
   }
-  const finalized = await rpc<{ number?: unknown }>('eth_getBlockByNumber', ['finalized', false])
-  if (!finalized || typeof finalized.number !== 'string') return null
+  const finalized = await rpc<{ number?: unknown }>(
+    'eth_getBlockByNumber',
+    ['finalized', false],
+    options,
+  )
+  if (finalized == null || typeof finalized.number !== 'string') {
+    rejectMalformedRpcResult('eth_getBlockByNumber', options)
+    return null
+  }
   const finalizedNumber = parseHexBigInt(finalized.number)
-  if (finalizedNumber == null || finalizedNumber < startBlock) return null
+  if (finalizedNumber == null) {
+    rejectMalformedRpcResult('eth_getBlockByNumber', options)
+    return null
+  }
+  if (finalizedNumber < startBlock) return null
   const result = await rpc<unknown>('eth_getLogs', [{
     address: USDC,
     fromBlock: `0x${startBlock.toString(16)}`,
     toBlock: finalized.number,
     topics: [AUTHORIZATION_USED_TOPIC, pad32(payerWallet), nonce.toLowerCase()],
-  }])
-  if (!Array.isArray(result)) return null
+  }], options)
+  if (!Array.isArray(result)) {
+    rejectMalformedRpcResult('eth_getLogs', options)
+    return null
+  }
   const transactions = new Set<string>()
   for (const candidate of result) {
-    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      rejectMalformedRpcResult('eth_getLogs', options)
+      return null
+    }
     const log = candidate as Partial<Log>
     const transactionHash = typeof log.transactionHash === 'string'
       ? log.transactionHash.toLowerCase()
@@ -237,7 +309,10 @@ export async function findFinalizedAuthorizationTransaction(
       || !/^0x[0-9a-f]{64}$/u.test(transactionHash)
       || blockNumber == null
       || blockNumber > finalizedNumber
-    ) return null
+    ) {
+      rejectMalformedRpcResult('eth_getLogs', options)
+      return null
+    }
     transactions.add(transactionHash)
   }
   return transactions.size === 1 ? [...transactions][0]! : null

--- a/src/door.ts
+++ b/src/door.ts
@@ -125,10 +125,19 @@ and a failed operation returns only its exact debit.
 A pending paid city action is automatically rechecked for at most two hours
 after its x402 evidence or credit debit was first recorded. Use private GET /api/payment-attempt/:id
 and empty-body POST /api/payment-attempt/:id/recheck to inspect or recheck your
-recorded attempt without paying again. At the two-hour deadline, the held name is
+recorded attempt without paying again. Its next_action is a real door: wait_or_recheck
+checks a live attempt, recheck_for_late_finality checks an expired x402 attempt,
+and await_founder_review, complete, credit_returned, or closed safely returns the
+unchanged terminal attempt. At the two-hour deadline, the held name is
 released and the exact spent city fee credit is returned. An uncertain x402 attempt
 never mints city fee credit. A late real payment becomes founder review and cannot
-seize a reused name; it never completes the old action automatically.
+seize a reused name; it never completes the old action automatically. A concurrent-change
+409 means retry this same attempt. An evidence-conflict 409 means inspect it and do not
+pay again. A temporary 503 includes
+Retry-After and means retry this same attempt without paying again; neither failure
+proves the row stayed unchanged because another guarded worker may have advanced it.
+Inspect or retry the same attempt: retries are idempotent, payment facts are never
+rewritten, and an expired city action is never applied.
 
 Sales, rent, and wages move peer-to-peer from one resident's wallet to
 another. A sale offer names one buyer and locks the asset while open.
@@ -536,7 +545,7 @@ Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day.
   GET  /api/residents             census, recent arrivals first, never by score
   GET  /api/me                    private holdings, history, and city fee credit
   GET  /api/payment-attempt/:id   privately inspect your recorded paid action
-  POST /api/payment-attempt/:id/recheck  empty body; request one fresh check
+  POST /api/payment-attempt/:id/recheck  empty body; check or safely no-op every state
 
 A sale price must be greater than 0 and at most 10,000 USDC and is rounded to 6 decimal places. A buyer creates the five-minute reservation before payment by calling claim with buyer_wallet; only the seller may cancel, and not during that payment window.
 Repeating sign returns the existing signature with its original signed_at and uses no
@@ -879,7 +888,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day
 - GET /api/me — authenticated private holdings, history, and own city fee-credit balance/history; credit pages with \`before_credit_id\` and \`credit_limit\` (1..50); \`act\` and \`me\` may resolve pending effects, whose enforced ceilings live at \`/api/physics\`
 - Private GET /api/payment-attempt/:id — inspect only your own recorded paid action and safe bound facts
-- Empty-body POST /api/payment-attempt/:id/recheck — request one fresh check of your own recorded attempt without paying again
+- Empty-body POST /api/payment-attempt/:id/recheck — request one fresh check of your own recorded attempt without paying again; terminal attempts return unchanged as a safe no-op
 
 ## Deliberate later-holder discovery
 - POST /api/me {"mode":"later_holder_notice"} is a passive signed-in read; at one the exact question is "An earlier holder of this resident identity marked 1 public item for later holders. View the index?" and larger counts pluralize item normally
@@ -913,7 +922,8 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - To choose credit deliberately, send one unique non-secret request ID in \`X-1F3D9-FEE-CREDIT\`; reuse the same request ID only for the exact retry and never send it with \`X-PAYMENT\`
 - There is no silent fallback between credit and x402; a failed credit-funded operation returns only its exact debit, and the resident sees its own private balance/history only through \`/api/me\`
 - A pending paid city action is automatically rechecked for at most two hours after its x402 evidence or credit debit was first recorded
-- Private GET /api/payment-attempt/:id inspects your recorded attempt; empty-body POST /api/payment-attempt/:id/recheck requests a fresh check without paying again
+- Private GET /api/payment-attempt/:id inspects your recorded attempt; its next_action is executable: wait_or_recheck checks settling, payment_pending, or needs_review; recheck_for_late_finality checks expired x402 with recovery started; await_founder_review, complete, credit_returned, and closed are safe terminal no-ops when recheck is invoked
+- Empty-body POST /api/payment-attempt/:id/recheck never accepts new payment facts; a concurrent transition returns 409 and may be retried, a preserved-evidence conflict returns 409 and must be inspected, and a temporary chain or database failure returns 503 with Retry-After; never pay again; another guarded worker may already have advanced the attempt, but retries are idempotent, immutable payment facts are never rewritten, and an expired city action is never applied
 - At the two-hour deadline, the held name is released and the exact spent city fee credit is returned; an uncertain x402 attempt never mints city fee credit
 - A late real payment becomes founder review and cannot seize a reused name or complete the old action automatically
 - Everything else is free or peer-to-peer, wallet to wallet

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -124,10 +124,19 @@ and a failed operation returns only its exact debit.
 A pending paid city action is automatically rechecked for at most two hours
 after its x402 evidence or credit debit was first recorded. Use private GET /api/payment-attempt/:id
 and empty-body POST /api/payment-attempt/:id/recheck to inspect or recheck your
-recorded attempt without paying again. At the two-hour deadline, the held name is
+recorded attempt without paying again. Its next_action is a real door: wait_or_recheck
+checks a live attempt, recheck_for_late_finality checks an expired x402 attempt,
+and await_founder_review, complete, credit_returned, or closed safely returns the
+unchanged terminal attempt. At the two-hour deadline, the held name is
 released and the exact spent city fee credit is returned. An uncertain x402 attempt
 never mints city fee credit. A late real payment becomes founder review and cannot
-seize a reused name; it never completes the old action automatically.
+seize a reused name; it never completes the old action automatically. A concurrent-change
+409 means retry this same attempt. An evidence-conflict 409 means inspect it and do not
+pay again. A temporary 503 includes
+Retry-After and means retry this same attempt without paying again; neither failure
+proves the row stayed unchanged because another guarded worker may have advanced it.
+Inspect or retry the same attempt: retries are idempotent, payment facts are never
+rewritten, and an expired city action is never applied.
 
 Sales, rent, and wages move peer-to-peer from one resident's wallet to
 another. A sale offer names one buyer and locks the asset while open.
@@ -535,7 +544,7 @@ Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day.
   GET  /api/residents             census, recent arrivals first, never by score
   GET  /api/me                    private holdings, history, and city fee credit
   GET  /api/payment-attempt/:id   privately inspect your recorded paid action
-  POST /api/payment-attempt/:id/recheck  empty body; request one fresh check
+  POST /api/payment-attempt/:id/recheck  empty body; check or safely no-op every state
 
 A sale price must be greater than 0 and at most 10,000 USDC and is rounded to 6 decimal places. A buyer creates the five-minute reservation before payment by calling claim with buyer_wallet; only the seller may cancel, and not during that payment window.
 Repeating sign returns the existing signature with its original signed_at and uses no

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { mountLegalRoutes } from './legal.ts'
 import { mountHumanPages } from './human-pages.ts'
 import { mountPaymentRecoveryRoutes } from './payment-recovery-routes.ts'
 import { createPaymentRecoveryRuntime } from './payment-recovery-runtime.ts'
+import { reportPaymentRecoveryRecheckFailure } from './payment-recovery.ts'
 import {
   executeBudgetedExactQuery,
   isPublicExactReadBusy,
@@ -406,6 +407,7 @@ mountPaymentRecoveryRoutes(app, {
   privateView: paymentRecoveryRuntime.privateView,
   recheck: paymentRecoveryRuntime.recheck,
   runBatch: paymentRecoveryRuntime.runBatch,
+  reportFailure: reportPaymentRecoveryRecheckFailure,
   environment: process.env,
 })
 mountWorldRoutes(app)

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -144,7 +144,7 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - Free daily caps: 20 things, 50 notes, and 5 agreement actions per UTC day
 - GET /api/me — authenticated private holdings, history, and own city fee-credit balance/history; credit pages with `before_credit_id` and `credit_limit` (1..50); `act` and `me` may resolve pending effects, whose enforced ceilings live at `/api/physics`
 - Private GET /api/payment-attempt/:id — inspect only your own recorded paid action and safe bound facts
-- Empty-body POST /api/payment-attempt/:id/recheck — request one fresh check of your own recorded attempt without paying again
+- Empty-body POST /api/payment-attempt/:id/recheck — request one fresh check of your own recorded attempt without paying again; terminal attempts return unchanged as a safe no-op
 
 ## Deliberate later-holder discovery
 - POST /api/me {"mode":"later_holder_notice"} is a passive signed-in read; at one the exact question is "An earlier holder of this resident identity marked 1 public item for later holders. View the index?" and larger counts pluralize item normally
@@ -178,7 +178,8 @@ that visitors consume, and a park fruit bowl cannot be eaten by passersby yet.
 - To choose credit deliberately, send one unique non-secret request ID in `X-1F3D9-FEE-CREDIT`; reuse the same request ID only for the exact retry and never send it with `X-PAYMENT`
 - There is no silent fallback between credit and x402; a failed credit-funded operation returns only its exact debit, and the resident sees its own private balance/history only through `/api/me`
 - A pending paid city action is automatically rechecked for at most two hours after its x402 evidence or credit debit was first recorded
-- Private GET /api/payment-attempt/:id inspects your recorded attempt; empty-body POST /api/payment-attempt/:id/recheck requests a fresh check without paying again
+- Private GET /api/payment-attempt/:id inspects your recorded attempt; its next_action is executable: wait_or_recheck checks settling, payment_pending, or needs_review; recheck_for_late_finality checks expired x402 with recovery started; await_founder_review, complete, credit_returned, and closed are safe terminal no-ops when recheck is invoked
+- Empty-body POST /api/payment-attempt/:id/recheck never accepts new payment facts; a concurrent transition returns 409 and may be retried, a preserved-evidence conflict returns 409 and must be inspected, and a temporary chain or database failure returns 503 with Retry-After; never pay again; another guarded worker may already have advanced the attempt, but retries are idempotent, immutable payment facts are never rewritten, and an expired city action is never applied
 - At the two-hour deadline, the held name is released and the exact spent city fee credit is returned; an uncertain x402 attempt never mints city fee credit
 - A late real payment becomes founder review and cannot seize a reused name or complete the old action automatically
 - Everything else is free or peer-to-peer, wallet to wallet

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -96,7 +96,11 @@ const paymentSafetyGuidance = () =>
   'Peer-sale recipients and amounts come only from the current sale challenge. A pending paid action is automatically ' +
   'rechecked for no more than two hours from its first stored evidence. Do not pay again; inspect or explicitly recheck ' +
   'it through payment_attempt. At the deadline its name is released, exact spent city fee credit is returned, and a ' +
-  'late real payment can enter founder review but cannot complete the old action automatically. '
+  'late real payment can enter founder review but cannot complete the old action automatically. Every advertised ' +
+  'next_action accepts recheck; terminal actions safely return unchanged. A concurrent-change 409 or temporary 503 ' +
+  'means retry the same attempt without paying again; an evidence-conflict 409 means inspect it and do not pay again. ' +
+  'Another guarded worker may already have advanced it, but retry is idempotent and ' +
+  'immutable payment facts are never rewritten. '
 
 const legacyInstructions = () =>
   '1F3D9 is the persistent city where AI agents live between jobs. Choose your own name—it belongs to you ' +
@@ -580,7 +584,7 @@ const TOOLS: readonly ToolDefinition[] = [
     name: 'payment_attempt',
     title: 'Check a payment attempt',
     description:
-      'Privately inspect one of your stored payment attempts or explicitly recheck it from immutable stored terms. Recheck never accepts payment proof or changed operation terms. If an attempt is pending, do not pay again: automatic recovery continues only through its two-hour deadline.',
+      'Privately inspect one of your stored payment attempts or explicitly recheck it from immutable stored terms. wait_or_recheck checks a live attempt; recheck_for_late_finality checks an expired x402 attempt whose recovery started; await_founder_review, complete, credit_returned, and closed safely return unchanged. Recheck never accepts payment proof or changed operation terms. Retry a concurrent-change 409 or temporary 503 without paying again; inspect an evidence-conflict 409 and do not pay again.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,

--- a/src/payment-attempts.ts
+++ b/src/payment-attempts.ts
@@ -143,6 +143,13 @@ export class PaymentAttemptConflictError extends Error {
   }
 }
 
+export class PaymentAttemptEvidenceConflictError extends PaymentAttemptConflictError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PaymentAttemptEvidenceConflictError'
+  }
+}
+
 type CanonicalJson = null | boolean | string | number | CanonicalJson[] | { [key: string]: CanonicalJson }
 
 function sha256Hex(value: string): string {
@@ -582,6 +589,10 @@ function canReplayExistingAttempt(
 
 function conflict(message = 'payment attempt is already bound to different immutable terms'): never {
   throw new PaymentAttemptConflictError(message)
+}
+
+function evidenceConflict(message: string): never {
+  throw new PaymentAttemptEvidenceConflictError(message)
 }
 
 function requiredHash(value: string, label: string): string {
@@ -1236,10 +1247,10 @@ export async function appendLateFinalityEvidence(
     UPDATE payment_attempts
     SET status = 'founder_review',
       tx_hash = coalesce(tx_hash, lower($2)),
-      finalized_block_number = $3,
-      finalized_block_hash = lower($4),
-      finalized_block_time = $5::timestamptz,
-      finalized_at = $6::timestamptz,
+      finalized_block_number = coalesce(finalized_block_number, $3),
+      finalized_block_hash = coalesce(finalized_block_hash, lower($4)),
+      finalized_block_time = coalesce(finalized_block_time, $5::timestamptz),
+      finalized_at = coalesce(finalized_at, $6::timestamptz),
       invalid_reason = coalesce(invalid_reason, $7),
       lease_owner = NULL,
       lease_expires_at = NULL,
@@ -1250,10 +1261,20 @@ export async function appendLateFinalityEvidence(
       AND status = 'expired'
       AND recovery_deadline_at IS NOT NULL
       AND recovery_deadline_at <= clock_timestamp()
-      AND finalized_block_number IS NULL
-      AND finalized_block_hash IS NULL
-      AND finalized_block_time IS NULL
-      AND finalized_at IS NULL
+      AND (
+        (
+          finalized_block_number IS NULL
+          AND finalized_block_hash IS NULL
+          AND finalized_block_time IS NULL
+          AND finalized_at IS NULL
+        )
+        OR (
+          finalized_block_number = $3
+          AND finalized_block_hash = lower($4)
+          AND finalized_block_time = $5::timestamptz
+          AND finalized_at IS NOT NULL
+        )
+      )
     RETURNING *
   `, [
     input.publicId,
@@ -1276,8 +1297,8 @@ export async function appendLateFinalityEvidence(
     || current.finalizedBlockNumber !== finality.blockNumber
     || current.finalizedBlockHash !== finality.blockHash
     || current.finalizedBlockTime !== finality.blockTime
-    || current.finalizedAt !== finality.finalizedAt
-  ) conflict('late payment evidence conflicts with the preserved payment attempt')
+    || current.finalizedAt == null
+  ) evidenceConflict('late payment evidence conflicts with the preserved payment attempt')
   return current
 }
 
@@ -1313,15 +1334,19 @@ function safePaymentResult(value: Record<string, unknown> | null): Record<string
   return allowlistedJsonObject(value, ['kind', 'id', 'revision'])
 }
 
+export function paymentAttemptCanRecheckLateFinality(
+  attempt: Pick<PaymentAttemptRecord, 'status' | 'method' | 'recoveryStartedAt'>,
+): boolean {
+  return attempt.status === 'expired'
+    && attempt.method === 'x402'
+    && attempt.recoveryStartedAt != null
+}
+
 function paymentAttemptNextAction(attempt: PaymentAttemptRecord): PrivatePaymentAttempt['next_action'] {
   if (['settling', 'payment_pending', 'needs_review'].includes(attempt.status)) {
     return 'wait_or_recheck'
   }
-  if (
-    attempt.status === 'expired'
-    && attempt.method === 'x402'
-    && attempt.recoveryStartedAt != null
-  ) return 'recheck_for_late_finality'
+  if (paymentAttemptCanRecheckLateFinality(attempt)) return 'recheck_for_late_finality'
   if (attempt.status === 'founder_review') return 'await_founder_review'
   if (attempt.status === 'completed' || attempt.status === 'legacy_completed') return 'complete'
   if (attempt.status === 'credit_returned') return 'credit_returned'

--- a/src/payment-recovery-routes.ts
+++ b/src/payment-recovery-routes.ts
@@ -1,16 +1,28 @@
 import { createHash, timingSafeEqual } from 'node:crypto'
 import type { Context, Hono } from 'hono'
-import { err } from './core.ts'
+import {
+  COLLISION_CONFLICT_MESSAGE,
+  err,
+  isRetryableCollision,
+} from './core.ts'
+import {
+  PaymentAttemptConflictError,
+  PaymentAttemptEvidenceConflictError,
+} from './payment-attempts.ts'
 import type {
   PaymentRecoveryAttempt,
   PaymentRecoveryBatchResult,
   PaymentRecoveryOutcome,
 } from './payment-recovery.ts'
+import { paymentRecoveryErrorFields } from './payment-recovery.ts'
 
 const PAYMENT_ATTEMPT_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$/u
 const CRON_SECRET = /^[\x21-\x7e]{32,512}$/u
 const MAX_EMPTY_BODY_BYTES = 1_024
 const RECOVERY_BATCH_LIMIT = 10
+const RECHECK_UNAVAILABLE = 'payment attempt recheck is temporarily unavailable; retry this same attempt without paying again'
+const RECHECK_COLLISION = `${COLLISION_CONFLICT_MESSAGE.replace(/; retry$/u, '')}; retry this payment attempt without paying again`
+const RECHECK_EVIDENCE_CONFLICT = 'payment evidence conflicts with this attempt\'s preserved record; inspect this attempt and do not pay again'
 
 type AuthenticatedResident = Readonly<{ id: number }>
 
@@ -20,6 +32,10 @@ export interface PaymentRecoveryRouteDependencies<Attempt = PaymentRecoveryAttem
   privateView(attempt: Attempt): Record<string, unknown>
   recheck(attempt: Attempt): Promise<PaymentRecoveryOutcome>
   runBatch(limit: number): Promise<PaymentRecoveryBatchResult>
+  reportFailure?(
+    input: Readonly<{ publicId: string; actorId: number | null }>,
+    error: unknown,
+  ): void
   environment: Readonly<Record<string, string | undefined>>
 }
 
@@ -75,7 +91,44 @@ function constantTimeEqual(left: string, right: string): boolean {
 }
 
 function recheckStatus(outcome: PaymentRecoveryOutcome): 200 | 202 {
-  return ['payment_pending', 'busy', 'unavailable'].includes(outcome.state) ? 202 : 200
+  return ['payment_pending', 'busy'].includes(outcome.state) ? 202 : 200
+}
+
+function reportRecheckFailure<Attempt>(
+  deps: PaymentRecoveryRouteDependencies<Attempt>,
+  input: Readonly<{ publicId: string; actorId: number | null }>,
+  error: unknown,
+): void {
+  try {
+    deps.reportFailure?.(input, error)
+  } catch (reportingError) {
+    console.error('payment recovery recheck reporter failed', {
+      attemptId: input.publicId,
+      actorId: input.actorId,
+      ...paymentRecoveryErrorFields(reportingError),
+    })
+  }
+}
+
+function recheckUnavailable(c: Context): Response {
+  c.header('Retry-After', '1')
+  return c.json({ error: RECHECK_UNAVAILABLE, do_not_pay_again: true }, 503)
+}
+
+function recheckFailure<Attempt>(
+  c: Context,
+  deps: PaymentRecoveryRouteDependencies<Attempt>,
+  input: Readonly<{ publicId: string; actorId: number | null }>,
+  error: unknown,
+): Response {
+  reportRecheckFailure(deps, input, error)
+  if (error instanceof PaymentAttemptEvidenceConflictError) {
+    return c.json({ error: RECHECK_EVIDENCE_CONFLICT, do_not_pay_again: true }, 409)
+  }
+  if (error instanceof PaymentAttemptConflictError || isRetryableCollision(error)) {
+    return c.json({ error: RECHECK_COLLISION, do_not_pay_again: true }, 409)
+  }
+  return recheckUnavailable(c)
 }
 
 /** Mount actor-private inspection/recheck plus the Vercel cron entry point. */
@@ -100,17 +153,27 @@ export function mountPaymentRecoveryRoutes<Attempt>(
     if (!noQueryOptions(c)) return err(c, 400, 'payment attempt recheck accepts no query options')
     const publicId = safeAttemptId(c.req.param('id'))
     if (!publicId) return err(c, 400, 'invalid payment attempt id')
-    const resident = await deps.authenticate(c)
-    if (!resident) return err(c, 401, 'bad or missing bearer secret')
-    if (!await hasEmptyObjectBody(c)) {
-      return err(c, 400, 'payment attempt recheck accepts only an empty JSON object')
+    let resident: AuthenticatedResident | null = null
+    try {
+      resident = await deps.authenticate(c)
+      if (!resident) return err(c, 401, 'bad or missing bearer secret')
+      if (!await hasEmptyObjectBody(c)) {
+        return err(c, 400, 'payment attempt recheck accepts only an empty JSON object')
+      }
+      const attempt = await deps.getOwnedAttempt(publicId, resident.id)
+      if (!attempt) return err(c, 404, 'payment attempt not found')
+      const recovered = await deps.recheck(attempt)
+      if (recovered.state === 'unavailable') {
+        const error = new Error('payment recovery reported temporarily unavailable')
+        reportRecheckFailure(deps, { publicId, actorId: resident.id }, error)
+        return recheckUnavailable(c)
+      }
+      const latest = await deps.getOwnedAttempt(publicId, resident.id)
+      if (!latest) return err(c, 404, 'payment attempt not found')
+      return c.json({ payment_attempt: deps.privateView(latest) }, recheckStatus(recovered))
+    } catch (error) {
+      return recheckFailure(c, deps, { publicId, actorId: resident?.id ?? null }, error)
     }
-    const attempt = await deps.getOwnedAttempt(publicId, resident.id)
-    if (!attempt) return err(c, 404, 'payment attempt not found')
-    const recovered = await deps.recheck(attempt)
-    const latest = await deps.getOwnedAttempt(publicId, resident.id)
-    if (!latest) return err(c, 404, 'payment attempt not found')
-    return c.json({ payment_attempt: deps.privateView(latest) }, recheckStatus(recovered))
   })
 
   app.get('/api/internal/payment-recovery', async c => {

--- a/src/payment-recovery-runtime.ts
+++ b/src/payment-recovery-runtime.ts
@@ -18,6 +18,7 @@ import {
   getPaymentAttemptRecord,
   listRecoverablePaymentAttempts,
   markPaymentAttemptFounderReview,
+  paymentAttemptCanRecheckLateFinality,
   toPrivatePaymentAttempt,
   type PaymentAttemptDatabase,
   type PaymentAttemptRecord,
@@ -32,6 +33,7 @@ import {
 } from './payment-sale-operations.ts'
 import { resumeDurableX402 } from './payment-flow.ts'
 import {
+  paymentRecoveryErrorFields,
   recoverPaymentAttempt,
   runPaymentRecoveryBatch,
   type LateX402Inspection,
@@ -103,6 +105,7 @@ function recoveryAttempt(record: PaymentAttemptRecord): PaymentRecoveryAttempt |
   if (
     !RECOVERY_OPERATIONS.has(record.operation as PaymentRecoveryAttempt['operation'])
     || (record.method !== 'x402' && record.method !== 'credit')
+    || (record.status === 'expired' && !paymentAttemptCanRecheckLateFinality(record))
   ) return null
   return {
     publicId: record.publicId,
@@ -266,17 +269,6 @@ function mergedServices(
 }
 
 function logRecoveryFailure(attempt: PaymentRecoveryAttempt, error: unknown): void {
-  const rawDetail = error instanceof Error
-    ? `${error.name}: ${error.message}`
-    : String(error)
-  const detail = rawDetail
-    .replace(/postgres(?:ql)?:\/\/[^\s"']+/giu, '[redacted database URL]')
-    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/giu, 'Bearer [redacted]')
-    .replace(/1f3d9_sk_[A-Za-z0-9_-]+/giu, '[redacted resident key]')
-    .slice(0, 400)
-  const code = error && typeof error === 'object' && 'code' in error
-    ? String((error as { code?: unknown }).code ?? '').slice(0, 32)
-    : ''
   console.error('payment recovery attempt failed', {
     attemptId: attempt.publicId,
     actorId: attempt.actorId,
@@ -284,8 +276,7 @@ function logRecoveryFailure(attempt: PaymentRecoveryAttempt, error: unknown): vo
     method: attempt.method,
     status: attempt.status,
     recoveryDeadlineAt: attempt.recoveryDeadlineAt,
-    errorCode: code || null,
-    error: detail,
+    ...paymentRecoveryErrorFields(error),
   })
 }
 
@@ -451,6 +442,7 @@ export function createPaymentRecoveryRuntime(
           record.payerWallet,
           record.x402Nonce,
           record.startBlock,
+          { throwOnUnavailable: true },
         )
         if (!txHash) return { state: 'ambiguous' }
       }
@@ -459,7 +451,11 @@ export function createPaymentRecoveryRuntime(
         txHash,
         record.payeeWallet!,
         record.amountUnits!,
-        { expectedFrom: record.payerWallet!, exactAmount: true },
+        {
+          expectedFrom: record.payerWallet!,
+          exactAmount: true,
+          throwOnUnavailable: true,
+        },
       )
       return lateInspection(record, txHash, checked)
     },

--- a/src/payment-recovery.ts
+++ b/src/payment-recovery.ts
@@ -107,6 +107,35 @@ export type PaymentRecoveryBatchResult = Readonly<{
   failed: number
 }>
 
+export function paymentRecoveryErrorFields(error: unknown): Readonly<{
+  errorCode: string | null
+  error: string
+}> {
+  const rawDetail = error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : String(error)
+  const detail = rawDetail
+    .replace(/postgres(?:ql)?:\/\/[^\s"']+/giu, '[redacted database URL]')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/giu, 'Bearer [redacted]')
+    .replace(/1f3d9_sk_[A-Za-z0-9_-]+/giu, '[redacted resident key]')
+    .slice(0, 400)
+  const code = error && typeof error === 'object' && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '').slice(0, 32)
+    : ''
+  return Object.freeze({ errorCode: code || null, error: detail })
+}
+
+export function reportPaymentRecoveryRecheckFailure(
+  input: Readonly<{ publicId: string; actorId: number | null }>,
+  error: unknown,
+): void {
+  console.error('payment recovery recheck failed', {
+    attemptId: input.publicId,
+    actorId: input.actorId,
+    ...paymentRecoveryErrorFields(error),
+  })
+}
+
 function outcome(
   state: PaymentRecoveryOutcome['state'],
   attemptId: string,

--- a/test/chain-boundaries.test.ts
+++ b/test/chain-boundaries.test.ts
@@ -32,6 +32,7 @@ globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
 }) as typeof fetch
 
 const {
+  BaseRpcUnavailableError,
   classifyUsdcTransfer,
   currentBaseBlockNumber,
   findFinalizedAuthorizationTransaction,
@@ -91,6 +92,80 @@ test('chain helpers fail closed on transport, response, and result failures', as
   answer = () => ({ result: '0x10' })
   assert.equal(await currentBaseBlockNumber(), 16n)
   assert.equal(toUnits(1.2345674), 1_234_567n)
+})
+
+test('strict late recovery distinguishes an RPC outage from a healthy missing transaction', async () => {
+  answer = () => ({ reject: true })
+  await assert.rejects(
+    classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+    BaseRpcUnavailableError,
+  )
+  await assert.rejects(
+    findFinalizedAuthorizationTransaction(PAYER, NONCE, 1n, { throwOnUnavailable: true }),
+    BaseRpcUnavailableError,
+  )
+
+  answer = () => ({ result: null })
+  assert.deepEqual(
+    await classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+    { state: 'pending' },
+  )
+
+  answer = () => ({ result: {} })
+  await assert.rejects(
+    classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+    BaseRpcUnavailableError,
+  )
+
+  for (const malformedReceipt of [false, 0, '']) {
+    answer = () => ({ result: malformedReceipt })
+    await assert.rejects(
+      classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+      BaseRpcUnavailableError,
+    )
+  }
+
+  finalizedRpc(validReceipt({ logs: [transferLog()] }), {
+    'eth_getBlockByNumber:0x100': {},
+  })
+  await assert.rejects(
+    classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+    BaseRpcUnavailableError,
+  )
+
+  for (const malformedBlock of [false, 0, '']) {
+    finalizedRpc(validReceipt({ logs: [transferLog()] }), {
+      'eth_getBlockByNumber:0x100': malformedBlock,
+    })
+    await assert.rejects(
+      classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+      BaseRpcUnavailableError,
+    )
+
+    finalizedRpc(validReceipt({ logs: [transferLog()] }), {
+      'eth_getBlockByNumber:finalized': malformedBlock,
+    })
+    await assert.rejects(
+      classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+      BaseRpcUnavailableError,
+    )
+  }
+
+  finalizedRpc(validReceipt({ logs: [transferLog()] }), {
+    [`eth_getBlockByHash:${BLOCK_HASH}`]: {},
+  })
+  await assert.rejects(
+    classifyUsdcTransfer(TX, PAYEE, 1n, { throwOnUnavailable: true }),
+    BaseRpcUnavailableError,
+  )
+
+  answer = method => method === 'eth_getBlockByNumber'
+    ? { result: { number: '0x100' } }
+    : { result: {} }
+  await assert.rejects(
+    findFinalizedAuthorizationTransaction(PAYER, NONCE, 1n, { throwOnUnavailable: true }),
+    BaseRpcUnavailableError,
+  )
 })
 
 test('receipt validation rejects every malformed public-RPC shape', async () => {

--- a/test/city-credit-schema.test.ts
+++ b/test/city-credit-schema.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
 import { splitSqlStatements } from '../scripts/migrate.ts'
 
 const schemaDdl = readFileSync(new URL('../db/schema.sql', import.meta.url), 'utf8')
@@ -8,8 +8,15 @@ const migrationDdl = readFileSync(
   new URL('../db/migrations/20260822_city_credit.sql', import.meta.url),
   'utf8',
 )
-const paymentRecoveryMigrationDdl = readFileSync(
-  new URL('../db/migrations/20260822_payment_recovery.sql', import.meta.url),
+const migrationDirectory = new URL('../db/migrations/', import.meta.url)
+const paymentHistoryMigrationDdls = readdirSync(migrationDirectory)
+  .filter(name => name.endsWith('.sql'))
+  .map(name => [name, readFileSync(new URL(name, migrationDirectory), 'utf8')] as const)
+  .filter(([, ddl]) => (
+    /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/iu.test(ddl)
+  ))
+const paymentLateFinalityRecheckDdl = readFileSync(
+  new URL('../db/migrations/20260825_payment_late_finality_recheck.sql', import.meta.url),
   'utf8',
 )
 const migrateSource = readFileSync(new URL('../scripts/migrate.ts', import.meta.url), 'utf8')
@@ -31,13 +38,20 @@ function table(ddl: string, name: string): string {
   )
 }
 
-test('rerunning city credit cannot replace the newer payment recovery rules', () => {
-  const guard = (ddl: string): string => normalizedStatement(
-    ddl,
-    /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/iu,
-    'missing payment history guard',
-  )
-  assert.equal(guard(migrationDdl), guard(paymentRecoveryMigrationDdl))
+test('rerunning any payment-history-defining SQL cannot replace the newest recovery rules', () => {
+  const guard = (ddl: string): string => {
+    const statements = splitSqlStatements(ddl).filter(statement => (
+      /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/iu.test(statement)
+    ))
+    const statement = statements.at(-1)
+    assert.ok(statement, 'missing payment history guard')
+    return statement.replace(/^\s*--.*$/gmu, '').replace(/\s+/gu, ' ').trim()
+  }
+  const expected = guard(paymentLateFinalityRecheckDdl)
+  for (const [name, ddl] of [
+    ['db/schema.sql', schemaDdl] as const,
+    ...paymentHistoryMigrationDdls,
+  ]) assert.equal(guard(ddl), expected, name)
 })
 
 test('fresh and upgraded schemas install the same private credit tables', () => {

--- a/test/deploy-safety.test.ts
+++ b/test/deploy-safety.test.ts
@@ -81,6 +81,10 @@ const paymentRecoveryTriggerRepairMigrationUrl = new URL(
   '../db/migrations/20260823_payment_recovery_trigger_repair.sql',
   import.meta.url,
 )
+const paymentLateFinalityRecheckMigrationUrl = new URL(
+  '../db/migrations/20260825_payment_late_finality_recheck.sql',
+  import.meta.url,
+)
 
 function withoutGitHookEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const environment = { ...process.env }
@@ -1246,6 +1250,49 @@ test('payment recovery trigger repair is an explicitly selected function correct
   assert.match(
     packageJson.scripts['migrate:production:payment-recovery-trigger-repair'] ?? '',
     /--target production --migration payment-recovery-trigger-repair$/,
+  )
+})
+
+test('late-finality recheck guard is an explicitly selected immutable-history correction', () => {
+  const migration = readFileSync(paymentLateFinalityRecheckMigrationUrl, 'utf8')
+  const uncommented = migration.replace(/^\s*--.*$/gm, '')
+  assert.equal(splitSqlStatements(migration).length, 1)
+  assert.match(uncommented, /OLD\.status\s*=\s*'expired'[\s\S]*NEW\.status\s*=\s*'founder_review'/i)
+  assert.match(uncommented, /OLD\.finalized_block_number\s+IS\s+NULL[\s\S]*OR\s+ROW\(/i)
+  assert.doesNotMatch(uncommented, /^\s*(?:DROP\s+TABLE|DELETE|TRUNCATE)\b/im)
+
+  const preview = resolveMigrationRun(
+    ['--target', 'preview', '--migration', 'payment-late-finality-recheck'],
+    {
+      CONFIRM_PREVIEW_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_ISOLATED_PREVIEW',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PREVIEW_BRANCH_ID: 'branch-preview',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PREVIEW_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+    },
+  )
+  assert.equal(preview.migrationFile, 'db/migrations/20260825_payment_late_finality_recheck.sql')
+
+  const production = resolveMigrationRun(
+    ['--target', 'production', '--migration', 'payment-late-finality-recheck'],
+    {
+      CONFIRM_PRODUCTION_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_PRODUCTION',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PRODUCTION_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+      PRODUCTION_SNAPSHOT_NAME: 'payment-late-finality-recheck-release',
+    },
+  )
+  assert.equal(production.migrationFile, 'db/migrations/20260825_payment_late_finality_recheck.sql')
+  assert.match(
+    packageJson.scripts['migrate:preview:payment-late-finality-recheck'] ?? '',
+    /--target preview --migration payment-late-finality-recheck$/,
+  )
+  assert.match(
+    packageJson.scripts['migrate:production:payment-late-finality-recheck'] ?? '',
+    /--target production --migration payment-late-finality-recheck$/,
   )
 })
 

--- a/test/integration/payment-recovery-postgres.test.ts
+++ b/test/integration/payment-recovery-postgres.test.ts
@@ -4,6 +4,7 @@ import { randomBytes } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { setTimeout as delay } from 'node:timers/promises'
 import test from 'node:test'
+import { Hono, type Context } from 'hono'
 import { Pool } from 'pg'
 import {
   PaymentAttemptConflictError,
@@ -17,6 +18,7 @@ import {
   findReplayableTargetPaymentAttempt,
   markPaymentAttemptFounderReview,
 } from '../../src/payment-attempts.ts'
+import { mountPaymentRecoveryRoutes } from '../../src/payment-recovery-routes.ts'
 import { bobPaymentRepairApplyOperations } from '../../scripts/bob-payment-repair-apply.ts'
 import {
   BOB_REPAIR_EXPECTATIONS,
@@ -40,6 +42,10 @@ const recoveryTriggerRepairMigrationDdl = await readFile(
   new URL('../../db/migrations/20260823_payment_recovery_trigger_repair.sql', import.meta.url),
   'utf8',
 )
+const lateFinalityRecheckMigrationDdl = await readFile(
+  new URL('../../db/migrations/20260825_payment_late_finality_recheck.sql', import.meta.url),
+  'utf8',
+)
 
 const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913'
 const PAYER = `0x${'1'.repeat(40)}`
@@ -48,6 +54,40 @@ const TX = `0x${'3'.repeat(64)}`
 const BLOCK_HASH = `0x${'4'.repeat(64)}`
 const RESPONSE = { ok: true, place: { id: 91 } }
 const RESPONSE_BODY = JSON.stringify(RESPONSE)
+const SPUTNIK_ATTEMPT_ID = 'pay_d5ca0953164f3787bd1ce39b80dbad535739f334a778a0a17d67cd211a01fe25'
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+
+process.env.BASE_RPC_URL = 'https://payment-recovery-rpc.test'
+const { createPaymentRecoveryRuntime } = await import('../../src/payment-recovery-runtime.ts')
+
+function topicAddress(address: string): string {
+  return `0x${address.slice(2).padStart(64, '0')}`
+}
+
+function previousLateFinalityGuardDdl(): string {
+  const matchingEvidence = `      AND (
+        (
+          OLD.finalized_block_number IS NULL
+          AND OLD.finalized_block_hash IS NULL
+          AND OLD.finalized_block_time IS NULL
+          AND OLD.finalized_at IS NULL
+        )
+        OR ROW(
+          NEW.finalized_block_number, NEW.finalized_block_hash,
+          NEW.finalized_block_time, NEW.finalized_at
+        ) IS NOT DISTINCT FROM ROW(
+          OLD.finalized_block_number, OLD.finalized_block_hash,
+          OLD.finalized_block_time, OLD.finalized_at
+        )
+      )`
+  const emptyEvidenceOnly = `      AND OLD.finalized_block_number IS NULL
+      AND OLD.finalized_block_hash IS NULL
+      AND OLD.finalized_block_time IS NULL
+      AND OLD.finalized_at IS NULL`
+  const previous = lateFinalityRecheckMigrationDdl.replace(matchingEvidence, emptyEvidenceOnly)
+  assert.notEqual(previous, lateFinalityRecheckMigrationDdl, 'late-finality guard fixture drifted')
+  return previous
+}
 
 function runDocker(args: readonly string[]): string {
   const result = spawnSync('docker', [...args], { encoding: 'utf8' })
@@ -562,6 +602,254 @@ test('payment recovery migration and primitives preserve exact deadline and term
         WHERE public_id = 'pay_recovery_late'`),
       (error: unknown) => postgresCode(error) === '55000',
     )
+  })
+
+  await t.test('sputnik-shaped explicit recheck preserves existing late finality and enters founder review', async t => {
+    await reset(database)
+    await database.query(previousLateFinalityGuardDdl())
+    await database.query(`
+      INSERT INTO residents (id, handle, model, secret_hash)
+      VALUES (66, 'sputnik', 'integration-test', repeat('6', 64))
+    `)
+    const request = {
+      name: 'Sputnik Late Kind',
+      description: 'Synthetic regression fixture',
+      traits: [],
+      recipe: [],
+    }
+    const canonical = canonicalPaymentRequest(request)
+    const blockNumber = 50_391_542n
+    const blockHash = `0x${'7'.repeat(64)}`
+    const txHash = `0x${'8'.repeat(64)}`
+    const nonce = `0x${'9'.repeat(64)}`
+    const blockTime = '2026-08-24T11:53:51.000Z'
+    const firstObservedFinality = '2026-08-24T12:15:46.453Z'
+    await database.query(`
+      INSERT INTO payment_attempts (
+        public_id, actor_id, operation, target_key, request_hash, request_json,
+        method, network, token, payer_wallet, payee_wallet, amount_units,
+        x402_nonce, x402_payload_digest, start_block, start_time, end_time,
+        status, tx_hash,
+        finalized_block_number, finalized_block_hash, finalized_block_time, finalized_at,
+        recovery_started_at, recovery_deadline_at, invalid_reason,
+        created_at, updated_at
+      ) VALUES (
+        $1, 66, 'kind_invention', 'kind:sputnik-late-kind', $2, $3::jsonb,
+        'x402', 'base', $4, $5, $6, 1000000,
+        $7, repeat('a', 64), 50380000,
+        '2026-08-24T11:48:50.722Z', '2026-08-24T12:03:50.722Z',
+        'expired', $8,
+        $9, $10, $11::timestamptz, $12::timestamptz,
+        '2026-08-24T11:53:50.722Z', '2026-08-24T13:53:50.722Z',
+        'automatic payment recovery deadline passed',
+        '2026-08-24T11:48:50.722Z', '2026-08-24T13:55:46.494Z'
+      )
+    `, [
+      SPUTNIK_ATTEMPT_ID,
+      canonical.hash,
+      canonical.json,
+      USDC,
+      PAYER,
+      PAYEE,
+      nonce,
+      txHash,
+      blockNumber.toString(),
+      blockHash,
+      blockTime,
+      firstObservedFinality,
+    ])
+
+    const originalFetch = globalThis.fetch
+    const rpcMethods: string[] = []
+    let rpcAvailable = false
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      const requestBody = JSON.parse(String(init?.body)) as {
+        id: number
+        method: string
+        params: readonly unknown[]
+      }
+      rpcMethods.push(requestBody.method)
+      if (!rpcAvailable) throw new Error('simulated Base RPC outage')
+      const blockHex = `0x${blockNumber.toString(16)}`
+      let result: unknown = null
+      if (requestBody.method === 'eth_getTransactionReceipt') {
+        result = {
+          status: '0x1',
+          blockHash,
+          blockNumber: blockHex,
+          logs: [{
+            address: USDC,
+            topics: [TRANSFER_TOPIC, topicAddress(PAYER), topicAddress(PAYEE)],
+            data: '0xf4240',
+          }],
+        }
+      } else if (requestBody.method === 'eth_getBlockByNumber') {
+        result = requestBody.params[0] === 'finalized'
+          ? { number: blockHex }
+          : { number: blockHex, hash: blockHash }
+      } else if (requestBody.method === 'eth_getBlockByHash') {
+        result = {
+          timestamp: `0x${BigInt(Math.floor(Date.parse(blockTime) / 1_000)).toString(16)}`,
+        }
+      }
+      return Response.json({ jsonrpc: '2.0', id: requestBody.id, result })
+    }) as typeof fetch
+    t.after(() => { globalThis.fetch = originalFetch })
+
+    const paymentDatabase = {
+      query: async (text: string, params: readonly unknown[] = []) => (
+        await database.query(text, [...params])
+      ).rows,
+    }
+    await assert.rejects(
+      appendLateFinalityEvidence(paymentDatabase, {
+        publicId: SPUTNIK_ATTEMPT_ID,
+        txHash,
+        finality: {
+          blockNumber,
+          blockHash,
+          blockTime,
+          finalizedAt: '2026-08-24T14:00:00.000Z',
+        },
+        reason: 'matching payment finalized after automatic recovery ended',
+      }),
+      (error: unknown) => postgresCode(error) === '55000',
+    )
+    await database.query(lateFinalityRecheckMigrationDdl)
+    await database.query(lateFinalityRecheckMigrationDdl)
+    await assert.rejects(
+      appendLateFinalityEvidence(paymentDatabase, {
+        publicId: SPUTNIK_ATTEMPT_ID,
+        txHash,
+        finality: {
+          blockNumber,
+          blockHash: `0x${'f'.repeat(64)}`,
+          blockTime,
+          finalizedAt: '2026-08-24T14:00:00.000Z',
+        },
+        reason: 'matching payment finalized after automatic recovery ended',
+      }),
+      PaymentAttemptConflictError,
+    )
+    const unchangedAfterConflict = await database.query<{
+      status: string
+      finalized_block_hash: string
+      finalized_at: Date
+    }>(`
+      SELECT status, finalized_block_hash, finalized_at
+      FROM payment_attempts WHERE public_id = $1
+    `, [SPUTNIK_ATTEMPT_ID])
+    assert.deepEqual(unchangedAfterConflict.rows.map(row => ({
+      ...row,
+      finalized_at: row.finalized_at.toISOString(),
+    })), [{
+      status: 'expired',
+      finalized_block_hash: blockHash,
+      finalized_at: firstObservedFinality,
+    }])
+
+    const runtime = createPaymentRecoveryRuntime(paymentDatabase)
+    const app = new Hono()
+    mountPaymentRecoveryRoutes(app, {
+      authenticate: async (c: Context) => c.req.header('authorization') === 'Bearer sputnik'
+        ? { id: 66 }
+        : null,
+      getOwnedAttempt: runtime.getOwnedAttempt,
+      privateView: runtime.privateView,
+      recheck: runtime.recheck,
+      runBatch: runtime.runBatch,
+      environment: {},
+    })
+
+    const beforeUnavailable = await database.query(`
+      SELECT status, tx_hash, finalized_block_number::text, finalized_block_hash,
+             finalized_block_time, finalized_at, invalid_reason, updated_at
+      FROM payment_attempts WHERE public_id = $1
+    `, [SPUTNIK_ATTEMPT_ID])
+    const unavailable = await app.request(`/api/payment-attempt/${SPUTNIK_ATTEMPT_ID}/recheck`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer sputnik',
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    })
+    assert.equal(unavailable.status, 503, await unavailable.clone().text())
+    assert.equal(unavailable.headers.get('retry-after'), '1')
+    assert.deepEqual(await unavailable.json(), {
+      error: 'payment attempt recheck is temporarily unavailable; retry this same attempt without paying again',
+      do_not_pay_again: true,
+    })
+    const afterUnavailable = await database.query(`
+      SELECT status, tx_hash, finalized_block_number::text, finalized_block_hash,
+             finalized_block_time, finalized_at, invalid_reason, updated_at
+      FROM payment_attempts WHERE public_id = $1
+    `, [SPUTNIK_ATTEMPT_ID])
+    assert.deepEqual(afterUnavailable.rows, beforeUnavailable.rows)
+    assert.deepEqual(rpcMethods, ['eth_getTransactionReceipt'])
+    rpcMethods.length = 0
+    rpcAvailable = true
+
+    const response = await app.request(`/api/payment-attempt/${SPUTNIK_ATTEMPT_ID}/recheck`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer sputnik',
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    })
+
+    assert.equal(response.status, 200, await response.clone().text())
+    const body = await response.json() as {
+      payment_attempt: { state: string; next_action: string; do_not_pay_again: boolean }
+    }
+    assert.deepEqual(body.payment_attempt, {
+      ...body.payment_attempt,
+      state: 'founder_review',
+      next_action: 'await_founder_review',
+      do_not_pay_again: true,
+    })
+    assert.deepEqual(rpcMethods, [
+      'eth_getTransactionReceipt',
+      'eth_getBlockByNumber',
+      'eth_getBlockByNumber',
+      'eth_getBlockByHash',
+    ])
+    const repeated = await app.request(`/api/payment-attempt/${SPUTNIK_ATTEMPT_ID}/recheck`, {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer sputnik',
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    })
+    assert.equal(repeated.status, 200, await repeated.clone().text())
+    assert.equal((await repeated.json() as {
+      payment_attempt: { next_action: string }
+    }).payment_attempt.next_action, 'await_founder_review')
+    assert.equal(rpcMethods.length, 4)
+    const preserved = await database.query<{
+      status: string
+      tx_hash: string
+      finalized_block_number: string
+      finalized_block_hash: string
+      finalized_block_time: Date
+      finalized_at: Date
+    }>(`
+      SELECT status, tx_hash, finalized_block_number::text, finalized_block_hash,
+             finalized_block_time, finalized_at
+      FROM payment_attempts WHERE public_id = $1
+    `, [SPUTNIK_ATTEMPT_ID])
+    assert.equal(preserved.rows[0]?.status, 'founder_review')
+    assert.equal(preserved.rows[0]?.tx_hash, txHash)
+    assert.equal(preserved.rows[0]?.finalized_block_number, blockNumber.toString())
+    assert.equal(preserved.rows[0]?.finalized_block_hash, blockHash)
+    assert.equal(preserved.rows[0]?.finalized_block_time.toISOString(), blockTime)
+    assert.equal(preserved.rows[0]?.finalized_at.toISOString(), firstObservedFinality)
+    const kinds = await database.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM kinds WHERE lower(name) = 'sputnik late kind'",
+    )
+    assert.equal(kinds.rows[0]?.count, '0')
   })
 
   await t.test('the trigger repair migration re-allows due x402 expiry from payment_pending', async () => {

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -23,6 +23,8 @@ const worldRootDescriptionMigrationFile =
   'db/migrations/20260823_world_root_description.sql' as const
 const paymentRecoveryTriggerRepairMigrationFile =
   'db/migrations/20260823_payment_recovery_trigger_repair.sql' as const
+const paymentLateFinalityRecheckMigrationFile =
+  'db/migrations/20260825_payment_late_finality_recheck.sql' as const
 
 function migrationDdl(file: string): string {
   return readFileSync(new URL(`../${file}`, import.meta.url), 'utf8')
@@ -406,6 +408,46 @@ test('payment recovery trigger repair is selected as one explicit transactional 
     },
   )
   assert.equal(production.migrationFile, paymentRecoveryTriggerRepairMigrationFile)
+  assert.equal(production.executionMode, 'transactional')
+})
+
+test('late-finality recheck guard is one explicit transactional preview or production migration', () => {
+  const migration = migrationDdl(paymentLateFinalityRecheckMigrationFile)
+  assert.equal(splitSqlStatements(migration).length, 1)
+  assert.match(migration, /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history/iu)
+  assert.match(migration, /OLD\.status\s*=\s*'expired'[\s\S]*NEW\.status\s*=\s*'founder_review'/iu)
+  assert.match(migration, /OLD\.finalized_block_number\s+IS\s+NULL[\s\S]*OR\s+ROW\(/iu)
+  assert.equal(
+    prepareMigrationExecution(paymentLateFinalityRecheckMigrationFile, migration).mode,
+    'transactional',
+  )
+
+  const preview = resolveMigrationRun(
+    ['--target', 'preview', '--migration', 'payment-late-finality-recheck'],
+    {
+      CONFIRM_PREVIEW_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_ISOLATED_PREVIEW',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PREVIEW_BRANCH_ID: 'branch-preview',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PREVIEW_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+    },
+  )
+  assert.equal(preview.migrationFile, paymentLateFinalityRecheckMigrationFile)
+  assert.equal(preview.executionMode, 'transactional')
+
+  const production = resolveMigrationRun(
+    ['--target', 'production', '--migration', 'payment-late-finality-recheck'],
+    {
+      CONFIRM_PRODUCTION_MIGRATION: 'APPLY_ADDITIVE_SCHEMA_TO_PRODUCTION',
+      NEON_API_KEY: 'secret-neon-key',
+      NEON_PROJECT_ID: 'project-one',
+      NEON_PRODUCTION_BRANCH_ID: 'branch-production',
+      PRODUCTION_DATABASE_URL_UNPOOLED: 'postgres://role@example.neon.tech/db',
+      PRODUCTION_SNAPSHOT_NAME: 'payment-late-finality-recheck-release',
+    },
+  )
+  assert.equal(production.migrationFile, paymentLateFinalityRecheckMigrationFile)
   assert.equal(production.executionMode, 'transactional')
 })
 

--- a/test/payment-attempts-schema.test.ts
+++ b/test/payment-attempts-schema.test.ts
@@ -59,9 +59,9 @@ function exactCompletionFunctionStatement(ddl: string): string {
 }
 
 function attemptHistoryFunctionStatement(ddl: string): string {
-  const statement = splitSqlStatements(ddl).find(candidate =>
+  const statement = splitSqlStatements(ddl).filter(candidate =>
     /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+protect_payment_attempt_history\s*\(\s*\)/iu.test(candidate),
-  )
+  ).at(-1)
   assert.ok(statement, 'missing payment-attempt history function')
   return statement.replace(/^\s*--.*$/gmu, '').replace(/\s+/gu, ' ').trim()
 }

--- a/test/payment-attempts.test.ts
+++ b/test/payment-attempts.test.ts
@@ -802,6 +802,51 @@ test('expired recovered x402 custody says not to repay and remains explicitly re
   assert.equal(legacyUnused.next_action, 'closed')
 })
 
+test('every stored payment state advertises one exact next action', () => {
+  const recovery = {
+    recoveryStartedAt: '2026-08-16T12:00:00.000Z',
+    recoveryDeadlineAt: '2026-08-16T14:00:00.000Z',
+  }
+  const cases: Array<{
+    name: string
+    attempt: PaymentAttemptRecord
+    nextAction: ReturnType<typeof toPrivatePaymentAttempt>['next_action']
+  }> = [
+    { name: 'settling', attempt: row({ status: 'settling' }), nextAction: 'wait_or_recheck' },
+    { name: 'payment pending', attempt: row({ status: 'payment_pending' }), nextAction: 'wait_or_recheck' },
+    { name: 'needs review', attempt: row({ status: 'needs_review' }), nextAction: 'wait_or_recheck' },
+    {
+      name: 'expired recoverable x402',
+      attempt: row({ status: 'expired', ...recovery }),
+      nextAction: 'recheck_for_late_finality',
+    },
+    { name: 'founder review', attempt: row({ status: 'founder_review' }), nextAction: 'await_founder_review' },
+    { name: 'completed', attempt: row({ status: 'completed' }), nextAction: 'complete' },
+    { name: 'legacy completed', attempt: row({ status: 'legacy_completed' }), nextAction: 'complete' },
+    {
+      name: 'credit returned',
+      attempt: row({ status: 'credit_returned', method: 'credit', network: null }),
+      nextAction: 'credit_returned',
+    },
+    { name: 'invalid', attempt: row({ status: 'invalid' }), nextAction: 'closed' },
+    { name: 'expired x402 without recovery', attempt: row({ status: 'expired' }), nextAction: 'closed' },
+    {
+      name: 'expired credit',
+      attempt: row({ status: 'expired', method: 'credit', network: null, ...recovery }),
+      nextAction: 'closed',
+    },
+    {
+      name: 'expired legacy claim',
+      attempt: row({ status: 'expired', method: 'claim', network: null }),
+      nextAction: 'closed',
+    },
+  ]
+
+  for (const current of cases) {
+    assert.equal(toPrivatePaymentAttempt(current.attempt).next_action, current.nextAction, current.name)
+  }
+})
+
 test('private attempt serialization exposes only allowlisted recovery and bound-request facts', () => {
   const storedRequest = {
     offer_id: 91,

--- a/test/payment-recovery-http-mcp.test.ts
+++ b/test/payment-recovery-http-mcp.test.ts
@@ -2,11 +2,15 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { Hono, type Context } from 'hono'
 import { mcp } from '../src/mcp.ts'
+import { PaymentAttemptEvidenceConflictError } from '../src/payment-attempts.ts'
 import {
   mountPaymentRecoveryRoutes,
   type PaymentRecoveryRouteDependencies,
 } from '../src/payment-recovery-routes.ts'
-import type { PaymentRecoveryAttempt } from '../src/payment-recovery.ts'
+import {
+  reportPaymentRecoveryRecheckFailure,
+  type PaymentRecoveryAttempt,
+} from '../src/payment-recovery.ts'
 
 const ATTEMPT_ID = `pay_${'ab'.repeat(32)}`
 const CRON_SECRET = `cron_${'cd'.repeat(32)}`
@@ -116,6 +120,16 @@ test('explicit recheck accepts exactly an empty object and uses stored terms onl
     'content-type': 'application/json',
   }
 
+  const unauthenticatedMalformed = await app.request(
+    `/api/payment-attempt/${ATTEMPT_ID}/recheck`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ transaction: 'must-not-be-read-before-auth' }),
+    },
+  )
+  assert.equal(unauthenticatedMalformed.status, 401)
+
   for (const body of [
     JSON.stringify({ name: 'changed' }),
     JSON.stringify({ transaction: `0x${'ef'.repeat(32)}` }),
@@ -138,6 +152,161 @@ test('explicit recheck accepts exactly an empty object and uses stored terms onl
   assert.equal(response.status, 202)
   assert.equal(response.headers.get('cache-control'), 'no-store')
   assert.equal(calls, 1)
+})
+
+test('explicit recheck contains transient chain and database failures in caller words', async () => {
+  const failures = [
+    {
+      name: 'authentication database',
+      dependencies: () => routeDependencies({
+        authenticate: async () => {
+          throw new Error('simulated auth outage Bearer private-token 1f3d9_sk_private')
+        },
+      }),
+    },
+    {
+      name: 'chain',
+      dependencies: () => routeDependencies({
+        recheck: async () => { throw new Error('simulated Base RPC failure') },
+      }),
+    },
+    {
+      name: 'database',
+      dependencies: () => {
+        let reads = 0
+        return routeDependencies({
+          getOwnedAttempt: async () => {
+            reads += 1
+            if (reads === 2) throw Object.assign(new Error('simulated database outage'), { code: '57P01' })
+            return storedAttempt()
+          },
+          recheck: async value => ({ state: 'payment_pending', attemptId: value.publicId }),
+        })
+      },
+    },
+    {
+      name: 'reported unavailable',
+      dependencies: () => routeDependencies({
+        recheck: async value => ({ state: 'unavailable', attemptId: value.publicId }),
+      }),
+    },
+  ]
+
+  const logged: unknown[][] = []
+  const originalError = console.error
+  console.error = (...values: unknown[]) => { logged.push(values) }
+  try {
+    for (const failure of failures) {
+      const app = createHttpApp({
+        ...failure.dependencies(),
+        reportFailure: reportPaymentRecoveryRecheckFailure,
+      })
+      const response = await app.request(`/api/payment-attempt/${ATTEMPT_ID}/recheck`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer resident', 'content-type': 'application/json' },
+        body: '{}',
+      })
+
+      assert.equal(response.status, 503, failure.name)
+      assert.equal(response.headers.get('retry-after'), '1', failure.name)
+      assert.equal(response.headers.get('cache-control'), 'no-store', failure.name)
+      assert.deepEqual(await response.json(), {
+        error: 'payment attempt recheck is temporarily unavailable; retry this same attempt without paying again',
+        do_not_pay_again: true,
+      }, failure.name)
+    }
+  } finally {
+    console.error = originalError
+  }
+  const recoveryLogs = logged.filter(values => values[0] === 'payment recovery recheck failed')
+  assert.equal(recoveryLogs.length, failures.length)
+  assert.doesNotMatch(JSON.stringify(recoveryLogs), /private-token|1f3d9_sk_private/iu)
+})
+
+test('explicit recheck preserves the ordinary retryable database-collision response', async () => {
+  const app = createHttpApp(routeDependencies({
+    recheck: async () => {
+      throw Object.assign(new Error('simulated serialization collision'), { code: '40001' })
+    },
+  }))
+
+  const response = await app.request(`/api/payment-attempt/${ATTEMPT_ID}/recheck`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer resident', 'content-type': 'application/json' },
+    body: '{}',
+  })
+
+  assert.equal(response.status, 409)
+  assert.equal(response.headers.get('cache-control'), 'no-store')
+  assert.deepEqual(await response.json(), {
+    error: 'another action changed the same records; retry this payment attempt without paying again',
+    do_not_pay_again: true,
+  })
+})
+
+test('preserved-evidence conflicts stop honestly instead of asking for an endless retry', async () => {
+  const app = createHttpApp(routeDependencies({
+    recheck: async () => {
+      throw new PaymentAttemptEvidenceConflictError('simulated immutable evidence mismatch')
+    },
+    reportFailure: () => undefined,
+  }))
+
+  const response = await app.request(`/api/payment-attempt/${ATTEMPT_ID}/recheck`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer resident', 'content-type': 'application/json' },
+    body: '{}',
+  })
+
+  assert.equal(response.status, 409)
+  assert.deepEqual(await response.json(), {
+    error: 'payment evidence conflicts with this attempt\'s preserved record; inspect this attempt and do not pay again',
+    do_not_pay_again: true,
+  })
+})
+
+test('retry converges when a guarded transition commits before the final read fails', async () => {
+  let current = storedAttempt()
+  let completedEffects = 0
+  let failFinalRead = true
+  const app = createHttpApp(routeDependencies({
+    getOwnedAttempt: async (publicId, actorId) => {
+      if (publicId !== current.publicId || actorId !== current.actorId) return null
+      if (failFinalRead && current.status === 'completed') {
+        failFinalRead = false
+        throw Object.assign(new Error('simulated post-commit read outage'), { code: '57P01' })
+      }
+      return current
+    },
+    recheck: async value => {
+      if (current.status === 'payment_pending') {
+        completedEffects += 1
+        current = storedAttempt({ ...value, status: 'completed' })
+      }
+      return {
+        state: current.status === 'completed' ? 'completed' : 'payment_pending',
+        attemptId: value.publicId,
+      }
+    },
+    reportFailure: () => undefined,
+  }))
+  const request = () => app.request(`/api/payment-attempt/${ATTEMPT_ID}/recheck`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer resident', 'content-type': 'application/json' },
+    body: '{}',
+  })
+
+  const uncertain = await request()
+  assert.equal(uncertain.status, 503)
+  assert.equal(current.status, 'completed')
+  assert.equal(completedEffects, 1)
+
+  const converged = await request()
+  assert.equal(converged.status, 200)
+  assert.equal((await converged.json() as {
+    payment_attempt: { state: string }
+  }).payment_attempt.state, 'completed')
+  assert.equal(completedEffects, 1)
 })
 
 test('cron recovery fails closed and returns aggregate counts without attempt identifiers', async () => {

--- a/test/payment-recovery-runtime.test.ts
+++ b/test/payment-recovery-runtime.test.ts
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { Hono, type Context } from 'hono'
 import type { TransferCheck } from '../src/chain.ts'
 import {
   canonicalPaymentRequest,
+  toPrivatePaymentAttempt,
   type PaymentAttemptRecord,
 } from '../src/payment-attempts.ts'
+import { mountPaymentRecoveryRoutes } from '../src/payment-recovery-routes.ts'
 import {
   createPaymentRecoveryRuntime,
   type PaymentRecoveryRuntimeServices,
@@ -372,4 +375,128 @@ test('private runtime view is allowlisted and owner lookup never crosses residen
   assert.equal(view.id, ATTEMPT_ID)
   assert.equal(view.do_not_pay_again, true)
   assert.doesNotMatch(JSON.stringify(view), /secret|must-not-leak|request_hash|lease_owner/iu)
+})
+
+test('every wait_or_recheck state can be explicitly invoked without changing its stored terms', async () => {
+  for (const status of ['settling', 'payment_pending', 'needs_review'] as const) {
+    const stored = attempt({ status })
+    let chainChecks = 0
+    const runtime = createPaymentRecoveryRuntime(database, serviceDefaults({
+      getAttempt: async () => stored,
+      resumeX402: async () => {
+        chainChecks += 1
+        return {
+          state: 'payment_pending',
+          status: 202,
+          attemptId: stored.publicId,
+          payerWallet: stored.payerWallet,
+          txHash: stored.txHash,
+          body: {
+            error: 'payment is still pending finality; retry this same attempt without paying again',
+            do_not_pay_again: true,
+          },
+        }
+      },
+    }), { now: () => new Date('2026-08-22T00:15:00.000Z') })
+    const app = new Hono()
+    mountPaymentRecoveryRoutes(app, {
+      authenticate: async (c: Context) => c.req.header('authorization') === 'Bearer resident'
+        ? { id: stored.actorId }
+        : null,
+      getOwnedAttempt: runtime.getOwnedAttempt,
+      privateView: runtime.privateView,
+      recheck: runtime.recheck,
+      runBatch: runtime.runBatch,
+      environment: {},
+    })
+
+    const response = await app.request(`/api/payment-attempt/${ATTEMPT_ID}/recheck`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer resident', 'content-type': 'application/json' },
+      body: '{}',
+    })
+
+    assert.equal(response.status, 202, status)
+    const body = await response.json() as { payment_attempt: Record<string, unknown> }
+    assert.equal(body.payment_attempt.state, status)
+    assert.equal(body.payment_attempt.next_action, 'wait_or_recheck')
+    assert.equal(body.payment_attempt.target, stored.targetKey)
+    assert.equal(chainChecks, 1)
+  }
+})
+
+test('every terminal next_action accepts an explicit recheck as an unchanged no-op', async () => {
+  const cases: Array<{
+    name: string
+    stored: PaymentAttemptRecord
+    nextAction: ReturnType<typeof toPrivatePaymentAttempt>['next_action']
+  }> = [
+    { name: 'founder review', stored: attempt({ status: 'founder_review' }), nextAction: 'await_founder_review' },
+    { name: 'completed', stored: attempt({ status: 'completed' }), nextAction: 'complete' },
+    { name: 'legacy completed', stored: attempt({ status: 'legacy_completed' }), nextAction: 'complete' },
+    {
+      name: 'credit returned',
+      stored: attempt({ status: 'credit_returned', method: 'credit', network: null, token: null, payerWallet: null }),
+      nextAction: 'credit_returned',
+    },
+    { name: 'invalid', stored: attempt({ status: 'invalid' }), nextAction: 'closed' },
+    {
+      name: 'expired x402 without a recovery start',
+      stored: attempt({
+        status: 'expired', recoveryStartedAt: null, recoveryDeadlineAt: null,
+        txHash: null, finalizedBlockNumber: null, finalizedBlockHash: null,
+        finalizedBlockTime: null, finalizedAt: null,
+      }),
+      nextAction: 'closed',
+    },
+    {
+      name: 'expired credit',
+      stored: attempt({ status: 'expired', method: 'credit', network: null, token: null, payerWallet: null }),
+      nextAction: 'closed',
+    },
+    {
+      name: 'expired legacy claim',
+      stored: attempt({ status: 'expired', method: 'claim', network: null, token: null, payerWallet: null }),
+      nextAction: 'closed',
+    },
+  ]
+
+  for (const current of cases) {
+    let recoverySideEffects = 0
+    const unexpectedSideEffect = async (): Promise<never> => {
+      recoverySideEffects += 1
+      throw new Error(`terminal recheck performed recovery work for ${current.name}`)
+    }
+    const runtime = createPaymentRecoveryRuntime(database, serviceDefaults({
+      getAttempt: async () => current.stored,
+      resumeX402: unexpectedSideEffect,
+      acquireLease: unexpectedSideEffect,
+      acquireDueLease: unexpectedSideEffect,
+      recoverTransaction: unexpectedSideEffect,
+      classifyTransfer: unexpectedSideEffect,
+      appendLateFinality: unexpectedSideEffect,
+    }))
+    const app = new Hono()
+    mountPaymentRecoveryRoutes(app, {
+      authenticate: async () => ({ id: current.stored.actorId }),
+      getOwnedAttempt: runtime.getOwnedAttempt,
+      privateView: runtime.privateView,
+      recheck: runtime.recheck,
+      runBatch: runtime.runBatch,
+      environment: {},
+    })
+
+    const before = runtime.privateView(current.stored)
+    assert.equal(before.next_action, current.nextAction, current.name)
+    const response = await app.request(`/api/payment-attempt/${ATTEMPT_ID}/recheck`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    })
+
+    assert.equal(response.status, 200, current.name)
+    const body = await response.json() as { payment_attempt: Record<string, unknown> }
+    assert.deepEqual(body.payment_attempt, before, current.name)
+    assert.equal(recoverySideEffects, 0, current.name)
+  }
 })


### PR DESCRIPTION
## Root cause

Production evidence showed that Sputnik's expired x402 attempt already held a matching transaction and complete finality evidence. `appendLateFinalityEvidence` only accepted rows whose four finality fields were null, so its update matched zero rows; the fallback saw `expired` instead of `founder_review` and threw `PaymentAttemptConflictError`. The explicit resident route did not contain that throw, so the advertised recheck became HTTP 500. The suspected bigint serialization was not involved: the block number was already converted to a SQL string.

## What changed

- Allow an expired x402 attempt to enter `founder_review` when the live transfer exactly matches either newly appended evidence or complete evidence already preserved on the attempt. Existing `finalized_at` is retained; partial or conflicting evidence is never rewritten.
- Add the forward guard migration and make every still-runnable payment migration that defines the history guard converge on the same corrected function. The test discovers all such migration files instead of maintaining an incomplete manual list.
- Make explicit rechecks distinguish a healthy pending chain result from RPC failure. Transient chain/database failures return caller-safe `503` + `Retry-After: 1`; ordinary races return retryable `409`; immutable evidence conflicts return inspect/do-not-pay `409`. Errors are sanitized before logging.
- Prove every advertised `next_action`: all three live states, expired x402 late-finality recovery, founder review, both completion states, credit returned, invalid, and every expired/legacy terminal shape. Terminal POST rechecks are idempotent no-ops.
- Update the system design, recovery runbook, front door, generated/published mirror, llms.txt, and MCP descriptions.

## Verification

Exact pushed candidate: `c738d965e4f570d83e635ef3d3ad9ecdc5f31265`.

- `bash scripts/deploy.sh --prepare` on the clean pushed branch: `GATE_EXIT=0`
- Unit suite: 1,062 passed
- TypeScript typecheck: passed
- PostgreSQL integration suite: 162 passed
- Playwright browser suite: 55 passed
- Coverage gate: passed (90.6% statements, 81.4% branches, 92% functions, 90.6% lines)
- `npm audit --audit-level=high`: 0 vulnerabilities
- Independent correctness, security/data-integrity, and final scope reviews: no remaining actionable findings

## Real-service evidence

Read-only production inspection found the two explicit rechecks throwing `PaymentAttemptConflictError` and confirmed the attempt remained `expired` with complete stored finality. A real Base RPC classification using this branch matched the exact USDC transfer at block `50391542`, block time `2026-08-24T11:53:51.000Z`; the city had first recorded finality at `2026-08-24T12:15:46.453Z`.

The isolated Preview database migration was applied through the guarded runner and the installed function was read back as repaired. Vercel deployed the same candidate commit; `GET /llms.txt` returned 200 with the new recheck contract, and an unauthenticated POST to the protected recheck route returned 401. Production was checked read-only and deliberately remains pending rollout; this PR is not merged and no production schema or attempt state was changed. The successful late-finality transition therefore cannot yet be claimed as live on 1f3d9.com.

## Rollout / live verification

1. Before the matching application release, take the required Neon production snapshot and run `npm run migrate:production:payment-late-finality-recheck` with its exact acknowledgement.
2. GitHub CI, Socket checks, and Vercel Preview are green; merge only after review and the production migration prerequisite.
3. After Vercel ships the merged commit, recheck the deployed private route and record the status/body. Do not pay again.

## Adjacent, deliberately not fixed

- The sibling 1f3ea market copy is excluded from this PR and untouched.
- `scripts/deploy.sh` does not itself emit the explicit `GATE_EXIT` line required by AGENTS.md. The release run used a non-piped wrapper to record `GATE_EXIT=0`; the pre-existing helper drift remains for a separate change.
- Sputnik's founder credit was already handled separately; this PR performs no refund or production mutation.

Fixes #100
