### PR TITLE
fix: align kind drawing live probe contract

### DIFF
--- a/.github/workflows/live-probe.yml
+++ b/.github/workflows/live-probe.yml
@@ -45,10 +45,13 @@ jobs:
       - name: paid kind drawings resolve without spending
         run: |
           # llms.txt is the caller contract for why a public kind is the right
-          # read-only specimen: kind drawings live in paid kind revisions.
+          # read-only specimen: kinds carry revision-owned drawings, while
+          # invention and revision are the paid actions.
           CONTRACT=$(curl -sf --max-time 20 https://1f3d9.com/llms.txt)
-          echo "$CONTRACT" | grep -Fq "Kind drawings live in paid kind revisions." \
-            || { echo "paid kind drawing contract missing"; exit 1; }
+          echo "$CONTRACT" | grep -Fq "A kind revision publishes at most eight variants drawn and described by that exact revision owner." \
+            || { echo "kind drawing ownership contract missing"; exit 1; }
+          echo "$CONTRACT" | grep -Fq "it pays only for frontier founding, kind invention, and kind revision" \
+            || { echo "paid kind action contract missing"; exit 1; }
 
           KINDS=$(curl -sf --max-time 20 "https://1f3d9.com/api/kinds?limit=1")
           echo "$KINDS" | jq -e '.kinds | type == "array"' >/dev/null \

--- a/test/deploy-safety.test.ts
+++ b/test/deploy-safety.test.ts
@@ -30,6 +30,7 @@ const liveProbeWorkflow = readFileSync(
   new URL('../.github/workflows/live-probe.yml', import.meta.url),
   'utf8',
 )
+const llmsContract = readFileSync(new URL('../src/llms.txt', import.meta.url), 'utf8')
 const testingGuide = readFileSync(new URL('../docs/TESTING.md', import.meta.url), 'utf8')
 const workingStandard = readFileSync(new URL('../AGENTS.md', import.meta.url), 'utf8')
 const PAYMENT_RELIABILITY_STANDARD = [
@@ -253,6 +254,20 @@ test('the read-only live probe enforces the public kind drawing contract', () =>
     /- name: paid kind drawings resolve without spending[\s\S]*?(?=\r?\n      - name:)/u,
   )?.[0]
   assert.ok(probe, 'missing paid kind drawing live-probe step')
+
+  const contractAssertions = [...probe.matchAll(
+    /echo "\$CONTRACT" \| grep -Fq "([^"]+)"/gu,
+  )].map(match => match[1])
+  assert.deepEqual(contractAssertions, [
+    'A kind revision publishes at most eight variants drawn and described by that exact revision owner.',
+    'it pays only for frontier founding, kind invention, and kind revision',
+  ])
+  for (const assertion of contractAssertions) {
+    assert.ok(
+      llmsContract.includes(assertion!),
+      `live-probe contract assertion is absent from src/llms.txt: ${assertion}`,
+    )
+  }
 
   assert.match(probe, /curl -sf --max-time 20 "https:\/\/1f3d9\.com\/api\/drawing\/kind\/\$KIND_ID"/u)
   assert.doesNotMatch(probe, /(?:-X|--request)\s+(?:POST|PUT|PATCH|DELETE)/iu)


### PR DESCRIPTION
## Summary
- repair the scheduled paid-kind drawing probe by checking two real published contract statements
- fail locally if any workflow contract assertion is absent from `src/llms.txt`
- keep the production probe strictly read-only

## Root cause
The workflow searched `/llms.txt` for a sentence that had never existed, so the scheduled health check failed even though the live drawing endpoint was healthy.

## Verification
- `npm test` — 1,565 passed
- `npm run typecheck`
- `git diff --check`
- independent correctness/security review: GO