### PR TITLE
fix: reject unsigned paypal webhooks honestly

### DIFF
--- a/docs/runbooks/ENVIRONMENT.md
+++ b/docs/runbooks/ENVIRONMENT.md
@@ -59,9 +59,12 @@ and allowance creation say that no payment was started only for a fresh operatio
 saved return or cancel URL may follow an approval, so dormant mode says to keep that exact
 URL and purchase ID, reconnect PayPal, and reload without starting another approval.
 Capture likewise retries the same purchase and order without paying again. Webhook delivery
-asks PayPal to retry that exact event. Do not advertise the buy door until the complete
-configuration is active. The separate `/gift-redirect` recovery door remains available
-because it starts no PayPal operation.
+asks PayPal to retry that exact event only when PayPal verification is temporarily
+unavailable. Missing or malformed PayPal signature headers must be refused as `401
+unverified`, without creating city state and without asking PayPal to retry a caller-built
+unsigned event. Do not advertise the buy door until the complete configuration is active.
+The separate `/gift-redirect` recovery door remains available because it starts no PayPal
+operation.
 
 Activate in this order:
 

--- a/src/paypal-credit-webhook.ts
+++ b/src/paypal-credit-webhook.ts
@@ -13,6 +13,7 @@ import {
   type PayPalCreditStoreDatabase,
 } from './paypal-credit-store.ts'
 import {
+  PayPalWebhookSignatureError,
   parsePayPalRenewal,
   verifyPayPalWebhook,
   type PayPalEnvironment,
@@ -204,11 +205,22 @@ export async function applyVerifiedPayPalWebhook(
   headers: Headers,
   dependencies: PayPalWebhookApplicationDependencies,
 ): Promise<'credited' | 'ignored' | PayPalDisputeApplicationOutcome> {
-  const verified = await verifyPayPalWebhook(
-    dependencies.environment,
-    { rawBody, headers },
-    dependencies.fetcher ?? fetch,
-  )
+  let verified: boolean
+  try {
+    verified = await verifyPayPalWebhook(
+      dependencies.environment,
+      { rawBody, headers },
+      dependencies.fetcher ?? fetch,
+    )
+  } catch (error) {
+    if (error instanceof PayPalWebhookSignatureError) {
+      throw new PayPalWebhookApplicationError(
+        401,
+        'PayPal webhook signature was not verified.',
+      )
+    }
+    throw error
+  }
   if (!verified) {
     throw new PayPalWebhookApplicationError(401, 'PayPal webhook signature was not verified.')
   }

--- a/src/paypal-credit.ts
+++ b/src/paypal-credit.ts
@@ -14,6 +14,13 @@ const RESOURCE_IDENTIFIER = /^[A-Za-z0-9._:-]{1,255}$/u
 const REQUEST_IDENTIFIER = /^[A-Za-z0-9._:-]{8,108}$/u
 const PAYPAL_CERTIFICATE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u
 
+export class PayPalWebhookSignatureError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PayPalWebhookSignatureError'
+  }
+}
+
 export type PayPalEnvironment = Readonly<Record<string, string | undefined>>
 
 export type PayPalReadiness =
@@ -224,12 +231,17 @@ function paypalCertificateUrl(
   paypalEnvironment: 'sandbox' | 'live',
 ): string {
   const label = 'PayPal certificate URL'
-  const parsedText = text(value, label, 500)
+  let parsedText: string
+  try {
+    parsedText = text(value, label, 500)
+  } catch {
+    throw new PayPalWebhookSignatureError(`${label} is invalid`)
+  }
   let parsed: URL
   try {
     parsed = new URL(parsedText)
   } catch {
-    throw new Error(`${label} is invalid`)
+    throw new PayPalWebhookSignatureError(`${label} is invalid`)
   }
   const expectedHost = paypalEnvironment === 'sandbox'
     ? 'api.sandbox.paypal.com'
@@ -247,7 +259,7 @@ function paypalCertificateUrl(
     || parsed.search
     || parsed.hash
     || !PAYPAL_CERTIFICATE_ID.test(certificateId)
-  ) throw new Error(`${label} is invalid`)
+  ) throw new PayPalWebhookSignatureError(`${label} is invalid`)
   return parsed.href
 }
 
