### PR TITLE
fix: alias bodies obey field rules without a Content-Length header

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -211,12 +211,23 @@ async function runResidentAction(
 async function actionRequest(c: Context, forced?: Partial<JsonObject>): Promise<Response> {
   const resident = await auth(c)
   if (!resident) return err(c, 401, 'bad or missing bearer secret')
-  const contentLength = c.req.header('content-length')
-  const supplied = forced && (contentLength == null || contentLength === '0')
-    ? {}
-    : await jsonBody(c)
-  if (supplied === null) return err(c, 400, 'body must be a JSON object')
-  const body = { ...supplied, ...forced }
+  // The production edge strips Content-Length, so an alias's optional body is
+  // detected by reading it, never from the header; a body that is present
+  // always faces the same accepted-field rules as /api/action.
+  const raw = await c.req.text()
+  if (forced && raw.trim() === '') {
+    return runResidentAction(c, resident, { ...forced })
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw) as unknown
+  } catch {
+    return err(c, 400, 'body must be a JSON object')
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return err(c, 400, 'body must be a JSON object')
+  }
+  const body = { ...parsed as JsonObject, ...forced }
   return runResidentAction(c, resident, body)
 }
 

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -8420,6 +8420,23 @@ test('use composes effects, local laws act on talk, and going home stays unblock
   assert.equal(home.status, 200)
   const homeBody = await home.json() as { action: { place_id: number | null } }
   assert.equal(homeBody.action.place_id, 3)
+
+  // An alias body without a Content-Length header — the shape the production
+  // edge forwards — still faces the accepted-field rules instead of being
+  // silently discarded.
+  const rejected = await app.request('/api/go-home', {
+    method: 'POST',
+    headers: authHeaders(OTHER_SECRET),
+    body: JSON.stringify({ to_place_id: 9 }),
+  })
+  assert.equal(rejected.status, 400)
+
+  const emptyObject = await app.request('/api/go-home', {
+    method: 'POST',
+    headers: authHeaders(OTHER_SECRET),
+    body: '{}',
+  })
+  assert.equal(emptyObject.status, 200)
 })
 
 test('a visitor may use an open thing but not consume it', async () => {


### PR DESCRIPTION
Found by the adversarial verification of #122's FRONTDOOR alias documentation: src/actions.ts detected an alias's optional body by sniffing the Content-Length header, which the production edge strips from every request (established in #123). In production, every POST to /api/go-home, /api/thing/:id/use, or /api/thing/:id/consume that carried a JSON body had all of its fields silently discarded — a use with to_handle ran without it, and go-home returned 200 for bodies with unsupported fields instead of the documented 400.

The optional body is now detected by reading it: an empty body forces the alias action alone (both existing no-body tests unchanged), and a present body faces the same accepted-field rules as /api/action. New tests pin the headerless-body cases. Same edge-stripped class as #123's credit-route sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)