### PR TITLE
test: enforce the payment reliability standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: npm run typecheck
       - name: Run unit tests
         run: npm test
+      - name: Run PostgreSQL integration tests
+        run: npm run test:postgres
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
       - name: Run end-to-end tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,20 @@ A change is done when ALL of these are true, and not before:
    that existed elsewhere, no abstraction with one caller, no option nothing
    varies. The simplest shape that fully works is the deliverable.
 
+## Payment reliability
+
+Every payment-path change requires:
+
+- real-timing tests against real PostgreSQL, including chain finality later than
+  the intent or operation window;
+- adversarial refuter review before merge; and
+- a read-only or self-cleaning post-deploy production probe of the changed
+  surface.
+
+Use city PR #107 as the test model. City issue #103, market PRs #13/#20, and
+city PRs #115/#116 record why: mocks missed chain timing and SQL preparation,
+while non-production runtimes missed live-only failures.
+
 ## How work runs here
 
 - **PRs only.** Production ships by merging to main; Vercel builds that exact

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -39,11 +39,12 @@ column is `at`, not `created_at`, and only the next layer caught it.
 
 ## Layer 2 — Postgres integration (`npm run test:postgres`)
 
-Seventeen suites run individually against disposable PostgreSQL 17 containers
+The suites run sequentially against disposable PostgreSQL 17 containers
 (Docker required). Real schema, real migrations, real triggers, real
 constraint validation. Any change that adds or edits SQL, schema, or
 migrations needs coverage here, not only in layer 1. The backup/restore drill
-lives here too.
+lives here too. Sequential execution is deliberate: PR #69 proved concurrent
+containers were resource-sensitive on hosted runners.
 
 ## Layer 3 — end-to-end (`npm run test:e2e`)
 
@@ -54,13 +55,12 @@ regression class lives exactly in this gap.
 ## Layer 4 — CI and the release gate
 
 CI (`.github/workflows/ci.yml`) runs typecheck, unit tests, `door:check`
