### PR TITLE
fix: trim the operator line to the LLC only

### DIFF
--- a/src/window-page.ts
+++ b/src/window-page.ts
@@ -218,7 +218,7 @@ export const WINDOW_HTML = `<!doctype html>
       <a href="https://github.com/onetapstudiogames/1f3d9-citylife" rel="external">City skill</a>
       <a href="https://github.com/onetapstudiogames/1f3d9" rel="external">Source</a>
     </nav>
-    <p class="operator-line">Run by TWAMD LLC, Gentry, Arkansas · <a href="mailto:adam@twamd.com">adam@twamd.com</a> · © 2026 TWAMD LLC · open source under <a href="https://github.com/onetapstudiogames/1f3d9/blob/main/LICENSE" rel="external">AGPL-3.0</a> · <a href="https://www.paypal.com/donate/?hosted_button_id=UE3PGQE3YYN2W" rel="external">tip the builder</a> (humans only, buys nothing)</p>
+    <p class="operator-line">Run by TWAMD LLC · <a href="mailto:adam@twamd.com">adam@twamd.com</a> · © 2026 TWAMD LLC · open source under <a href="https://github.com/onetapstudiogames/1f3d9/blob/main/LICENSE" rel="external">AGPL-3.0</a> · <a href="https://www.paypal.com/donate/?hosted_button_id=UE3PGQE3YYN2W" rel="external">tip the builder</a> (humans only, buys nothing)</p>
   </footer>
 </body>
 </html>

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -60,7 +60,10 @@ test('the human window exposes organized, linkable, read-only views', () => {
   assert.match(cityHeader, /watching through the glass and want to say thanks\?/)
   assert.match(cityHeader, /href="https:\/\/www\.paypal\.com\/donate\/\?hosted_button_id=UE3PGQE3YYN2W"[^>]*>tip the builder!<\/a>/)
   assert.match(cityHeader, /this is for humans only and doesn't change the city\./)
-  assert.match(cityFooter, /Run by TWAMD LLC, Gentry, Arkansas/)
+  assert.match(cityFooter, /Run by TWAMD LLC/)
+  // The operator's home town never appears on any served page; the legal
+  // pages carry the same guard in human-pages.test.ts.
+  assert.doesNotMatch(WINDOW_HTML, /Gentry/iu)
   assert.match(cityFooter, /© 2026 TWAMD LLC/)
   assert.match(cityFooter, /href="\/terms"/)
   assert.match(cityFooter, /href="\/privacy"/)


### PR DESCRIPTION
Removes the operator's home town from the window footer (the legal pages were already scrubbed and guarded; this was the surviving instance) and adds the same doesNotMatch guard to the window page test so no served page can carry it again. Behavior otherwise unchanged.