### PR TITLE
fix: record paid completion failures

### DIFF
--- a/src/world-support.ts
+++ b/src/world-support.ts
@@ -2,6 +2,7 @@ import type { Context } from 'hono'
 import {
   auth,
   err,
+  postgresErrorConstraint,
   postgresErrorCode,
   postgresErrorMessage,
   type Resident,
@@ -163,6 +164,44 @@ export function unknownTraitMessage(error: unknown): string | null {
   return raised.includes('unknown or duplicate trait')
     ? 'names an unknown or duplicate trait; coin each trait first with POST /api/trait'
     : null
+}
+
+function safeTreasuryCompletionText(error: unknown): string | null {
+  const detail = postgresErrorMessage(error) ?? (error instanceof Error ? error.message : null)
+  if (!detail) return null
+  return detail
+    .replace(/postgres(?:ql)?:\/\/[^\s"']+/giu, '[redacted database URL]')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/giu, 'Bearer [redacted]')
+    .replace(/1f3d9_sk_[A-Za-z0-9_-]+/giu, '[redacted resident key]')
+    .slice(0, 240)
+}
+
+export function reportTreasuryCompletionFailure(
+  input: Readonly<{
+    operation: 'frontier' | 'kind_invention' | 'kind_revision'
+    rail: FeePayment['rail']
+    attemptId: string
+    status: number
+  }>,
+  error: unknown,
+): void {
+  const code = postgresErrorCode(error)
+  const constraint = postgresErrorConstraint(error)
+  const detail = safeTreasuryCompletionText(error)
+  console.error('treasury_completion_failure', JSON.stringify({
+    event: 'treasury_completion_failure',
+    operation: input.operation,
+    rail: input.rail,
+    attempt_id: input.attemptId,
+    status: Number.isSafeInteger(input.status) && input.status >= 100 && input.status <= 599
+      ? input.status
+      : 500,
+    ...(code && /^[0-9A-Z]{5}$/u.test(code) ? { error_code: code } : {}),
+    ...(constraint && /^[A-Za-z0-9_.-]{1,120}$/u.test(constraint)
+      ? { constraint }
+      : {}),
+    ...(detail ? { error: detail } : {}),
+  }))
 }
 
 export function hasDuplicateNames(source: unknown, normalized: string[]): boolean {

--- a/src/world.ts
+++ b/src/world.ts
@@ -33,6 +33,7 @@ import {
   jsonBody,
   openOffer,
   reconcileTreasuryCompletionNoEffect,
+  reportTreasuryCompletionFailure,
   returnFailedTreasuryFee,
   requireResident,
   THING_BODY_MAX_BYTES,
@@ -576,15 +577,29 @@ export function mountWorldRoutes(app: Hono): void {
     } catch (error) {
       const message = conflictMessage(error, 'place name or payment proof already used')
       if (fee.rail === 'credit') {
-        return await returnFailedTreasuryFee(
+        const response = await returnFailedTreasuryFee(
           fee,
           resident.id,
           message ?? 'frontier founding failed before completion',
           message ? 409 : 503,
         ) as Response
+        reportTreasuryCompletionFailure({
+          operation: 'frontier',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: response.status,
+        }, error)
+        return response
       }
       if (message) {
-        return await reconcileTreasuryCompletionNoEffect(c, fee, resident.id, message)
+        const response = await reconcileTreasuryCompletionNoEffect(c, fee, resident.id, message)
+        reportTreasuryCompletionFailure({
+          operation: 'frontier',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: response.status,
+        }, error)
+        return response
       }
       throw error
     }
@@ -892,16 +907,38 @@ export function mountWorldRoutes(app: Hono): void {
       const unknownTrait = unknownTraitMessage(error)
       const message = conflictMessage(error, 'kind name or payment proof already used')
       if (fee.rail === 'credit') {
-        return await returnFailedTreasuryFee(
+        const response = await returnFailedTreasuryFee(
           fee,
           resident.id,
           unknownTrait ? `kind ${unknownTrait}` : message ?? 'kind invention failed before completion',
           unknownTrait ? 400 : message ? 409 : 503,
         ) as Response
+        reportTreasuryCompletionFailure({
+          operation: 'kind_invention',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: response.status,
+        }, error)
+        return response
       }
-      if (unknownTrait) return err(c, 400, `kind ${unknownTrait}`)
+      if (unknownTrait) {
+        reportTreasuryCompletionFailure({
+          operation: 'kind_invention',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: 400,
+        }, error)
+        return err(c, 400, `kind ${unknownTrait}`)
+      }
       if (message) {
-        return await reconcileTreasuryCompletionNoEffect(c, fee, resident.id, message)
+        const response = await reconcileTreasuryCompletionNoEffect(c, fee, resident.id, message)
+        reportTreasuryCompletionFailure({
+          operation: 'kind_invention',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: response.status,
+        }, error)
+        return response
       }
       throw error
     }
@@ -996,7 +1033,7 @@ export function mountWorldRoutes(app: Hono): void {
       const unknownTrait = unknownTraitMessage(error)
       const message = conflictMessage(error, 'payment proof already used')
       if (fee.rail === 'credit') {
-        return await returnFailedTreasuryFee(
+        const response = await returnFailedTreasuryFee(
           fee,
           resident.id,
           unknownTrait
@@ -1004,10 +1041,32 @@ export function mountWorldRoutes(app: Hono): void {
             : message ?? 'kind revision failed before completion',
           unknownTrait ? 400 : message ? 409 : 503,
         ) as Response
+        reportTreasuryCompletionFailure({
+          operation: 'kind_revision',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: response.status,
+        }, error)
+        return response
       }
-      if (unknownTrait) return err(c, 400, `kind revision ${unknownTrait}`)
+      if (unknownTrait) {
+        reportTreasuryCompletionFailure({
+          operation: 'kind_revision',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: 400,
+        }, error)
+        return err(c, 400, `kind revision ${unknownTrait}`)
+      }
       if (message) {
-        return await reconcileTreasuryCompletionNoEffect(c, fee, resident.id, message)
+        const response = await reconcileTreasuryCompletionNoEffect(c, fee, resident.id, message)
+        reportTreasuryCompletionFailure({
+          operation: 'kind_revision',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          status: response.status,
+        }, error)
+        return response
       }
       throw error
     }

--- a/test/integration/payment-treasury-operations-postgres.test.ts
+++ b/test/integration/payment-treasury-operations-postgres.test.ts
@@ -96,6 +96,22 @@ async function issueThreeCredits(db: CityCreditDatabase): Promise<void> {
   }
 }
 
+async function issueCredits(
+  db: CityCreditDatabase,
+  count: number,
+  prefix: string,
+): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    const result = await issueCityFeeCredit(db, {
+      founderId: 1,
+      residentId: 2,
+      sourceKey: `${prefix}-${index}`,
+      reason: `fund PostgreSQL completion proof ${index}`,
+    })
+    assert.equal(result.disposition, 'created')
+  }
+}
+
 test('shared treasury completion executes every paid credit operation in real PostgreSQL', {
   timeout: 120_000,
 }, async () => {
@@ -220,6 +236,74 @@ test('shared treasury completion executes every paid credit operation in real Po
       balance_units: '0',
       frontier_places: 1,
       kind_revision: 2,
+    }])
+  } finally {
+    await postgres.client.end().catch(() => undefined)
+    spawnSync('docker', ['stop', '--time', '0', postgres.containerName], { encoding: 'utf8' })
+  }
+})
+
+test('shared treasury completion survives twelve immediate paid kind inventions in real PostgreSQL', {
+  timeout: 120_000,
+}, async () => {
+  const postgres = await startPostgres()
+  try {
+    await resetFresh(postgres.client)
+    const db = database(postgres.client)
+    await issueCredits(db, 12, 'treasury-burst-kind-credit')
+
+    for (let index = 0; index < 12; index += 1) {
+      const request = {
+        name: `treasury-burst-kind-${index.toString().padStart(2, '0')}`,
+        description: `Burst completion proof ${index}.`,
+        traits: [],
+        recipe: [],
+      }
+      const spend = await beginCityCreditSpend(db, {
+        actorId: 2,
+        operation: 'kind_invention',
+        targetKey: `kind-invention:${request.name}`,
+        request,
+        requestId: `treasury-burst-kind-request-${index.toString().padStart(2, '0')}`,
+      })
+      assert.equal(spend.state, 'ready')
+      if (spend.state !== 'ready') assert.fail(`kind invention ${index} did not acquire its lease`)
+      const completion = await completeTreasuryPaymentOperation(db, {
+        attemptId: spend.attempt_id,
+        leaseOwner: spend.lease_owner,
+      })
+      assert.equal(completion.state, 'completed')
+      if (completion.state !== 'completed') assert.fail(`kind invention ${index} did not complete`)
+      assert.equal(completion.operation, 'kind_invention')
+      assert.equal(completion.method, 'credit')
+      assert.equal(completion.status, 201)
+    }
+
+    const finalState = await postgres.client.query<{
+      completed_attempts: number
+      spend_entries: number
+      return_entries: number
+      kind_count: number
+      balance_units: string
+    }>(`
+      SELECT
+        (SELECT count(*)::int FROM payment_attempts WHERE actor_id = 2 AND status = 'completed')
+          AS completed_attempts,
+        (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'spend')
+          AS spend_entries,
+        (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'return')
+          AS return_entries,
+        (SELECT count(*)::int FROM kinds WHERE owner_id = 2 AND name LIKE 'treasury-burst-kind-%')
+          AS kind_count,
+        (SELECT balance_units::text FROM city_credit_accounts WHERE resident_id = 2)
+          AS balance_units
+    `)
+    assert.deepEqual(finalState.rows, [{
+      completed_attempts: 12,
+      spend_entries: 12,
+      return_entries: 0,
+      kind_count: 12,
+      balance_units: '0',
     }])
   } finally {
     await postgres.client.end().catch(() => undefined)

--- a/test/integration/world-postgres.test.ts
+++ b/test/integration/world-postgres.test.ts
@@ -6,6 +6,7 @@ import { setTimeout as delay } from 'node:timers/promises'
 import test, { mock } from 'node:test'
 import { Pool, type PoolClient } from 'pg'
 
+import { issueCityFeeCredit, type CityCreditDatabase } from '../../src/city-credit.ts'
 import type { Resident } from '../../src/core.ts'
 import type { TaggedSql } from '../../src/engine.ts'
 
@@ -38,6 +39,11 @@ const sql = (async (
   }
   return result.rows as Record<string, unknown>[]
 }) as unknown as IntegrationSql
+
+sql.query = async (text, values = []) => {
+  assert.ok(database, 'the PostgreSQL test client must be connected')
+  return (await database.query(text, [...values])).rows as Record<string, unknown>[]
+}
 
 function transactionSql(client: PoolClient): TaggedSql {
   const tagged = (async (
@@ -295,6 +301,81 @@ test('world mutations plan and commit atomically in PostgreSQL', async t => {
     const app = new Hono()
     mountSocietyRoutes(app)
     mountWorldRoutes(app)
+
+    await t.test('twelve immediate paid kind requests complete through the real public route', async () => {
+      await resetDatabase()
+      const creditDatabase: CityCreditDatabase = {
+        query: async (text, params = []) => (
+          await database!.query(text, [...params])
+        ).rows,
+      }
+      for (let index = 0; index < 12; index += 1) {
+        const issued = await issueCityFeeCredit(creditDatabase, {
+          founderId: 1,
+          residentId: 2,
+          sourceKey: `route-burst-kind-credit-${index}`,
+          reason: `fund route burst kind ${index}`,
+        })
+        assert.equal(issued.disposition, 'created')
+      }
+
+      for (let index = 0; index < 12; index += 1) {
+        const name = `route-burst-kind-${index.toString().padStart(2, '0')}`
+        const response = await app.request('/api/kind', {
+          method: 'POST',
+          headers: {
+            ...bearer(neighborSecret),
+            'content-type': 'application/json',
+            'X-1F3D9-FEE-CREDIT': `route-burst-kind-request-${index}`,
+          },
+          body: JSON.stringify({
+            name,
+            description: `Immediate route completion proof ${index}.`,
+            traits: [],
+            recipe: [],
+          }),
+        })
+        assert.equal(response.status, 201, `request ${index}: ${await response.clone().text()}`)
+        const body = await response.json() as {
+          readonly kind: { readonly name: string }
+          readonly city_fee_credit: { readonly spent_usdc: string }
+        }
+        assert.equal(body.kind.name, name)
+        assert.equal(body.city_fee_credit.spent_usdc, '1.000000')
+      }
+
+      const finalState = await database!.query<{
+        completed_attempts: number
+        spend_entries: number
+        return_entries: number
+        kind_count: number
+        event_count: number
+        balance_units: string
+      }>(`
+        SELECT
+          (SELECT count(*)::int FROM payment_attempts
+            WHERE actor_id = 2 AND operation = 'kind_invention' AND status = 'completed')
+            AS completed_attempts,
+          (SELECT count(*)::int FROM city_credit_entries
+            WHERE resident_id = 2 AND entry_kind = 'spend') AS spend_entries,
+          (SELECT count(*)::int FROM city_credit_entries
+            WHERE resident_id = 2 AND entry_kind = 'return') AS return_entries,
+          (SELECT count(*)::int FROM kinds
+            WHERE owner_id = 2 AND name LIKE 'route-burst-kind-%') AS kind_count,
+          (SELECT count(*)::int FROM events
+            WHERE actor = 'neighbor' AND kind = 'kind_invented') AS event_count,
+          (SELECT balance_units::text FROM city_credit_accounts WHERE resident_id = 2)
+            AS balance_units
+      `)
+      assert.deepEqual(finalState.rows, [{
+        completed_attempts: 12,
+        spend_entries: 12,
+        return_entries: 0,
+        kind_count: 12,
+        event_count: 12,
+        balance_units: '0',
+      }])
+    })
 
     await t.test('the reported parent and child both accept make through the public route', async () => {
       const existingRoomId = await resetDatabase()

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -170,6 +170,18 @@ interface FakeFounderPayPalDisputeEvent {
     action: 'credit_dispute_seller_favour' | 'credit_dispute_buyer_favour'
   }>
 }
+interface FakePaidCompletionFailure {
+  message: string
+  code?: string
+  constraint?: string
+}
+const paidCompletionError = (failure: FakePaidCompletionFailure) => Object.assign(
+  new Error(failure.message),
+  {
+    ...(failure.code ? { code: failure.code } : {}),
+    ...(failure.constraint ? { constraint: failure.constraint } : {}),
+  },
+)
 type LawRecipe = Record<string, unknown>
 interface FakeState {
   scenario: string
@@ -236,6 +248,9 @@ interface FakeState {
   facilitatorSettle: boolean
   flagSlotsUsed: Record<string, number>
   failPaidWriteOnce: boolean
+  failCreditReturnOnce: boolean
+  failFounderReviewOnce: boolean
+  paidCompletionFailure: FakePaidCompletionFailure | null
   interruptTreasuryCompletionOnce: boolean
   treasuryCompletionHeader?: string
   placeDescription: string
@@ -322,6 +337,9 @@ const initialState = (): FakeState => ({
   facilitatorSettle: false,
   flagSlotsUsed: {},
   failPaidWriteOnce: false,
+  failCreditReturnOnce: false,
+  failFounderReviewOnce: false,
+  paidCompletionFailure: null,
   interruptTreasuryCompletionOnce: false,
   placeDescription: 'a place made from words',
   roomPurpose: '',
@@ -1086,6 +1104,10 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     }]
   }
   if (q.includes('/* city-credit:return-spend */')) {
+    if (state.failCreditReturnOnce) {
+      state = { ...state, failCreditReturnOnce: false }
+      throw new Error('connection interrupted while returning city fee credit')
+    }
     const actorId = Number(params[0])
     const attemptId = String(params[1])
     const leaseOwner = String(params[2])
@@ -1467,6 +1489,13 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     return [{ ...updated }]
   }
   if (q.includes('/* payment-attempts:founder-review */')) {
+    if (state.failFounderReviewOnce) {
+      state = { ...state, failFounderReviewOnce: false }
+      throw paidCompletionError({
+        code: '57P01',
+        message: 'connection interrupted while recording founder review',
+      })
+    }
     const key = String(params[0])
     const current = state.paymentAttempts.get(key)
     if (
@@ -1739,6 +1768,11 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
         attempt_id: attemptId,
         reason: 'stored treasury request is invalid or its target changed',
       }]
+    }
+    if (state.paidCompletionFailure) {
+      const failure = state.paidCompletionFailure
+      state = { ...state, paidCompletionFailure: null }
+      throw paidCompletionError(failure)
     }
 
     let responseStatus: 200 | 201
@@ -2654,6 +2688,11 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
       state = { ...state, failPaidWriteOnce: false }
       return []
     }
+    if (state.paidCompletionFailure && /complete_city_credit_attempt/iu.test(q)) {
+      const failure = state.paidCompletionFailure
+      state = { ...state, paidCompletionFailure: null }
+      throw paidCompletionError(failure)
+    }
     const returned = placeRow(3, 2)
     const creditAttemptId = String(params.find(value =>
       typeof value === 'string' && value.startsWith('credit_attempt_')) ?? '')
@@ -2740,6 +2779,11 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
     if (state.failPaidWriteOnce) {
       state = { ...state, failPaidWriteOnce: false }
       return []
+    }
+    if (state.paidCompletionFailure && /complete_city_credit_attempt/iu.test(q)) {
+      const failure = state.paidCompletionFailure
+      state = { ...state, paidCompletionFailure: null }
+      throw paidCompletionError(failure)
     }
     const returned = { ...kindRow(), revision: state.kindRevision + 1 }
     const creditAttemptId = String(params.find(value =>
@@ -6423,6 +6467,7 @@ test('/api/city-credit/preflight privately shows exact cost and balance without 
 const CITY_CREDIT_ROUTE_CASES = [
   {
     label: 'frontier',
+    operation: 'frontier',
     path: '/api/place',
     status: 201,
     requestId: 'wave4-frontier-0001',
@@ -6430,9 +6475,11 @@ const CITY_CREDIT_ROUTE_CASES = [
     invalidBody: { parent_id: null, name: '', description: 'invalid before debit' },
     resultKey: 'place',
     failureReason: 'frontier target changed before completion',
+    temporaryFailure: 'frontier founding failed before completion',
   },
   {
     label: 'kind invention',
+    operation: 'kind_invention',
     path: '/api/kind',
     status: 201,
     requestId: 'wave4-kind-0000001',
@@ -6443,9 +6490,11 @@ const CITY_CREDIT_ROUTE_CASES = [
     },
     resultKey: 'kind',
     failureReason: 'kind invention target changed before completion',
+    temporaryFailure: 'kind invention failed before completion',
   },
   {
     label: 'kind revision',
+    operation: 'kind_revision',
     path: '/api/kind/3/revise',
     status: 200,
     requestId: 'wave4-revision-001',
@@ -6455,6 +6504,7 @@ const CITY_CREDIT_ROUTE_CASES = [
     },
     resultKey: 'kind',
     failureReason: 'kind revision target changed before completion',
+    temporaryFailure: 'kind revision failed before completion',
   },
 ] as const
 
@@ -6672,6 +6722,261 @@ test('every post-debit city-credit fee failure appends one exact return and repl
     assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'return').length, 1, creditCase.label)
     assert.equal(cityCreditDomainWriteCount(), 1, `${creditCase.label}: replay repeated the failed domain write`)
     assert.equal(networkCalled('/settle'), false, creditCase.label)
+  }
+})
+
+test('every post-debit paid database failure is logged before its honest temporary refusal', async () => {
+  for (const creditCase of CITY_CREDIT_ROUTE_CASES) {
+    reset({
+      scenario: 'paid claims',
+      cityCreditBalances: new Map([[7, 1_000_000n]]),
+      paidCompletionFailure: {
+        code: '42883',
+        constraint: 'payment_attempts_completion_body_check',
+        message: 'operator does not exist at postgresql://resident-secret@fake-host.example/city with Bearer private-token and 1f3d9_sk_private-key',
+      },
+    })
+    const logged: unknown[][] = []
+    const originalConsoleError = console.error
+    console.error = (...values: unknown[]) => logged.push(values)
+    try {
+      const response = await app.request(creditCase.path, {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'X-1F3D9-FEE-CREDIT': `${creditCase.requestId}-database-failure`,
+        },
+        body: JSON.stringify(creditCase.body),
+      })
+      assert.equal(response.status, 503, `${creditCase.label}: ${await response.clone().text()}`)
+      assertCityCreditNoStore(response, `${creditCase.label} database failure`)
+      assert.deepEqual(await response.json(), {
+        error: `${creditCase.temporaryFailure}; city fee credit returned`,
+        city_fee_credit: 'credit_returned',
+        returned_usdc: '1.000000',
+      }, creditCase.label)
+      assert.equal(state.cityCreditBalances.get(7), 1_000_000n, creditCase.label)
+      assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'spend').length, 1, creditCase.label)
+      assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'return').length, 1, creditCase.label)
+      assert.equal(logged.length, 1, creditCase.label)
+      assert.equal(logged[0]?.[0], 'treasury_completion_failure', creditCase.label)
+      const diagnostic = JSON.parse(String(logged[0]?.[1] ?? '{}')) as Record<string, unknown>
+      assert.equal(diagnostic.operation, creditCase.operation, creditCase.label)
+      assert.equal(diagnostic.rail, 'credit', creditCase.label)
+      assert.equal(diagnostic.error_code, '42883', creditCase.label)
+      assert.equal(diagnostic.constraint, 'payment_attempts_completion_body_check', creditCase.label)
+      assert.equal(diagnostic.status, 503, creditCase.label)
+      assert.match(typeof diagnostic.attempt_id === 'string' ? diagnostic.attempt_id : '', /^credit_attempt_[0-9a-f]+$/, creditCase.label)
+      assert.doesNotMatch(JSON.stringify(diagnostic), /fake-host\.example|private-token|1f3d9_sk_/iu, creditCase.label)
+    } finally {
+      console.error = originalConsoleError
+    }
+  }
+})
+
+test('a paid kind check violation stays a temporary city fault instead of blaming the caller', async () => {
+  reset({
+    scenario: 'paid claims',
+    cityCreditBalances: new Map([[7, 1_000_000n]]),
+    paidCompletionFailure: {
+      code: '23514',
+      constraint: 'payment_attempts_completion_body_check',
+      message: 'stored completion response violates an internal payment invariant',
+    },
+  })
+  const logged: unknown[][] = []
+  const originalConsoleError = console.error
+  console.error = (...values: unknown[]) => logged.push(values)
+  try {
+    const response = await app.request('/api/kind', {
+      method: 'POST',
+      headers: {
+        ...authHeaders(),
+        'X-1F3D9-FEE-CREDIT': 'wave4-kind-check-violation',
+      },
+      body: JSON.stringify({
+        name: 'check-violation-kind',
+        description: 'the database invariant belongs to the city',
+        traits: [],
+        recipe: [],
+      }),
+    })
+    assert.equal(response.status, 503, await response.clone().text())
+    assert.deepEqual(await response.json(), {
+      error: 'kind invention failed before completion; city fee credit returned',
+      city_fee_credit: 'credit_returned',
+      returned_usdc: '1.000000',
+    })
+    assert.equal(state.cityCreditBalances.get(7), 1_000_000n)
+    assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'spend').length, 1)
+    assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'return').length, 1)
+    assert.equal(logged.length, 1)
+    const diagnostic = JSON.parse(String(logged[0]?.[1] ?? '{}')) as Record<string, unknown>
+    assert.equal(diagnostic.error_code, '23514')
+    assert.equal(diagnostic.constraint, 'payment_attempts_completion_body_check')
+    assert.equal(diagnostic.status, 503)
+  } finally {
+    console.error = originalConsoleError
+  }
+})
+
+test('an ambiguous credit return logs the client-visible 202 rather than the intended refusal', async () => {
+  reset({
+    scenario: 'paid claims',
+    cityCreditBalances: new Map([[7, 1_000_000n]]),
+    failCreditReturnOnce: true,
+    paidCompletionFailure: {
+      code: '42883',
+      message: 'operator does not exist after the paid kind debit',
+    },
+  })
+  const logged: unknown[][] = []
+  const originalConsoleError = console.error
+  console.error = (...values: unknown[]) => logged.push(values)
+  try {
+    const response = await app.request('/api/kind', {
+      method: 'POST',
+      headers: {
+        ...authHeaders(),
+        'X-1F3D9-FEE-CREDIT': 'wave4-kind-return-ambiguous',
+      },
+      body: JSON.stringify({
+        name: 'ambiguous-return-kind',
+        description: 'the return response is interrupted',
+        traits: [],
+        recipe: [],
+      }),
+    })
+    assert.equal(response.status, 202, await response.clone().text())
+    assertCityCreditNoStore(response, 'ambiguous credit return')
+    const body = await response.json() as Record<string, unknown>
+    assert.equal(body.city_fee_credit, 'payment_pending')
+    assert.match(String(body.credit_attempt_id ?? ''), /^credit_attempt_[0-9a-f]+$/u)
+    assert.equal(state.cityCreditBalances.get(7), 0n)
+    assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'spend').length, 1)
+    assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'return').length, 0)
+    assert.equal(logged.length, 1)
+    const diagnostic = JSON.parse(String(logged[0]?.[1] ?? '{}')) as Record<string, unknown>
+    assert.equal(diagnostic.event, 'treasury_completion_failure')
+    assert.equal(diagnostic.error_code, '42883')
+    assert.equal(diagnostic.status, 202)
+  } finally {
+    console.error = originalConsoleError
+  }
+})
+
+test('an unexpected x402 completion failure is logged once by the global request boundary', async () => {
+  reset({
+    scenario: 'paid claims',
+    facilitatorVerify: true,
+    facilitatorSettle: true,
+    chainFrom: SELLER_WALLET,
+    chainTo: TREASURY,
+    interruptTreasuryCompletionOnce: true,
+  })
+  const logged: unknown[][] = []
+  const originalConsoleError = console.error
+  console.error = (...values: unknown[]) => logged.push(values)
+  try {
+    const response = await app.request('/api/place', {
+      method: 'POST',
+      headers: { ...authHeaders(), 'X-PAYMENT': X_PAYMENT },
+      body: JSON.stringify({
+        parent_id: null,
+        name: 'Single Log Continent',
+        description: 'one unexpected failure, one diagnostic',
+      }),
+    })
+    assert.equal(response.status, 500, await response.clone().text())
+    assert.equal(logged.filter(values => values[0] === 'treasury_completion_failure').length, 0)
+    const requestFailures = logged.filter(values => values[0] === 'request_failure')
+    assert.equal(requestFailures.length, 1)
+    const diagnostic = JSON.parse(String(requestFailures[0]?.[1] ?? '{}')) as Record<string, unknown>
+    assert.equal(diagnostic.error_code, '57P01')
+    assert.equal(diagnostic.status, 500)
+  } finally {
+    console.error = originalConsoleError
+  }
+})
+
+test('an x402 conflict is not logged as 409 before founder review is durably recorded', async () => {
+  reset({
+    scenario: 'paid claims',
+    facilitatorVerify: true,
+    facilitatorSettle: true,
+    chainFrom: SELLER_WALLET,
+    chainTo: TREASURY,
+    failFounderReviewOnce: true,
+    paidCompletionFailure: {
+      code: '23505',
+      constraint: 'places_parent_id_lower_name_key',
+      message: 'duplicate place name after settlement',
+    },
+  })
+  const logged: unknown[][] = []
+  const originalConsoleError = console.error
+  console.error = (...values: unknown[]) => logged.push(values)
+  try {
+    const response = await app.request('/api/place', {
+      method: 'POST',
+      headers: { ...authHeaders(), 'X-PAYMENT': X_PAYMENT },
+      body: JSON.stringify({
+        parent_id: null,
+        name: 'Founder Review Interrupted',
+        description: 'the conflict cannot be reported until review is durable',
+      }),
+    })
+    assert.equal(response.status, 500, await response.clone().text())
+    assert.equal(logged.filter(values => values[0] === 'treasury_completion_failure').length, 0)
+    const requestFailures = logged.filter(values => values[0] === 'request_failure')
+    assert.equal(requestFailures.length, 1)
+    const diagnostic = JSON.parse(String(requestFailures[0]?.[1] ?? '{}')) as Record<string, unknown>
+    assert.equal(diagnostic.error_code, '57P01')
+    assert.equal(diagnostic.status, 500)
+  } finally {
+    console.error = originalConsoleError
+  }
+})
+
+test('every x402 conflict is logged once after founder review is durably recorded', async () => {
+  for (const paidCase of CITY_CREDIT_ROUTE_CASES) {
+    reset({
+      scenario: 'paid claims',
+      facilitatorVerify: true,
+      facilitatorSettle: true,
+      chainFrom: SELLER_WALLET,
+      chainTo: TREASURY,
+      paidCompletionFailure: {
+        code: '23505',
+        constraint: 'paid_completion_unique_key',
+        message: 'paid completion conflict after settlement',
+      },
+    })
+    const logged: unknown[][] = []
+    const originalConsoleError = console.error
+    console.error = (...values: unknown[]) => logged.push(values)
+    try {
+      const response = await app.request(paidCase.path, {
+        method: 'POST',
+        headers: { ...authHeaders(), 'X-PAYMENT': X_PAYMENT },
+        body: JSON.stringify(paidCase.body),
+      })
+      assert.equal(response.status, 409, `${paidCase.label}: ${await response.clone().text()}`)
+      const body = await response.json() as Record<string, unknown>
+      assert.equal(body.payment, 'founder_review', paidCase.label)
+      const attempt = state.paymentAttempts.get(String(body.payment_attempt_id ?? ''))
+      assert.equal(attempt?.status, 'founder_review', paidCase.label)
+      assert.equal(logged.filter(values => values[0] === 'request_failure').length, 0, paidCase.label)
+      const completionFailures = logged.filter(values => values[0] === 'treasury_completion_failure')
+      assert.equal(completionFailures.length, 1, paidCase.label)
+      const diagnostic = JSON.parse(String(completionFailures[0]?.[1] ?? '{}')) as Record<string, unknown>
+      assert.equal(diagnostic.operation, paidCase.operation, paidCase.label)
+      assert.equal(diagnostic.rail, 'x402', paidCase.label)
+      assert.equal(diagnostic.error_code, '23505', paidCase.label)
+      assert.equal(diagnostic.status, 409, paidCase.label)
+    } finally {
+      console.error = originalConsoleError
+    }
   }
 })
 