-(generated front-door mirrors must match their sources), and the e2e suite on
-every PR; postgres suites run locally because one Docker case is unreliable
-on hosted runners (recorded in PR #69). Release candidates additionally run
-`bash scripts/deploy.sh --prepare` — read its explicit `GATE_EXIT` line;
-piping can mask a failure. The working standard in [AGENTS.md](../AGENTS.md)
-adds the non-mechanical bar: one real run against the live service for
-anything that touches one.
+(generated front-door mirrors must match their sources), the sequential
+PostgreSQL integration suite, and the e2e suite on every PR. Release
+candidates additionally run `bash scripts/deploy.sh --prepare` — read its
+explicit `GATE_EXIT` line; piping can mask a failure. The working standard in
+[AGENTS.md](../AGENTS.md) adds the production-runtime and adversarial-review
+bar for payment-path changes.
 
 ## Gotchas that have bitten before
 

--- a/docs/runbooks/BACKUP_RESTORE.md
+++ b/docs/runbooks/BACKUP_RESTORE.md
@@ -46,7 +46,9 @@ npm run backup -- --target local --database city
 Keep local PostgreSQL bound to loopback. The backup first proves the exact
 authenticated database through `host.docker.internal`; on Linux it tries host
 networking only when that route is unavailable. A public database bind is not
-needed.
+needed. The host reserves the private temporary archive before `pg_dump` fills
+it, so verified publication keeps host ownership and never overwrites an
+existing archive.
 
 Preview and production also require `NEON_API_KEY`, `NEON_PROJECT_ID`,
 `NEON_PRODUCTION_BRANCH_ID`, and the matching branch ID. They require an explicit
@@ -79,11 +81,14 @@ branch equal to production, a database-name mismatch, an unproven private output
 directory, and ambient `DATABASE_URL` fallback. On Linux and macOS, the remote
 directory must be owned by the current user with mode `0700`.
 
-Local default output is under ignored `backups/`. A successful run publishes two
-files together:
+Local default output is under ignored `backups/`. A successful run leaves two
+files; the manifest is the completion marker:
 
 - `*.dump` — sensitive schema and data.
 - `*.dump.manifest.json` — safe target identity, byte size, SHA-256, and tool evidence.
+
+After a hard stop, an archive without its manifest is incomplete and must not be
+used as a recovery backup.
 
 Do not sync the archive to a public service. On Windows, use a folder accessible
 only to the owner account.

--- a/docs/runbooks/BACKUP_RESTORE.md
+++ b/docs/runbooks/BACKUP_RESTORE.md
@@ -25,7 +25,7 @@ Time: usually 1–15 minutes, depending on database size and network speed.
 
 Before running the command:
 
-1. Start Docker Desktop.
+1. Start Docker Desktop, or Docker Engine on native Linux.
 2. Put the direct, non-pooled database URL in the target-specific environment
    variable. Never paste it into the command itself.
 3. Set the exact confirmation variable below.
@@ -42,6 +42,11 @@ Local example:
 ```powershell
 npm run backup -- --target local --database city
 ```
+
+Keep local PostgreSQL bound to loopback. The backup first proves the exact
+authenticated database through `host.docker.internal`; on Linux it tries host
+networking only when that route is unavailable. A public database bind is not
+needed.
 
 Preview and production also require `NEON_API_KEY`, `NEON_PROJECT_ID`,
 `NEON_PRODUCTION_BRANCH_ID`, and the matching branch ID. They require an explicit

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "node --experimental-strip-types scripts/run-tests.ts",
     "test:coverage": "node --experimental-strip-types scripts/run-tests.ts --coverage",
     "test:e2e": "playwright test",
-    "test:postgres": "node --test --experimental-strip-types --experimental-test-module-mocks test/integration/oauth-postgres.test.ts test/integration/world-root-postgres.test.ts test/integration/world-postgres.test.ts test/integration/engine-timer-postgres.test.ts test/integration/public-pagination-postgres.test.ts test/integration/public-search-index-postgres.test.ts test/integration/small-reader-postgres.test.ts test/integration/payment-postgres.test.ts test/integration/identity-recovery-postgres.test.ts test/integration/backup-restore-postgres.test.ts test/integration/credential-exposure-scan-postgres.test.ts test/integration/thing-maker-postgres.test.ts test/integration/later-holder-postgres.test.ts test/integration/city-credit-postgres.test.ts test/integration/payment-recovery-postgres.test.ts test/integration/room-orientation-postgres.test.ts test/integration/public-snapshot-postgres.test.ts test/integration/runtime-logs-postgres.test.ts",
+    "test:postgres": "node --test --test-concurrency=1 --experimental-strip-types --experimental-test-module-mocks test/integration/*.test.ts",
     "backup": "node --experimental-strip-types scripts/backup.ts",
     "restore:drill": "node --experimental-strip-types scripts/restore-drill.ts",
     "credential:scan": "node --experimental-strip-types scripts/credential-exposure-scan.ts",

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -414,17 +414,64 @@ function decodedUrlPart(value: string, label: string): string {
   return decoded
 }
 
-function connectionEnvironment(databaseUrl: string): Readonly<{
+export function dockerDatabaseRoutePlan(
+  databaseUrl: string,
+  platform: NodeJS.Platform = process.platform,
+): Readonly<{
+  candidates: readonly Readonly<{
+    hostname: string
+    runArguments: readonly string[]
+  }>[]
+  defaultSslMode: 'disable' | 'require'
+  loopback: boolean
+}> {
+  const hostname = new URL(databaseUrl).hostname.toLowerCase()
+  const loopback = ['localhost', '127.0.0.1', '[::1]'].includes(hostname)
+  const defaultSslMode = loopback || hostname === 'host.docker.internal'
+    ? 'disable'
+    : 'require'
+  const gatewayRoute = Object.freeze({
+    hostname: loopback ? 'host.docker.internal' : hostname,
+    runArguments: Object.freeze(['--add-host', 'host.docker.internal:host-gateway']),
+  })
+  const candidates = platform === 'linux' && loopback
+    ? Object.freeze([
+        gatewayRoute,
+        Object.freeze({
+          hostname: hostname === '[::1]' ? '::1' : hostname,
+          runArguments: Object.freeze(['--network', 'host']),
+        }),
+      ])
+    : Object.freeze([gatewayRoute])
+  return Object.freeze({
+    candidates,
+    defaultSslMode,
+    loopback,
+  })
+}
+
+export async function selectDockerDatabaseRoute(
+  plan: ReturnType<typeof dockerDatabaseRoutePlan>,
+  probe: (candidate: (typeof plan.candidates)[number]) => Promise<boolean>,
+): Promise<(typeof plan.candidates)[number]> {
+  if (!plan.loopback) return plan.candidates[0]!
+  for (const candidate of plan.candidates) {
+    if (await probe(candidate)) return candidate
+  }
+  throw new Error('Docker could not reach the validated local PostgreSQL endpoint')
+}
+
+function connectionEnvironment(
+  databaseUrl: string,
+  defaultSslMode: 'disable' | 'require',
+  route: Readonly<{ hostname: string; runArguments: readonly string[] }>,
+): Readonly<{
   environment: NodeJS.ProcessEnv
   keys: readonly string[]
+  runArguments: readonly string[]
 }> {
   const parsed = new URL(databaseUrl)
-  const hostname = parsed.hostname.toLowerCase()
-  const dockerHost = ['localhost', '127.0.0.1', '[::1]'].includes(hostname)
-    ? 'host.docker.internal'
-    : hostname
-  const sslMode = parsed.searchParams.get('sslmode') ??
-    (dockerHost === 'host.docker.internal' ? 'disable' : 'require')
+  const sslMode = parsed.searchParams.get('sslmode') ?? defaultSslMode
   if (!['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full'].includes(sslMode)) {
     throw new Error('database URL contains an unsupported sslmode')
   }
@@ -434,7 +481,7 @@ function connectionEnvironment(databaseUrl: string): Readonly<{
   }
 
   const variables: NodeJS.ProcessEnv = {
-    PGHOST: dockerHost,
+    PGHOST: route.hostname,
     PGPORT: parsed.port || '5432',
     PGDATABASE: decodedUrlPart(parsed.pathname.slice(1), 'database name'),
     PGUSER: decodedUrlPart(parsed.username, 'role'),
@@ -448,6 +495,7 @@ function connectionEnvironment(databaseUrl: string): Readonly<{
   return Object.freeze({
     environment: Object.freeze({ ...process.env, ...variables }),
     keys: Object.freeze(Object.keys(variables)),
+    runArguments: route.runArguments,
   })
 }
 
@@ -461,17 +509,43 @@ async function dumpWithDocker(options: Readonly<{
   outputPath: string
   toolImage: string
 }>): Promise<DumpResult> {
-  const connection = connectionEnvironment(options.databaseUrl)
+  const plan = dockerDatabaseRoutePlan(options.databaseUrl)
   const containerName = `1f3d9-pg-dump-${process.pid}-${randomBytes(6).toString('hex')}`
   const outputDirectory = dirname(options.outputPath)
   const outputName = basename(options.outputPath)
   try {
     const version = await runCommand('docker', ['run', '--rm', options.toolImage, 'pg_dump', '--version'])
+    const route = await selectDockerDatabaseRoute(plan, async candidate => {
+      const candidateConnection = connectionEnvironment(
+        options.databaseUrl,
+        plan.defaultSslMode,
+        candidate,
+      )
+      try {
+        const probe = await runCommand('docker', [
+          'run', '--rm',
+          ...candidate.runArguments,
+          ...candidateConnection.keys.flatMap(key => ['--env', key]),
+          options.toolImage,
+          'psql', '-X', '-v', 'ON_ERROR_STOP=1', '-Atqc', 'SELECT current_database()',
+        ], {
+          allowFailure: true,
+          maxOutput: 64 * 1024,
+          environment: candidateConnection.environment,
+          sensitiveOutput: true,
+        })
+        return probe.code === 0 &&
+          probe.stdout.trim() === candidateConnection.environment.PGDATABASE
+      } catch {
+        return false
+      }
+    })
+    const connection = connectionEnvironment(options.databaseUrl, plan.defaultSslMode, route)
     await runCommand('docker', [
       'run', '--rm', '--name', containerName,
       '--label', 'com.1f3d9.role=backup',
       '--label', `com.1f3d9.expires=${new Date(Date.now() + 60 * 60_000).toISOString()}`,
-      '--add-host', 'host.docker.internal:host-gateway',
+      ...connection.runArguments,
       ...connection.keys.flatMap(key => ['--env', key]),
       '--mount', dockerBindMount(outputDirectory, '/backup'),
       options.toolImage,

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -600,11 +600,17 @@ export async function sha256File(path: string): Promise<string> {
 
 async function writePrivateFile(path: string, text: string): Promise<void> {
   const handle = await open(path, 'wx', 0o600)
+  let completed = false
   try {
     await handle.writeFile(text, 'utf8')
     await handle.sync()
-  } finally {
     await handle.close()
+    completed = true
+  } finally {
+    if (!completed) {
+      await handle.close().catch(() => {})
+      await unlink(path).catch(() => {})
+    }
   }
 }
 
@@ -715,8 +721,12 @@ export async function runBackup(options: Readonly<{
   const inspectArchive = options.inspectArchive ?? inspectWithDocker
   let archivePublished = false
   let manifestPublished = false
+  let tempArchiveCreated = false
+  let tempManifestCreated = false
 
   try {
+    await writePrivateFile(tempArchive, '')
+    tempArchiveCreated = true
     const dumped = await dumpArchive({
       databaseUrl: target.identity.databaseUrl,
       outputPath: tempArchive,
@@ -764,6 +774,7 @@ export async function runBackup(options: Readonly<{
       },
     }
     await writePrivateFile(tempManifest, `${JSON.stringify(manifest, null, 2)}\n`)
+    tempManifestCreated = true
     await publishExclusive(tempArchive, archivePath)
     archivePublished = true
     await publishExclusive(tempManifest, manifestPath)
@@ -808,8 +819,8 @@ export async function runBackup(options: Readonly<{
     }
     throw error
   } finally {
-    await unlink(tempArchive).catch(() => {})
-    await unlink(tempManifest).catch(() => {})
+    if (tempArchiveCreated) await unlink(tempArchive).catch(() => {})
+    if (tempManifestCreated) await unlink(tempManifest).catch(() => {})
   }
 }
 

--- a/test/backup-restore.test.ts
+++ b/test/backup-restore.test.ts
@@ -7,8 +7,10 @@ import test from 'node:test'
 
 import {
   assertPrivateBackupDirectory,
+  dockerDatabaseRoutePlan,
   parseBackupArgs,
   runBackup,
+  selectDockerDatabaseRoute,
 } from '../scripts/backup.ts'
 import {
   combineRestoreCleanupErrors,
@@ -51,6 +53,93 @@ test('backup arguments require an explicit target and expected database', () => 
   ]) {
     assert.throws(() => parseBackupArgs(args), /target|database|argument|duplicate/i)
   }
+})
+
+test('Docker plans gateway-first loopback access without negotiating remote databases', async () => {
+  const linux = dockerDatabaseRoutePlan(
+    'postgres://role:password@127.0.0.1:5432/city',
+    'linux',
+  )
+  assert.deepEqual(
+    linux,
+    {
+      candidates: [
+        {
+          hostname: 'host.docker.internal',
+          runArguments: ['--add-host', 'host.docker.internal:host-gateway'],
+        },
+        { hostname: '127.0.0.1', runArguments: ['--network', 'host'] },
+      ],
+      defaultSslMode: 'disable',
+      loopback: true,
+    },
+  )
+  const windows = dockerDatabaseRoutePlan(
+    'postgres://role:password@127.0.0.1:5432/city',
+    'win32',
+  )
+  assert.deepEqual(windows.candidates, [linux.candidates[0]])
+
+  let remoteProbes = 0
+  const remote = dockerDatabaseRoutePlan(
+    'postgres://role:password@ep-preview.us-east-2.aws.neon.tech/city',
+    'linux',
+  )
+  const selectedRemote = await selectDockerDatabaseRoute(remote, async () => {
+    remoteProbes += 1
+    return false
+  })
+  assert.deepEqual(
+    selectedRemote,
+    {
+      hostname: 'ep-preview.us-east-2.aws.neon.tech',
+      runArguments: ['--add-host', 'host.docker.internal:host-gateway'],
+    },
+  )
+  assert.equal(remote.defaultSslMode, 'require')
+  assert.equal(remote.loopback, false)
+  assert.equal(remoteProbes, 0)
+})
+
+test('Docker selects only an authenticated reachable loopback route', async () => {
+  const linux = dockerDatabaseRoutePlan(
+    'postgres://role:password@[::1]:5432/city',
+    'linux',
+  )
+  const gatewayCalls: string[] = []
+  const gateway = await selectDockerDatabaseRoute(linux, async candidate => {
+    gatewayCalls.push(candidate.hostname)
+    return true
+  })
+  assert.equal(gateway.hostname, 'host.docker.internal')
+  assert.deepEqual(gatewayCalls, ['host.docker.internal'])
+
+  const fallbackCalls: string[] = []
+  const fallback = await selectDockerDatabaseRoute(linux, async candidate => {
+    fallbackCalls.push(candidate.hostname)
+    return candidate.hostname === '::1'
+  })
+  assert.equal(fallback.hostname, '::1')
+  assert.deepEqual(fallbackCalls, ['host.docker.internal', '::1'])
+
+  await assert.rejects(
+    selectDockerDatabaseRoute(linux, async () => false),
+    /could not reach the validated local PostgreSQL endpoint/,
+  )
+
+  const windows = dockerDatabaseRoutePlan(
+    'postgres://role:password@localhost:5432/city',
+    'win32',
+  )
+  let windowsProbes = 0
+  await assert.rejects(
+    selectDockerDatabaseRoute(windows, async () => {
+      windowsProbes += 1
+      return false
+    }),
+    /could not reach the validated local PostgreSQL endpoint/,
+  )
+  assert.equal(windowsProbes, 1)
 })
 
 test('backup requires a proven source target before starting pg_dump', async t => {

--- a/test/backup-restore.test.ts
+++ b/test/backup-restore.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import test from 'node:test'
@@ -430,7 +430,11 @@ test('backup publishes a target-named custom archive with matching SHA-256 evide
     log: () => {},
     dumpArchive: async ({ databaseUrl, outputPath }) => {
       assert.equal(databaseUrl, secretUrl)
-      await writeFile(outputPath, archiveBytes, { flag: 'wx', mode: 0o600 })
+      const reserved = await stat(outputPath)
+      assert.equal(reserved.isFile(), true)
+      assert.equal(reserved.size, 0)
+      if (process.platform !== 'win32') assert.equal(reserved.mode & 0o777, 0o600)
+      await writeFile(outputPath, archiveBytes, { flag: 'w' })
       return { pgDumpVersion: 'pg_dump (PostgreSQL) 17.6' }
     },
     inspectArchive: async ({ archivePath }) => {
@@ -490,6 +494,98 @@ test('backup publishes a target-named custom archive with matching SHA-256 evide
     basename(result.archivePath),
     basename(result.manifestPath),
   ].sort())
+})
+
+test('backup never replaces an existing archive or manifest', async t => {
+  const now = new Date('2026-08-16T14:15:16.789Z')
+  const archiveName = '1f3d9-local-city-2026-08-16T14-15-16-789Z.dump'
+
+  for (const occupied of ['archive', 'manifest'] as const) {
+    const root = await temporaryRoot(t, `1f3d9-backup-${occupied}-collision-red-`)
+    const backupDirectory = join(root, 'backups')
+    const archivePath = join(backupDirectory, archiveName)
+    const manifestPath = `${archivePath}.manifest.json`
+    const occupiedPath = occupied === 'archive' ? archivePath : manifestPath
+    const original = Buffer.from(`existing ${occupied}`)
+    await mkdir(backupDirectory)
+    await writeFile(occupiedPath, original)
+
+    await assert.rejects(
+      runBackup({
+        argv: ['--target', 'local', '--database', 'city'],
+        root,
+        environment: {
+          CONFIRM_LOCAL_BACKUP: LOCAL_ACKNOWLEDGEMENT,
+          LOCAL_DATABASE_URL_UNPOOLED: 'postgres://role@127.0.0.1/city',
+        },
+        now: () => now,
+        nonce: () => '0011223344556677',
+        log: () => {},
+        dumpArchive: async ({ outputPath }) => {
+          await writeFile(outputPath, 'new archive', { flag: 'w' })
+          return { pgDumpVersion: 'pg_dump (PostgreSQL) 17.6' }
+        },
+        inspectArchive: async () => ({
+          pgRestoreVersion: 'pg_restore (PostgreSQL) 17.6',
+          tocEntries: 42,
+        }),
+      }),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === 'EEXIST',
+    )
+
+    assert.deepEqual(await readFile(occupiedPath), original)
+    assert.deepEqual(await readdir(backupDirectory), [basename(occupiedPath)])
+  }
+})
+
+test('backup cleanup never deletes a temporary file it did not create', async t => {
+  const now = new Date('2026-08-16T14:15:16.789Z')
+  const archiveName = '1f3d9-local-city-2026-08-16T14-15-16-789Z.dump'
+  const nonce = '0011223344556677'
+
+  for (const occupied of ['archive-temp', 'manifest-temp'] as const) {
+    const root = await temporaryRoot(t, `1f3d9-backup-${occupied}-collision-red-`)
+    const backupDirectory = join(root, 'backups')
+    const archivePath = join(backupDirectory, archiveName)
+    const tempArchive = join(backupDirectory, `.${archiveName}.${nonce}.tmp`)
+    const tempManifest = join(backupDirectory, `.${archiveName}.manifest.json.${nonce}.tmp`)
+    const occupiedPath = occupied === 'archive-temp' ? tempArchive : tempManifest
+    const original = Buffer.from(`existing ${occupied}`)
+    let dumpCalls = 0
+    let inspectCalls = 0
+    await mkdir(backupDirectory)
+    await writeFile(occupiedPath, original)
+
+    await assert.rejects(
+      runBackup({
+        argv: ['--target', 'local', '--database', 'city'],
+        root,
+        environment: {
+          CONFIRM_LOCAL_BACKUP: LOCAL_ACKNOWLEDGEMENT,
+          LOCAL_DATABASE_URL_UNPOOLED: 'postgres://role@127.0.0.1/city',
+        },
+        now: () => now,
+        nonce: () => nonce,
+        log: () => {},
+        dumpArchive: async ({ outputPath }) => {
+          dumpCalls += 1
+          await writeFile(outputPath, 'new archive', { flag: 'w' })
+          return { pgDumpVersion: 'pg_dump (PostgreSQL) 17.6' }
+        },
+        inspectArchive: async () => {
+          inspectCalls += 1
+          return { pgRestoreVersion: 'pg_restore (PostgreSQL) 17.6', tocEntries: 42 }
+        },
+      }),
+      (error: unknown) => (error as NodeJS.ErrnoException).code === 'EEXIST',
+    )
+
+    assert.deepEqual(await readFile(occupiedPath), original)
+    assert.deepEqual(await readdir(backupDirectory), [basename(occupiedPath)])
+    assert.equal(dumpCalls, occupied === 'archive-temp' ? 0 : 1)
+    assert.equal(inspectCalls, occupied === 'archive-temp' ? 0 : 1)
+    await assert.rejects(readFile(archivePath), { code: 'ENOENT' })
+  }
 })
 
 test('retention cleanup cannot discard a newly verified backup', async t => {

--- a/test/city-credit-schema.test.ts
+++ b/test/city-credit-schema.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readdirSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { splitSqlStatements } from '../scripts/migrate.ts'
 
 const schemaDdl = readFileSync(new URL('../db/schema.sql', import.meta.url), 'utf8')
@@ -146,5 +146,9 @@ test('credit is an explicit additive migration target', () => {
   assert.doesNotMatch(migrationDdl, /DROP\s+TABLE[\s\S]{0,100}city_credit/iu)
   assert.match(packageJson.scripts['migrate:preview:city-credit'] ?? '', /--target preview --migration city-credit$/u)
   assert.match(packageJson.scripts['migrate:production:city-credit'] ?? '', /--target production --migration city-credit$/u)
-  assert.match(packageJson.scripts['test:postgres'] ?? '', /city-credit-postgres\.test\.ts/u)
+  assert.match(packageJson.scripts['test:postgres'] ?? '', /test\/integration\/\*\.test\.ts/u)
+  assert.equal(
+    existsSync(new URL('../test/integration/city-credit-postgres.test.ts', import.meta.url)),
+    true,
+  )
 })

--- a/test/deploy-safety.test.ts
+++ b/test/deploy-safety.test.ts
@@ -25,6 +25,24 @@ import {
 } from '../scripts/migrate.ts'
 
 const deployScript = readFileSync(new URL('../scripts/deploy.sh', import.meta.url), 'utf8')
+const ciWorkflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8')
+const testingGuide = readFileSync(new URL('../docs/TESTING.md', import.meta.url), 'utf8')
+const workingStandard = readFileSync(new URL('../AGENTS.md', import.meta.url), 'utf8')
+const PAYMENT_RELIABILITY_STANDARD = [
+  '## Payment reliability',
+  '',
+  'Every payment-path change requires:',
+  '',
+  '- real-timing tests against real PostgreSQL, including chain finality later than',
+  '  the intent or operation window;',
+  '- adversarial refuter review before merge; and',
+  '- a read-only or self-cleaning post-deploy production probe of the changed',
+  '  surface.',
+  '',
+  'Use city PR #107 as the test model. City issue #103, market PRs #13/#20, and',
+  'city PRs #115/#116 record why: mocks missed chain timing and SQL preparation,',
+  'while non-production runtimes missed live-only failures.',
+].join('\n')
 const deploymentRunbook = readFileSync(
   new URL('../docs/runbooks/DEPLOYMENT.md', import.meta.url),
   'utf8',
@@ -32,6 +50,16 @@ const deploymentRunbook = readFileSync(
 const packageJson = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
 ) as { scripts: Record<string, string> }
+
+function assertPostgresTestDiscovered(fileName: string): void {
+  assert.match(packageJson.scripts['test:postgres'] ?? '', /test\/integration\/\*\.test\.ts/u)
+  assert.equal(
+    existsSync(new URL(`../test/integration/${fileName}`, import.meta.url)),
+    true,
+    `missing glob-discovered PostgreSQL test: ${fileName}`,
+  )
+}
+
 const fullSchema = readFileSync(new URL('../db/schema.sql', import.meta.url), 'utf8')
 const oauthMigration = readFileSync(
   new URL('../db/migrations/20260813_hosted_chat_signin.sql', import.meta.url),
@@ -164,6 +192,27 @@ test('every release test gate remains part of explicit branch preparation', () =
   }
   assert.match(deployScript, /--prepare/)
   assert.match(deployScript, /merge[^\n]*\bmain\b/i)
+})
+
+test('payment reliability is fail-hard in required checks and documented where it binds', () => {
+  assert.ok(workingStandard.includes(PAYMENT_RELIABILITY_STANDARD))
+  assert.match(ciWorkflow, /^jobs:\r?\n  checks:\r?\n    runs-on:/mu)
+  assert.match(
+    ciWorkflow,
+    /- name: Run PostgreSQL integration tests\r?\n\s+run: npm run test:postgres/u,
+  )
+  assert.doesNotMatch(ciWorkflow, /continue-on-error:\s*true/iu)
+
+  const postgresCommand = packageJson.scripts['test:postgres'] ?? ''
+  assert.match(postgresCommand, /--test-concurrency=1/u)
+  assert.match(postgresCommand, /test\/integration\/\*\.test\.ts/u)
+  assert.doesNotMatch(postgresCommand, /test\/integration\/[\w-]+-postgres\.test\.ts/u)
+
+  assert.match(
+    testingGuide,
+    /CI \(`\.github\/workflows\/ci\.yml`\)[\s\S]{0,300}PostgreSQL/iu,
+  )
+  assert.doesNotMatch(testingGuide, /postgres suites run locally/iu)
 })
 
 test('preview migration requires exact acknowledgement and named isolated Neon targets', () => {
@@ -946,7 +995,7 @@ test('identity recovery is an explicitly selected additive release with a Postgr
     },
   )
   assert.equal(production.migrationFile, 'db/migrations/20260816_identity_recovery.sql')
-  assert.match(packageJson.scripts['test:postgres'] ?? '', /identity-recovery-postgres\.test\.ts/)
+  assertPostgresTestDiscovered('identity-recovery-postgres.test.ts')
 })
 
 test('identity rotation is additive, schema-complete, and covered by the existing identity PostgreSQL gate', () => {
@@ -979,9 +1028,12 @@ test('identity rotation is additive, schema-complete, and covered by the existin
     )
   }
 
-  const postgresCommand = packageJson.scripts['test:postgres'] ?? ''
-  assert.match(postgresCommand, /identity-recovery-postgres\.test\.ts/)
-  assert.doesNotMatch(postgresCommand, /identity-rotation-postgres\.test\.ts/)
+  assertPostgresTestDiscovered('identity-recovery-postgres.test.ts')
+  assert.equal(
+    existsSync(new URL('../test/integration/identity-rotation-postgres.test.ts', import.meta.url)),
+    false,
+    'identity rotation should stay covered by the existing identity integration suite',
+  )
 })
 
 test('initial recovery codes use two additive normalized pending tables', () => {
@@ -1032,9 +1084,8 @@ test('initial recovery codes are selected as one separate preview or production 
   )
   assert.equal(production.migrationFile, 'db/migrations/20260817_initial_recovery_codes.sql')
 
-  const postgresCommand = packageJson.scripts['test:postgres'] ?? ''
-  assert.match(postgresCommand, /identity-recovery-postgres\.test\.ts/)
-  assert.match(postgresCommand, /oauth-postgres\.test\.ts/)
+  assertPostgresTestDiscovered('identity-recovery-postgres.test.ts')
+  assertPostgresTestDiscovered('oauth-postgres.test.ts')
 })
 
 test('payment attempts are an explicitly selected additive release', () => {

--- a/test/integration/backup-restore-postgres.test.ts
+++ b/test/integration/backup-restore-postgres.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { randomBytes } from 'node:crypto'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -164,6 +164,13 @@ test('a custom archive stays coherent across a concurrent commit and restores tw
   `)
   await locker.query('COMMIT')
   const backup = await backupPromise
+  if (process.platform !== 'win32') {
+    const archiveStat = await stat(backup.archivePath)
+    const hostUid = process.getuid?.()
+    assert.equal(archiveStat.mode & 0o777, 0o600)
+    assert.equal(Number.isInteger(hostUid), true)
+    assert.equal(archiveStat.uid, hostUid)
+  }
 
   const sourceVersions = await source.query<{ before: number; after: number }>(`
     SELECT

--- a/test/integration/payment-recovery-postgres.test.ts
+++ b/test/integration/payment-recovery-postgres.test.ts
@@ -221,16 +221,7 @@ async function insertAttempt(database: Pool, options: AttemptOptions): Promise<v
 }
 
 test('payment recovery migration and primitives preserve exact deadline and terminal history', async t => {
-  let postgres: Awaited<ReturnType<typeof startPostgres>> | null = null
-  try {
-    postgres = await startPostgres()
-  } catch (error) {
-    if (/docker .*not recognized|docker .*not found|cannot connect|daemon/iu.test(String(error))) {
-      t.skip(`Docker unavailable: ${String(error)}`)
-      return
-    }
-    throw error
-  }
+  const postgres = await startPostgres()
   const { database, containerName } = postgres
   t.after(async () => {
     await database.end().catch(() => undefined)
@@ -302,7 +293,7 @@ test('payment recovery migration and primitives preserve exact deadline and term
     assert.equal(windows.rows[0]?.exact, true)
   })
 
-  await t.test('due-only leases refuse one millisecond before, acquire at equality, and overlap safely', async () => {
+  await t.test('due-only leases refuse one millisecond before, acquire at and after equality, and overlap safely', async () => {
     await reset(database)
     await insertAttempt(database, {
       publicId: 'pay_recovery_due_lease_boundary', targetKey: 'frontier:root:due-lease-boundary',
@@ -337,6 +328,23 @@ test('payment recovery migration and primitives preserve exact deadline and term
     }, () => 'due_lease_exact')
     assert.equal(acquired.acquired, true)
     assert.equal(acquired.leaseOwner, 'due_lease_exact')
+
+    await insertAttempt(database, {
+      publicId: 'pay_recovery_due_lease_after', targetKey: 'frontier:root:due-lease-after',
+      status: 'payment_pending', leaseOwner: null, recovery: 'due',
+    })
+    const afterBoundary = await database.query<{ recovery_deadline_at: Date }>(`
+      SELECT recovery_deadline_at FROM payment_attempts
+      WHERE public_id = 'pay_recovery_due_lease_after'
+    `)
+    const afterDeadline = afterBoundary.rows[0]?.recovery_deadline_at
+    assert.ok(afterDeadline instanceof Date)
+    const oneMillisecondAfter = new Date(afterDeadline.getTime() + 1)
+    const acquiredAfter = await acquireDueSettlementLease(databaseAt(oneMillisecondAfter), {
+      publicId: 'pay_recovery_due_lease_after', actorId: 2, leaseMilliseconds: 30_000,
+    }, () => 'due_lease_after')
+    assert.equal(acquiredAfter.acquired, true)
+    assert.equal(acquiredAfter.leaseOwner, 'due_lease_after')
 
     await insertAttempt(database, {
       publicId: 'pay_recovery_due_lease_race', targetKey: 'frontier:root:due-lease-race',
@@ -532,6 +540,66 @@ test('payment recovery migration and primitives preserve exact deadline and term
         WHERE public_id = 'pay_recovery_immutable'`),
       (error: unknown) => postgresCode(error) === '55000',
     )
+  })
+
+  await t.test('finality arriving after a pending observation completes inside the recovery window', async () => {
+    await reset(database)
+    await insertAttempt(database, {
+      publicId: 'pay_recovery_finality_inside_window',
+      targetKey: 'frontier:root:finality-inside-window',
+      status: 'settling', leaseOwner: 'lease-finality-inside', txHash: null, recovery: 'none',
+    })
+    const paymentDatabase = { query: async (text: string, params: readonly unknown[] = []) => (
+      await database.query(text, [...params])
+    ).rows }
+
+    const pending = await bindPaymentEvidence(paymentDatabase, {
+      publicId: 'pay_recovery_finality_inside_window',
+      leaseOwner: 'lease-finality-inside',
+      txHash: TX,
+      finality: null,
+    })
+    assert.equal(pending.status, 'payment_pending')
+    assert.equal(pending.finalizedAt, null)
+    assert.ok(pending.recoveryStartedAt)
+    assert.ok(pending.recoveryDeadlineAt)
+
+    await delay(20)
+    const finalizedAt = new Date().toISOString()
+    const finalized = await bindPaymentEvidence(paymentDatabase, {
+      publicId: 'pay_recovery_finality_inside_window',
+      leaseOwner: 'lease-finality-inside',
+      txHash: TX,
+      finality: {
+        blockNumber: 50_000_001n,
+        blockHash: BLOCK_HASH,
+        blockTime: new Date(Date.now() - 30_000).toISOString(),
+        finalizedAt,
+      },
+    })
+    assert.equal(finalized.status, 'payment_pending')
+    assert.equal(finalized.finalizedAt, finalizedAt)
+    assert.equal(finalized.recoveryStartedAt, pending.recoveryStartedAt)
+    assert.equal(finalized.recoveryDeadlineAt, pending.recoveryDeadlineAt)
+    const timing = await database.query<{
+      finality_inside_window: boolean
+      window_still_open: boolean
+    }>(`
+      SELECT finalized_at < recovery_deadline_at AS finality_inside_window,
+             clock_timestamp() < recovery_deadline_at AS window_still_open
+      FROM payment_attempts WHERE public_id = 'pay_recovery_finality_inside_window'
+    `)
+    assert.deepEqual(timing.rows, [{ finality_inside_window: true, window_still_open: true }])
+
+    const completed = await completePaymentAttempt(paymentDatabase, {
+      publicId: 'pay_recovery_finality_inside_window',
+      leaseOwner: 'lease-finality-inside',
+      result: { place_id: 94 },
+      responseStatus: 201,
+      response: RESPONSE,
+      responseBody: RESPONSE_BODY,
+    })
+    assert.equal(completed.status, 'completed')
   })
 
   await t.test('expired late finality appends founder review without deleting or rewriting history', async () => {

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync, readdirSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import {
   MIGRATION_LOCK_TIMEOUT,
   MIGRATION_STATEMENT_TIMEOUT,
@@ -512,7 +512,11 @@ test('runtime logs are one explicit guarded transactional preview or production 
   ) as { scripts?: Record<string, string> }
   assert.match(packageJson.scripts?.['migrate:preview:runtime-logs'] ?? '', /--migration runtime-logs/u)
   assert.match(packageJson.scripts?.['migrate:production:runtime-logs'] ?? '', /--migration runtime-logs/u)
-  assert.match(packageJson.scripts?.['test:postgres'] ?? '', /runtime-logs-postgres\.test\.ts/u)
+  assert.match(packageJson.scripts?.['test:postgres'] ?? '', /test\/integration\/\*\.test\.ts/u)
+  assert.equal(
+    existsSync(new URL('../test/integration/runtime-logs-postgres.test.ts', import.meta.url)),
+    true,
+  )
 })
 
 test('round-two records are append-only rather than deleted after resolution', () => {

--- a/test/public-search-index-contract.test.ts
+++ b/test/public-search-index-contract.test.ts
@@ -117,5 +117,9 @@ test('the search-index release is explicitly selected and runs outside one long 
   const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
     scripts?: Record<string, string>
   }
-  assert.match(packageJson.scripts?.['test:postgres'] ?? '', new RegExp(postgresTestFile, 'u'))
+  assert.match(packageJson.scripts?.['test:postgres'] ?? '', /test\/integration\/\*\.test\.ts/u)
+  assert.equal(
+    existsSync(new URL(`../test/integration/${postgresTestFile}`, import.meta.url)),
+    true,
+  )
 })

--- a/test/public-snapshot-automation.test.ts
+++ b/test/public-snapshot-automation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import test from 'node:test'
 import { resolveMigrationRun } from '../scripts/migrate.ts'
 
@@ -67,7 +67,11 @@ test('package scripts expose migration, snapshot, and PostgreSQL proof commands'
   )
   assert.match(
     packageJson.scripts['test:postgres'] ?? '',
-    /(?:^|\s)test\/integration\/public-snapshot-postgres\.test\.ts(?:\s|$)/u,
+    /test\/integration\/\*\.test\.ts/u,
+  )
+  assert.equal(
+    existsSync(new URL('test/integration/public-snapshot-postgres.test.ts', root)),
+    true,
   )
 })
 


### PR DESCRIPTION
Addresses #103.

## Outcome

- Runs every city PostgreSQL integration file sequentially through one fail-hard glob and requires it inside the existing checks job.
- Adds only the genuine missing real-PostgreSQL timing cases: just after the two-hour deadline and pending-to-finalized completion inside the recovery window. Existing PR #107 coverage remains the source for equality, before-boundary, post-window finality, and founder-review handoff.
- Adds the binding payment-reliability standard: real timing plus real PostgreSQL, adversarial refuter review, and a read-only or self-cleaning production probe after deployment.
- Updates the testing contract and its enforcement tests so a new integration file cannot silently fall outside CI.

## Incident basis

This makes the lesson from #103 and PRs #107, #115, and #116 enforceable, and applies the market escape evidence from onetapstudiogames/1f3ea#13 and onetapstudiogames/1f3ea#20.

The new required hosted gate also exposed two pre-existing native-Linux defects in the backup roundtrip: Docker could not reach a loopback-only host database through its bridge, then a container-owned temporary archive could not be hard-linked by the runner. The fixes now prove the exact authenticated route, preserve loopback binding, reserve a host-owned private archive inode, and refuse all final or temporary-name collisions without deleting files this run did not create.

## Verification

- Clean install: passed; zero dependency vulnerabilities.
- Typecheck: passed.
- Unit suite: 1,108/1,108 passed.
- Coverage: 90.81% statements and 81.60% branches; all enforced thresholds passed.
- Real PostgreSQL: 164/164 passed, zero skipped.
- Browser suite: 83/83 passed.
- Required hosted checks: passed on final SHA 15c8d66 — https://github.com/onetapstudiogames/1f3d9/actions/runs/33021032701
- Independent adversarial refuter: no material findings.
- Branch protection and workflow job id both remain exactly checks.

## Release preparation

The helper verified the clean branch at its exact pushed origin commit, then printed GATE_EXIT=1 at the existing LATER_HOLDER_CURSOR_KEY Preview/Production verification prerequisite. That unrelated provider value was not guessed or acknowledged. Every component gate that prepare would run passed independently above.

## Explicit exclusions and remaining leg

- No payment behavior changed.
- The owner-funded live payment canary is the payment standard's one unimplemented leg.
- Emulator checks remain a separate concern.
- This PR is intentionally unmerged, so the new post-deploy production probe can run only after an approved merge and deployment.