### PR TITLE
fix: drain feedback loop - receiver stores logs of its own deliveries

### DIFF
--- a/src/log-drain-routes.ts
+++ b/src/log-drain-routes.ts
@@ -231,13 +231,21 @@ function normalizeRecord(value: unknown, secret: string): RuntimeLogRecord | nul
     secret,
   )
 
+  // The drain must never store logs of its own deliveries: each delivery
+  // request produces request logs that Vercel drains back here, and relying
+  // on drain-side sampling to exclude them proved wrong live (a feedback
+  // loop grew the table thousands of rows in a minute). Dropping the
+  // receiver's own path here is deterministic and ours.
+  const path = requestPath(proxy?.path ?? input.path, secret)
+  if (path === '/api/internal/log-drain') return null
+
   return Object.freeze({
     id,
     timestamp,
     project,
     source,
     level,
-    requestPath: requestPath(proxy?.path ?? input.path, secret),
+    requestPath: path,
     requestMethod: method,
     statusCode: normalizedStatusCode(proxy?.statusCode ?? input.statusCode),
     durationMs: null,


### PR DESCRIPTION
Live incident minutes after activation: the drain's head_sampling rate-0 rule for /api/internal/log-drain did not exclude the receiver's own request logs, so every delivery generated logs that drained back as new deliveries - runtime_logs grew 565 to 4,873 rows in under a minute. Fix: the receiver drops any record whose request path is its own route before insert. Deterministic, independent of Vercel sampling semantics. A one-time cleanup DELETE of the looped rows follows after merge; the 30-day purge would age them out regardless. Receiver tests 10/10, typecheck clean.