@@ -500,7 +512,12 @@ export async function capturePayPalCreditOrder(
 }
 
 function webhookHeader(headers: Headers, name: string): string {
-  return text(headers.get(name), `PayPal ${name} header`, 8_192)
+  const label = `PayPal ${name} header`
+  try {
+    return text(headers.get(name), label, 8_192)
+  } catch {
+    throw new PayPalWebhookSignatureError(`${label} is invalid`)
+  }
 }
 
 function rawWebhookJson(rawBody: Buffer): string {

--- a/src/paypal-credit.ts
+++ b/src/paypal-credit.ts
@@ -13,6 +13,9 @@ const IDENTIFIER = /^[A-Za-z0-9._:-]{1,128}$/u
 const RESOURCE_IDENTIFIER = /^[A-Za-z0-9._:-]{1,255}$/u
 const REQUEST_IDENTIFIER = /^[A-Za-z0-9._:-]{8,108}$/u
 const PAYPAL_CERTIFICATE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u
+const PAYPAL_WEBHOOK_ALGORITHM = /^[A-Za-z0-9]+$/u
+const PAYPAL_WEBHOOK_TRANSMISSION = /^(?!\d+$)\w+\S+$/u
+const PAYPAL_WEBHOOK_TIME = /^(\d{4})-(\d{2})-(\d{2})[Tt](\d{2}):(\d{2}):([0-5]\d|60)(?:\.\d+)?([Zz]|[+-]\d{2}:\d{2})$/u
 
 export class PayPalWebhookSignatureError extends Error {
   constructor(message: string) {
@@ -511,13 +514,58 @@ export async function capturePayPalCreditOrder(
   })
 }
 
-function webhookHeader(headers: Headers, name: string): string {
+function invalidWebhookSignatureField(label: string): never {
+  throw new PayPalWebhookSignatureError(`${label} is invalid`)
+}
+
+function webhookHeader(
+  headers: Headers,
+  name: string,
+  maximum: number,
+  pattern?: RegExp,
+): string {
   const label = `PayPal ${name} header`
+  let parsed: string
   try {
-    return text(headers.get(name), label, 8_192)
+    parsed = text(headers.get(name), label, maximum)
   } catch {
-    throw new PayPalWebhookSignatureError(`${label} is invalid`)
+    invalidWebhookSignatureField(label)
   }
+  if (pattern && !pattern.test(parsed)) invalidWebhookSignatureField(label)
+  return parsed
+}
+
+function webhookTransmissionTime(headers: Headers): string {
+  const name = 'paypal-transmission-time'
+  const label = `PayPal ${name} header`
+  const parsed = webhookHeader(headers, name, 100, PAYPAL_WEBHOOK_TIME)
+  const match = PAYPAL_WEBHOOK_TIME.exec(parsed)
+  if (!match) invalidWebhookSignatureField(label)
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, zone] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const hour = Number(hourText)
+  const minute = Number(minuteText)
+  const second = Number(secondText)
+  if (zone!.toUpperCase() !== 'Z') {
+    const offsetHour = Number(zone!.slice(1, 3))
+    const offsetMinute = Number(zone!.slice(4, 6))
+    if (offsetHour > 23 || offsetMinute > 59) invalidWebhookSignatureField(label)
+  }
+  const leapSecond = second === 60
+  const wall = new Date(0)
+  wall.setUTCFullYear(year, month - 1, day)
+  wall.setUTCHours(hour, minute, leapSecond ? 59 : second, 0)
+  if (
+    wall.getUTCFullYear() !== year
+    || wall.getUTCMonth() !== month - 1
+    || wall.getUTCDate() !== day
+    || wall.getUTCHours() !== hour
+    || wall.getUTCMinutes() !== minute
+    || wall.getUTCSeconds() !== (leapSecond ? 59 : second)
+  ) invalidWebhookSignatureField(label)
+  return parsed
 }
 
 function rawWebhookJson(rawBody: Buffer): string {
@@ -546,14 +594,29 @@ export async function verifyPayPalWebhook(
   const configuration = requiredConfiguration(environment)
   const rawEvent = rawWebhookJson(input.rawBody)
   const fields = {
-    auth_algo: webhookHeader(input.headers, 'paypal-auth-algo'),
+    auth_algo: webhookHeader(
+      input.headers,
+      'paypal-auth-algo',
+      100,
+      PAYPAL_WEBHOOK_ALGORITHM,
+    ),
     cert_url: paypalCertificateUrl(
-      webhookHeader(input.headers, 'paypal-cert-url'),
+      webhookHeader(input.headers, 'paypal-cert-url', 500),
       configuration.environment,
     ),
-    transmission_id: webhookHeader(input.headers, 'paypal-transmission-id'),
-    transmission_sig: webhookHeader(input.headers, 'paypal-transmission-sig'),
-    transmission_time: webhookHeader(input.headers, 'paypal-transmission-time'),
+    transmission_id: webhookHeader(
+      input.headers,
+      'paypal-transmission-id',
+      50,
+      PAYPAL_WEBHOOK_TRANSMISSION,
+    ),
+    transmission_sig: webhookHeader(
+      input.headers,
+      'paypal-transmission-sig',
+      500,
+      PAYPAL_WEBHOOK_TRANSMISSION,
+    ),
+    transmission_time: webhookTransmissionTime(input.headers),
     webhook_id: configuration.webhookId,
   }
   const serializedFields = JSON.stringify(fields)

--- a/test/paypal-credit-delivery-routes.test.ts
+++ b/test/paypal-credit-delivery-routes.test.ts
@@ -185,6 +185,45 @@ test('an unsigned dispute webhook is rejected as unverified before network or ci
   assert.equal(database.founderNotes.size, 0)
 })
 
+test('malformed PayPal signature headers are rejected before network or city writes', async t => {
+  const cases = [
+    ['auth algorithm', 'paypal-auth-algo', 'SHA256 with RSA'],
+    ['transmission id', 'paypal-transmission-id', '123456'],
+    ['transmission signature', 'paypal-transmission-sig', '123456'],
+    ['transmission time', 'paypal-transmission-time', 'not-a-date'],
+    ['impossible transmission date', 'paypal-transmission-time', '2026-02-30T12:00:00Z'],
+    ['impossible transmission offset', 'paypal-transmission-time', '2026-08-28T12:00:00+99:99'],
+    ['certificate URL', 'paypal-cert-url', 'https://example.com/cert.pem'],
+  ] as const
+
+  for (const [name, header, value] of cases) {
+    await t.test(name, async () => {
+      const database = new MemoryPayPalDatabase()
+      const { app, paypal } = configuredApp(database)
+      const response = await app.request('/api/city-credit/paypal/webhook', postRaw(
+        disputeWebhook({
+          eventId: `WH-MALFORMED-${header}`,
+          eventKind: 'CUSTOMER.DISPUTE.CREATED',
+          disputeId: `PP-D-MALFORMED-${header}`,
+        }),
+        { ...WEBHOOK_HEADERS, [header]: value },
+      ))
+
+      assert.equal(response.status, 401, await response.clone().text())
+      assert.deepEqual(await response.json(), {
+        error: 'PayPal webhook signature was not verified.',
+      })
+      assert.equal(paypal.calls.length, 0, 'malformed evidence must not reach PayPal')
+      assert.equal(database.purchases.size, 0)
+      assert.equal(database.events.size, 0)
+      assert.equal(database.disputes.size, 0)
+      assert.equal(database.disputeEvents.size, 0)
+      assert.equal(database.disputeReceipts.size, 0)
+      assert.equal(database.founderNotes.size, 0)
+    })
+  }
+})
+
 test('unverified dispute webhooks cannot freeze or record a delivered gift', async t => {
   const cases = [
     {

--- a/test/paypal-credit-delivery-routes.test.ts
+++ b/test/paypal-credit-delivery-routes.test.ts
@@ -160,6 +160,31 @@ test('unverified PayPal webhooks cannot create credit, ledger rows, or delivery 
   }
 })
 
+test('an unsigned dispute webhook is rejected as unverified before network or city writes', async () => {
+  const database = new MemoryPayPalDatabase()
+  const { app, paypal } = configuredApp(database)
+  const response = await app.request('/api/city-credit/paypal/webhook', postRaw(
+    disputeWebhook({
+      eventId: 'WH-UNSIGNED-DISPUTE-1',
+      eventKind: 'CUSTOMER.DISPUTE.CREATED',
+      disputeId: 'PP-D-UNSIGNED-1',
+    }),
+    { 'content-type': 'application/json' },
+  ))
+
+  assert.equal(response.status, 401, await response.clone().text())
+  assert.deepEqual(await response.json(), {
+    error: 'PayPal webhook signature was not verified.',
+  })
+  assert.equal(paypal.calls.length, 0, 'unsigned evidence must not reach PayPal')
+  assert.equal(database.purchases.size, 0)
+  assert.equal(database.events.size, 0)
+  assert.equal(database.disputes.size, 0)
+  assert.equal(database.disputeEvents.size, 0)
+  assert.equal(database.disputeReceipts.size, 0)
+  assert.equal(database.founderNotes.size, 0)
+})
+
 test('unverified dispute webhooks cannot freeze or record a delivered gift', async t => {
   const cases = [
     {


### PR DESCRIPTION
## Summary
- reject missing or locally malformed PayPal webhook signature evidence as 401 unverified instead of a retryable 503
- validate PayPal's documented header shapes and certificate origin before any outbound PayPal request or city write
- preserve 503 plus exact-event retry guidance only for real PayPal verification/configuration failures
- document the refusal and retry contract in the environment runbook

## Root cause
The webhook route treated missing signature headers as an ordinary thrown error. Its generic boundary therefore described an unsigned caller request as a temporary PayPal outage and told PayPal to retry it.

## Safety
Rejected evidence reaches neither PayPal nor any credit, delivery, dispute, or founder-note write. No secret, database, migration, or provider configuration changes are included.

## Verification
- npm run typecheck
- npm test: 1,381 passed; coverage gate passed
- npm run test:postgres: 199 passed against real PostgreSQL
- npm run test:e2e: 104 passed in Chromium
- npm audit --audit-level=high: 0 vulnerabilities
- bash scripts/deploy.sh --prepare from a clean clone at the exact pushed commit: GATE_EXIT=0
- GitHub CI, Socket checks, and Vercel preview: green

## Post-deploy proof
After merge and Vercel production deployment, resend the safe unsigned dispute canary. Expected: 401 with no retry instruction. This PR has not generated a real signed PayPal delivery; that remains a separate provider-originated proof.