### PR TITLE
fix: harden payment reliability follow-ups

### DIFF
--- a/src/paypal-credit-routes.ts
+++ b/src/paypal-credit-routes.ts
@@ -14,6 +14,7 @@ import {
 import {
   capturePayPalCreditOrder, createPayPalCreditOrder, createWeeklyAllowancePlan,
   createWeeklyAllowanceProduct, createWeeklyAllowanceSubscription,
+  PayPalWebhookSignatureError,
   paypalHostedApprovalUrl, paypalReadiness,
   type PayPalEnvironment,
 } from './paypal-credit.ts'
@@ -407,6 +408,9 @@ function responseFailure(
         : error.message,
       ...error.details,
     }, error.status)
+  }
+  if (error instanceof PayPalWebhookSignatureError) {
+    return c.json({ error: 'PayPal webhook signature was not verified.' }, 401)
   }
   if (error instanceof PayPalCreditStoreConflictError || error instanceof PrepaidCreditConflictError) {
     if (operation === 'webhook') {

--- a/src/runtime-logs.ts
+++ b/src/runtime-logs.ts
@@ -1,6 +1,7 @@
 const INSERT_BATCH_LIMIT = 500
 const RETENTION_PAGE_LIMIT = 1_000
 const RETENTION_DAYS_MS = 30 * 24 * 60 * 60 * 1_000
+const RETENTION_STATEMENT_TIMEOUT_MS = 15_000
 
 export interface RuntimeLogDatabase {
   query(
@@ -83,7 +84,9 @@ export async function runRuntimeLogRetention(
 
   const cutoff = new Date(now.getTime() - RETENTION_DAYS_MS)
   const rows = await database.query(`
-    WITH requested AS (
+    WITH timeout_guard AS (
+      SELECT set_config('statement_timeout', '${RETENTION_STATEMENT_TIMEOUT_MS}', true) AS applied
+    ), requested AS (
       SELECT (
         date_trunc('hour', $1::timestamptz AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
       ) AS retention_hour
@@ -98,7 +101,8 @@ export async function runRuntimeLogRetention(
     ), expired AS MATERIALIZED (
       SELECT log.id
       FROM runtime_logs AS log
-      WHERE EXISTS (SELECT 1 FROM claimed)
+      WHERE EXISTS (SELECT 1 FROM timeout_guard)
+        AND EXISTS (SELECT 1 FROM claimed)
         AND log.received_at < $2::timestamptz
       ORDER BY log.received_at, log.id
       LIMIT $3

--- a/src/world-support.ts
+++ b/src/world-support.ts
@@ -3,6 +3,7 @@ import {
   auth,
   err,
   postgresErrorCode,
+  postgresErrorConstraint,
   postgresErrorMessage,
   type Resident,
 } from './core.ts'
@@ -153,6 +154,44 @@ export function openOffer(row: { has_open_offer?: unknown }): boolean {
 
 export function conflictMessage(error: unknown, fallback: string): string | null {
   return postgresErrorCode(error) === '23505' ? fallback : null
+}
+
+function treasuryFailureMessage(error: unknown): string | null {
+  const detail = error instanceof Error
+    ? `${error.name}: ${error.message}`
+    : postgresErrorMessage(error) ?? null
+  return detail
+    ?.replace(/postgres(?:ql)?:\/\/[^\s"']+/giu, '[redacted database URL]')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/giu, 'Bearer [redacted]')
+    .replace(/1f3d9_sk_[A-Za-z0-9_-]+/giu, '[redacted resident key]')
+    .slice(0, 240) ?? null
+}
+
+export function logSwallowedTreasuryCompletionFailure(input: {
+  operation: 'frontier' | 'kind_invention' | 'kind_revision'
+  rail: 'credit' | 'x402'
+  attemptId: string
+  actorId: number
+  error: unknown
+}): void {
+  const errorName = input.error instanceof Error
+    && /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/u.test(input.error.name)
+    ? input.error.name
+    : 'Error'
+  const errorCode = postgresErrorCode(input.error)
+  const constraint = postgresErrorConstraint(input.error)
+  const message = treasuryFailureMessage(input.error)
+  console.error('treasury_completion_failure', JSON.stringify({
+    event: 'treasury_completion_failure',
+    operation: input.operation,
+    rail: input.rail,
+    attempt_id: input.attemptId,
+    actor_id: input.actorId,
+    error_name: errorName,
+    ...(errorCode && /^[0-9A-Z]{5}$/u.test(errorCode) ? { error_code: errorCode } : {}),
+    ...(constraint && /^[A-Za-z0-9_]{1,128}$/u.test(constraint) ? { constraint } : {}),
+    ...(message ? { message } : {}),
+  }))
 }
 
 // link_kind_revision_traits raises 23503 with a message the caller can act on.

--- a/src/world.ts
+++ b/src/world.ts
@@ -31,6 +31,7 @@ import {
   hasOnly,
   isResponse,
   jsonBody,
+  logSwallowedTreasuryCompletionFailure,
   openOffer,
   reconcileTreasuryCompletionNoEffect,
   returnFailedTreasuryFee,
@@ -575,6 +576,15 @@ export function mountWorldRoutes(app: Hono): void {
       )
     } catch (error) {
       const message = conflictMessage(error, 'place name or payment proof already used')
+      if (fee.rail === 'credit' || message) {
+        logSwallowedTreasuryCompletionFailure({
+          operation: 'frontier',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          actorId: resident.id,
+          error,
+        })
+      }
       if (fee.rail === 'credit') {
         return await returnFailedTreasuryFee(
           fee,
@@ -891,6 +901,15 @@ export function mountWorldRoutes(app: Hono): void {
     } catch (error) {
       const unknownTrait = unknownTraitMessage(error)
       const message = conflictMessage(error, 'kind name or payment proof already used')
+      if (fee.rail === 'credit' || unknownTrait || message) {
+        logSwallowedTreasuryCompletionFailure({
+          operation: 'kind_invention',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          actorId: resident.id,
+          error,
+        })
+      }
       if (fee.rail === 'credit') {
         return await returnFailedTreasuryFee(
           fee,
@@ -995,6 +1014,15 @@ export function mountWorldRoutes(app: Hono): void {
     } catch (error) {
       const unknownTrait = unknownTraitMessage(error)
       const message = conflictMessage(error, 'payment proof already used')
+      if (fee.rail === 'credit' || unknownTrait || message) {
+        logSwallowedTreasuryCompletionFailure({
+          operation: 'kind_revision',
+          rail: fee.rail,
+          attemptId: fee.attemptId,
+          actorId: resident.id,
+          error,
+        })
+      }
       if (fee.rail === 'credit') {
         return await returnFailedTreasuryFee(
           fee,

--- a/test/integration/payment-treasury-operations-postgres.test.ts
+++ b/test/integration/payment-treasury-operations-postgres.test.ts
@@ -96,6 +96,22 @@ async function issueThreeCredits(db: CityCreditDatabase): Promise<void> {
   }
 }
 
+async function issueCredits(
+  db: CityCreditDatabase,
+  count: number,
+  prefix: string,
+): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    const result = await issueCityFeeCredit(db, {
+      founderId: 1,
+      residentId: 2,
+      sourceKey: `${prefix}-${index}`,
+      reason: `fund PostgreSQL completion proof ${index}`,
+    })
+    assert.equal(result.disposition, 'created')
+  }
+}
+
 test('shared treasury completion executes every paid credit operation in real PostgreSQL', {
   timeout: 120_000,
 }, async () => {
@@ -220,6 +236,74 @@ test('shared treasury completion executes every paid credit operation in real Po
       balance_units: '0',
       frontier_places: 1,
       kind_revision: 2,
+    }])
+  } finally {
+    await postgres.client.end().catch(() => undefined)
+    spawnSync('docker', ['stop', '--time', '0', postgres.containerName], { encoding: 'utf8' })
+  }
+})
+
+test('shared treasury completion survives twelve immediate paid kind inventions in real PostgreSQL', {
+  timeout: 120_000,
+}, async () => {
+  const postgres = await startPostgres()
+  try {
+    await resetFresh(postgres.client)
+    const db = database(postgres.client)
+    await issueCredits(db, 12, 'treasury-burst-kind-credit')
+
+    for (let index = 0; index < 12; index += 1) {
+      const request = {
+        name: `treasury-burst-kind-${index.toString().padStart(2, '0')}`,
+        description: `Burst completion proof ${index}.`,
+        traits: [],
+        recipe: [],
+      }
+      const spend = await beginCityCreditSpend(db, {
+        actorId: 2,
+        operation: 'kind_invention',
+        targetKey: `kind-invention:${request.name}`,
+        request,
+        requestId: `treasury-burst-kind-request-${index.toString().padStart(2, '0')}`,
+      })
+      assert.equal(spend.state, 'ready')
+      if (spend.state !== 'ready') assert.fail(`kind invention ${index} did not acquire its lease`)
+      const completion = await completeTreasuryPaymentOperation(db, {
+        attemptId: spend.attempt_id,
+        leaseOwner: spend.lease_owner,
+      })
+      assert.equal(completion.state, 'completed')
+      if (completion.state !== 'completed') assert.fail(`kind invention ${index} did not complete`)
+      assert.equal(completion.operation, 'kind_invention')
+      assert.equal(completion.method, 'credit')
+      assert.equal(completion.status, 201)
+    }
+
+    const finalState = await postgres.client.query<{
+      completed_attempts: number
+      spend_entries: number
+      return_entries: number
+      kind_count: number
+      balance_units: string
+    }>(`
+      SELECT
+        (SELECT count(*)::int FROM payment_attempts WHERE actor_id = 2 AND status = 'completed')
+          AS completed_attempts,
+        (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'spend')
+          AS spend_entries,
+        (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'return')
+          AS return_entries,
+        (SELECT count(*)::int FROM kinds WHERE owner_id = 2 AND name LIKE 'treasury-burst-kind-%')
+          AS kind_count,
+        (SELECT balance_units::text FROM city_credit_accounts WHERE resident_id = 2)
+          AS balance_units
+    `)
+    assert.deepEqual(finalState.rows, [{
+      completed_attempts: 12,
+      spend_entries: 12,
+      return_entries: 0,
+      kind_count: 12,
+      balance_units: '0',
     }])
   } finally {
     await postgres.client.end().catch(() => undefined)

--- a/test/integration/world-postgres.test.ts
+++ b/test/integration/world-postgres.test.ts
@@ -38,6 +38,10 @@ const sql = (async (
   }
   return result.rows as Record<string, unknown>[]
 }) as unknown as IntegrationSql
+sql.query = async (text, values = []) => {
+  assert.ok(database, 'the PostgreSQL test client must be connected')
+  return (await database.query(text, [...values])).rows as Record<string, unknown>[]
+}
 
 function transactionSql(client: PoolClient): TaggedSql {
   const tagged = (async (
@@ -289,12 +293,18 @@ test('world mutations plan and commit atomically in PostgreSQL', async t => {
     })
 
     const { Hono } = await import('hono')
+    const { issueCityFeeCredit } = await import('../../src/city-credit.ts')
     const { setEngineTransactionRunnerForTests } = await import('../../src/engine.ts')
     const { mountSocietyRoutes } = await import('../../src/society.ts')
     const { mountWorldRoutes } = await import('../../src/world.ts')
     const app = new Hono()
     mountSocietyRoutes(app)
     mountWorldRoutes(app)
+    const cityCreditDatabase = {
+      query: async (text: string, params: readonly unknown[] | unknown[] = []) => (
+        await database!.query(text, [...params])
+      ).rows as Record<string, unknown>[],
+    }
 
     await t.test('the reported parent and child both accept make through the public route', async () => {
       const existingRoomId = await resetDatabase()
@@ -399,6 +409,145 @@ test('world mutations plan and commit atomically in PostgreSQL', async t => {
         { action_place_id: 112, thing_place_id: 112, event_place_id: '112', status: 'applied' },
         { action_place_id: 173, thing_place_id: 173, event_place_id: '173', status: 'applied' },
       ])
+    })
+
+    await t.test('twelve immediate paid kind inventions complete through the public route in real PostgreSQL', async () => {
+      await resetDatabase()
+      for (let index = 0; index < 12; index += 1) {
+        const issued = await issueCityFeeCredit(cityCreditDatabase, {
+          founderId: 1,
+          residentId: 2,
+          sourceKey: `route-kind-burst-credit-${index.toString().padStart(2, '0')}`,
+          reason: `fund immediate route kind invention ${index}`,
+        })
+        assert.equal(issued.disposition, 'created')
+      }
+
+      const responses = []
+      for (let index = 0; index < 12; index += 1) {
+        responses.push(await app.request('/api/kind', {
+          method: 'POST',
+          headers: {
+            ...bearer(neighborSecret),
+            'content-type': 'application/json',
+            'X-1F3D9-FEE-CREDIT': `route-kind-burst-request-${index.toString().padStart(2, '0')}`,
+          },
+          body: JSON.stringify({
+            name: `route-kind-burst-${index.toString().padStart(2, '0')}`,
+            description: `Immediate route kind invention ${index}.`,
+            traits: [],
+            recipe: [],
+          }),
+        }))
+      }
+
+      for (const [index, response] of responses.entries()) {
+        assert.equal(response.status, 201, `request ${index}: ${await response.clone().text()}`)
+        const body = await response.json() as {
+          kind: { owner_id: number; name: string }
+          city_fee_credit: { spent_usdc: string }
+        }
+        assert.equal(body.kind.owner_id, 2)
+        assert.equal(body.kind.name, `route-kind-burst-${index.toString().padStart(2, '0')}`)
+        assert.equal(body.city_fee_credit.spent_usdc, '1.000000')
+      }
+
+      const finalState = await database!.query<{
+        completed_attempts: number
+        spend_entries: number
+        return_entries: number
+        kind_count: number
+        balance_units: string
+      }>(`
+        SELECT
+          (SELECT count(*)::int FROM payment_attempts WHERE actor_id = 2 AND status = 'completed')
+            AS completed_attempts,
+          (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'spend')
+            AS spend_entries,
+          (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'return')
+            AS return_entries,
+          (SELECT count(*)::int FROM kinds WHERE owner_id = 2 AND name LIKE 'route-kind-burst-%')
+            AS kind_count,
+          (SELECT balance_units::text FROM city_credit_accounts WHERE resident_id = 2)
+            AS balance_units
+      `)
+      assert.deepEqual(finalState.rows, [{
+        completed_attempts: 12,
+        spend_entries: 12,
+        return_entries: 0,
+        kind_count: 12,
+        balance_units: '0',
+      }])
+    })
+
+    await t.test('twelve concurrent paid kind inventions complete through the public route in real PostgreSQL', async () => {
+      await resetDatabase()
+      for (let index = 0; index < 12; index += 1) {
+        const issued = await issueCityFeeCredit(cityCreditDatabase, {
+          founderId: 1,
+          residentId: 2,
+          sourceKey: `route-kind-concurrent-credit-${index.toString().padStart(2, '0')}`,
+          reason: `fund concurrent route kind invention ${index}`,
+        })
+        assert.equal(issued.disposition, 'created')
+      }
+
+      const responses = await Promise.all(
+        Array.from({ length: 12 }, async (_, index) => (
+          await app.request('/api/kind', {
+            method: 'POST',
+            headers: {
+              ...bearer(neighborSecret),
+              'content-type': 'application/json',
+              'X-1F3D9-FEE-CREDIT': `route-kind-concurrent-request-${index.toString().padStart(2, '0')}`,
+            },
+            body: JSON.stringify({
+              name: `route-kind-concurrent-${index.toString().padStart(2, '0')}`,
+              description: `Concurrent route kind invention ${index}.`,
+              traits: [],
+              recipe: [],
+            }),
+          })
+        )),
+      )
+
+      for (const [index, response] of responses.entries()) {
+        assert.equal(response.status, 201, `request ${index}: ${await response.clone().text()}`)
+        const body = await response.json() as {
+          kind: { owner_id: number; name: string }
+          city_fee_credit: { spent_usdc: string }
+        }
+        assert.equal(body.kind.owner_id, 2)
+        assert.equal(body.kind.name, `route-kind-concurrent-${index.toString().padStart(2, '0')}`)
+        assert.equal(body.city_fee_credit.spent_usdc, '1.000000')
+      }
+
+      const finalState = await database!.query<{
+        completed_attempts: number
+        spend_entries: number
+        return_entries: number
+        kind_count: number
+        balance_units: string
+      }>(`
+        SELECT
+          (SELECT count(*)::int FROM payment_attempts WHERE actor_id = 2 AND status = 'completed')
+            AS completed_attempts,
+          (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'spend')
+            AS spend_entries,
+          (SELECT count(*)::int FROM city_credit_entries WHERE resident_id = 2 AND entry_kind = 'return')
+            AS return_entries,
+          (SELECT count(*)::int FROM kinds WHERE owner_id = 2 AND name LIKE 'route-kind-concurrent-%')
+            AS kind_count,
+          (SELECT balance_units::text FROM city_credit_accounts WHERE resident_id = 2)
+            AS balance_units
+      `)
+      assert.deepEqual(finalState.rows, [{
+        completed_attempts: 12,
+        spend_entries: 12,
+        return_entries: 0,
+        kind_count: 12,
+        balance_units: '0',
+      }])
     })
 
     await t.test('an existing agreement stays closed until its creator opts in', async () => {

--- a/test/paypal-credit-routes.test.ts
+++ b/test/paypal-credit-routes.test.ts
@@ -118,6 +118,30 @@ test('unusable declared lengths reject before DB or network work', async () => {
   assert.equal(paypal.calls.length, 0)
 })
 
+test('missing PayPal signature headers answer 401 before any PayPal verification call', async () => {
+  const { app, database, paypal } = configuredApp()
+  const response = await app.request('/api/city-credit/paypal/webhook', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: 'live-probe-dispute',
+      event_type: 'CUSTOMER.DISPUTE.CREATED',
+      resource: {
+        dispute_id: 'PP-D-LIVE-PROBE',
+        status: 'WAITING_FOR_SELLER_RESPONSE',
+        disputed_transactions: [{ seller_transaction_id: 'LIVE-PROBE-CAPTURE' }],
+      },
+    }),
+  })
+
+  assert.equal(response.status, 401, await response.clone().text())
+  assert.deepEqual(await response.json(), {
+    error: 'PayPal webhook signature was not verified.',
+  })
+  assert.equal(paypal.calls.length, 0)
+  assert.equal(database.calls.length, 1, 'the route still spends one bounded webhook rate slot')
+})
+
 test('headerless bodies are refused with their real causes: empty names empty, oversized names the bound', async () => {
   // Production traffic carries no Content-Length, so these two messages are
   // the only voice of the body rules a live caller can ever hear.

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -158,6 +158,11 @@ interface FakeResidentRefusalState {
   causeHash: string
   repetitionCount: number
 }
+interface FakeTreasuryCompletionFailure {
+  code: string
+  message: string
+  constraint?: string
+}
 interface FakeFounderPayPalDispute {
   dispute_id: string
   state: 'open' | 'resolved_seller' | 'resolved_against_seller' | 'resolution_review'
@@ -237,6 +242,7 @@ interface FakeState {
   flagSlotsUsed: Record<string, number>
   failPaidWriteOnce: boolean
   interruptTreasuryCompletionOnce: boolean
+  treasuryCompletionFailure: FakeTreasuryCompletionFailure | null
   treasuryCompletionHeader?: string
   placeDescription: string
   roomPurpose: string
@@ -323,6 +329,7 @@ const initialState = (): FakeState => ({
   flagSlotsUsed: {},
   failPaidWriteOnce: false,
   interruptTreasuryCompletionOnce: false,
+  treasuryCompletionFailure: null,
   placeDescription: 'a place made from words',
   roomPurpose: '',
   frontMatterThingIds: [],
@@ -1731,6 +1738,14 @@ function dbRespond(query: string, params: unknown[]): Record<string, unknown>[] 
       : new Date(attempt.recovery_deadline_at).getTime()
     if (deadline != null && deadline <= Date.now()) {
       return [{ state: 'deadline_passed', attempt_id: attemptId }]
+    }
+    if (state.treasuryCompletionFailure) {
+      const failure = state.treasuryCompletionFailure
+      state = { ...state, treasuryCompletionFailure: null }
+      throw Object.assign(new Error(failure.message), {
+        code: failure.code,
+        ...(failure.constraint ? { constraint: failure.constraint } : {}),
+      })
     }
     if (deadline == null || state.failPaidWriteOnce || !attempt.request_json) {
       if (state.failPaidWriteOnce) state = { ...state, failPaidWriteOnce: false }
@@ -6673,6 +6688,61 @@ test('every post-debit city-credit fee failure appends one exact return and repl
     assert.equal(cityCreditDomainWriteCount(), 1, `${creditCase.label}: replay repeated the failed domain write`)
     assert.equal(networkCalled('/settle'), false, creditCase.label)
   }
+})
+
+test('a paid kind invention logs its swallowed PostgreSQL failure before returning city fee credit', async t => {
+  reset({
+    scenario: 'paid claims',
+    cityCreditBalances: new Map([[7, 1_000_000n]]),
+    treasuryCompletionFailure: {
+      code: '23514',
+      message: 'city credit response body does not match its canonical response',
+      constraint: 'payment_attempts_response_shape',
+    },
+  })
+  const logged: unknown[][] = []
+  t.mock.method(console, 'error', (...values: unknown[]) => {
+    logged.push(values)
+  })
+  const response = await app.request('/api/kind', {
+    method: 'POST',
+    headers: {
+      ...authHeaders(),
+      'X-1F3D9-FEE-CREDIT': 'wave4-kind-log-0001',
+    },
+    body: JSON.stringify({
+      name: 'logged-credit-kind',
+      description: 'prove the SQLSTATE is kept',
+      traits: [],
+      recipe: [],
+    }),
+  })
+
+  assert.equal(response.status, 503, await response.clone().text())
+  assert.deepEqual(await response.json(), {
+    error: 'kind invention failed before completion; city fee credit returned',
+    city_fee_credit: 'credit_returned',
+    returned_usdc: '1.000000',
+  })
+  assert.equal(state.cityCreditBalances.get(7), 1_000_000n)
+  assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'spend').length, 1)
+  assert.equal(state.cityCreditEntries.filter(entry => entry.entry_kind === 'return').length, 1)
+  assert.equal(logged.length, 1)
+  assert.equal(logged[0]?.[0], 'treasury_completion_failure')
+  const record = JSON.parse(String(logged[0]?.[1])) as Record<string, unknown>
+  assert.deepEqual({
+    event: record.event,
+    operation: record.operation,
+    rail: record.rail,
+    error_code: record.error_code,
+    constraint: record.constraint,
+  }, {
+    event: 'treasury_completion_failure',
+    operation: 'kind_invention',
+    rail: 'credit',
+    error_code: '23514',
+    constraint: 'payment_attempts_response_shape',
+  })
 })
 
 test('concurrent duplicate city-credit fee calls make one debit and one domain effect for every action', async () => {

--- a/test/runtime-logs.test.ts
+++ b/test/runtime-logs.test.ts
@@ -69,6 +69,7 @@ test('the five-minute cron wrapper opens one small UTC retention slot per hour',
     await runRuntimeLogRetention(database, new Date('2026-03-17T12:04:59.999Z')),
     { ran: true, deleted: 3 },
   )
+  assert.match(calls[0]!.text, /set_config\(\s*'statement_timeout'\s*,\s*'15000'\s*,\s*true\s*\)/iu)
   assert.match(calls[0]!.text, /INSERT\s+INTO\s+runtime_log_retention_state/iu)
   assert.match(calls[0]!.text, /ON\s+CONFLICT\s*\(singleton\)\s+DO\s+UPDATE/iu)
   assert.match(calls[0]!.text, /received_at\s*<\s*\$2/iu)


### PR DESCRIPTION
## What this fixes
- logs swallowed treasury completion failures with redacted SQLSTATE context so paid kind/frontier/revision failures stop disappearing
- proves shared treasury completion survives twelve immediate paid kind inventions, both directly and through the public route
- bounds runtime-log retention with its own database statement timeout so the scheduled sweep cannot sit on a five-minute query budget
- answers missing PayPal webhook signature headers with an honest 401 before any verification call

## Why
- the reported paid kind burst needed real PostgreSQL proof, not another guess
- the missing logs made SQLSTATE-level diagnosis impossible on the failing paid completion path
- the metronomic five-minute database errors matched the unbounded retention sweep class
- unsigned webhook input was still being softened into the wrong caller-visible failure

## Verification
- npm run typecheck
- npm test
- npm run test:postgres
- npm audit --omit=dev