### PR DESCRIPTION
## What changed

- Records paid frontier, kind invention, and kind revision completion failures before their public error response is returned.
- Captures safe PostgreSQL details such as SQLSTATE and constraint while redacting database URLs, bearer tokens, and resident secrets.
- Preserves the existing public responses and credit/x402 accounting behavior.
- Adds real PostgreSQL coverage for 12 immediate paid kind completions through both the completion helper and the actual HTTP route.

## Why

The paid completion catch paths converted database failures into generic responses without leaving the SQLSTATE in server logs. That made production-only failures impossible to diagnose. The rapid-request route proof also checks the reported burst case without adding an artificial delay.

A completion-side 23514 remains a 503: the reachable checks here protect server-built response-body and payment invariants, not caller input. Caller payloads are already validated before payment completion.

## Verification

- npm run typecheck
- npm test — 1,387 passing
- npm run test:postgres — 201 passing
- npm run test:coverage — 91.01% statements, 81.25% branches
- npm audit --audit-level=high — 0 vulnerabilities

No migration or environment change. No paid production action was performed; a live post-deploy paid probe is still required before calling the production fix fully verified.

## Release gate

- `npm run test:e2e` — 104 passing
- Exact clean pushed-commit release gate at `7c710dc` — `GATE_EXIT=0`
- GitHub CI, Socket checks, and Vercel preview — passing
- Final gate used verified-free `E2E_PORT=41837` because another approved task owned the default local test port; the test configuration and application code were unchanged.

A prior gate attempt hit one existing wall-clock timing assertion; its focused rerun passed. A later attempt passed unit and PostgreSQL coverage but stopped before browser tests because the default local port was occupied. The final complete run passed in one process.