### PR TITLE
fix: keep crowded Live views responsive

### DIFF
--- a/e2e/public-window-live.spec.ts
+++ b/e2e/public-window-live.spec.ts
@@ -29,6 +29,252 @@ async function copiedLiveShareLinks(page: Page): Promise<readonly string[]> {
   ])
 }
 
+type LiveRenderWork = Readonly<{
+  renders: number
+  stageSurveys: number
+  residentLayouts: number
+  largeResidentLayouts: number
+  residentRowsVisited: number
+  residentAnchorMembershipChecks: number
+  residentAnchorMembershipRowsVisited: number
+  placeAnchorCalls: number
+  placeAnchorLookupBuilds: number
+  placeAnchorPlaceRowsVisited: number
+  placeAnchorMapRowsVisited: number
+  placeAnchorChildRowsVisited: number
+  placeAnchorResolutionSteps: number
+  replayCatchUpRecords: number
+  residentReplayPoints: number
+  moveGeometries: number
+  thingPresentations: number
+  plotBuilds: number
+  rosterRenders: number
+}>
+
+const emptyLiveRenderWork = (): LiveRenderWork => ({
+  renders: 0,
+  stageSurveys: 0,
+  residentLayouts: 0,
+  largeResidentLayouts: 0,
+  residentRowsVisited: 0,
+  residentAnchorMembershipChecks: 0,
+  residentAnchorMembershipRowsVisited: 0,
+  placeAnchorCalls: 0,
+  placeAnchorLookupBuilds: 0,
+  placeAnchorPlaceRowsVisited: 0,
+  placeAnchorMapRowsVisited: 0,
+  placeAnchorChildRowsVisited: 0,
+  placeAnchorResolutionSteps: 0,
+  replayCatchUpRecords: 0,
+  residentReplayPoints: 0,
+  moveGeometries: 0,
+  thingPresentations: 0,
+  plotBuilds: 0,
+  rosterRenders: 0,
+})
+
+async function installLiveRenderWorkRecorder(page: Page): Promise<void> {
+  await page.addInitScript(initial => {
+    Object.defineProperty(window, '__liveRenderWork', {
+      configurable: true,
+      value: { ...initial },
+    })
+    Object.defineProperty(window, '__liveReplayStarts', {
+      configurable: true,
+      value: [],
+    })
+  }, emptyLiveRenderWork())
+  await page.route('**/window.js', async route => {
+    const response = await route.fetch()
+    let body = await response.text()
+    for (const [functionName, counter] of [
+      ['renderLive', 'renders'],
+      ['liveStageSurvey', 'stageSurveys'],
+      ['liveResidentReplayPoint', 'residentReplayPoints'],
+      ['liveReplayMoveGeometry', 'moveGeometries'],
+      ['livePlaceAnchor', 'placeAnchorCalls'],
+      ['livePlacePlot', 'plotBuilds'],
+      ['renderLiveRoster', 'rosterRenders'],
+    ] as const) {
+      const pattern = new RegExp(`function ${functionName}\\([^)]*\\) \\{`, 'u')
+      const matches = body.match(new RegExp(pattern.source, 'gu')) ?? []
+      if (matches.length !== 1) {
+        throw new Error(`expected one ${functionName} function in the served Live client`)
+      }
+      body = body.replace(pattern, match => `${match}\n` +
+        `    window.__liveRenderWork.${counter} += 1`)
+    }
+    const residentLayoutStart = '    const ordered = [...residents.filter(resident => ' +
+      '!resident.asleep),\n      ...residents.filter(resident => resident.asleep)]'
+    if (body.split(residentLayoutStart).length !== 2) {
+      throw new Error('expected one resident layout build in the served Live client')
+    }
+    body = body.replace(residentLayoutStart,
+      '    window.__liveRenderWork.residentLayouts += 1\n' +
+      '    if (residents.length >= 100) window.__liveRenderWork.largeResidentLayouts += 1\n' +
+      '    window.__liveRenderWork.residentRowsVisited += residents.length\n' +
+      '    if (window.__liveResidentRowBudget > 0 &&\n' +
+      '        window.__liveRenderWork.residentRowsVisited > window.__liveResidentRowBudget &&\n' +
+      '        !window.__liveResidentRowBudgetExceededAt) {\n' +
+      '      window.__liveResidentRowBudgetExceededAt =\n' +
+      '        window.__liveRenderWork.residentRowsVisited\n' +
+      '    }\n' +
+      residentLayoutStart)
+    const legacyAnchorMembership =
+      'anchoredResidents.some(candidate => candidate.id === resident.id)'
+    const anchoredIdSetBuild =
+      'new Set(anchoredResidents.map(candidate => candidate.id))'
+    const anchoredIdSetLookup = 'anchoredResidentIds.has(resident.id)'
+    const recordMembershipRow =
+      'window.__liveRenderWork.residentAnchorMembershipRowsVisited += 1; ' +
+      'if (window.__liveResidentAnchorRowBudget > 0 && ' +
+      'window.__liveRenderWork.residentAnchorMembershipRowsVisited > ' +
+      'window.__liveResidentAnchorRowBudget && ' +
+      '!window.__liveResidentAnchorRowBudgetExceededAt) ' +
+      'window.__liveResidentAnchorRowBudgetExceededAt = ' +
+      'window.__liveRenderWork.residentAnchorMembershipRowsVisited; '
+    if (body.includes(legacyAnchorMembership)) {
+      body = body.replace(
+        legacyAnchorMembership,
+        '((window.__liveRenderWork.residentAnchorMembershipChecks += 1), ' +
+        'anchoredResidents.some(candidate => { ' + recordMembershipRow +
+        'return candidate.id === resident.id }))',
+      )
+    } else if (body.includes(anchoredIdSetBuild) && body.includes(anchoredIdSetLookup)) {
+      body = body.replace(
+        anchoredIdSetBuild,
+        'new Set(anchoredResidents.map(candidate => { ' + recordMembershipRow +
+        'return candidate.id }))',
+      )
+      body = body.replace(
+        anchoredIdSetLookup,
+        '((window.__liveRenderWork.residentAnchorMembershipChecks += 1), ' +
+        anchoredIdSetLookup + ')',
+      )
+    } else {
+      throw new Error('expected one resident anchor membership path in the served Live client')
+    }
+    const placeAnchorLookup =
+      '    const places = state.snapshot\n' +
+      '      ? livePlaceRows(state.snapshot)\n' +
+      '      : state.directory.loaded ? state.directory.places : []\n' +
+      '    const byId = new Map(places.map(place => [place.id, place]))\n' +
+      '    const childIds = new Set(children.map(place => place.id))'
+    if (body.split(placeAnchorLookup).length !== 2) {
+      throw new Error('expected one place anchor lookup build in the served Live client')
+    }
+    body = body.replace(
+      placeAnchorLookup,
+      '    window.__liveRenderWork.placeAnchorLookupBuilds += 1\n' +
+      '    const places = state.snapshot\n' +
+      '      ? livePlaceRows(state.snapshot)\n' +
+      '      : state.directory.loaded ? state.directory.places : []\n' +
+      '    window.__liveRenderWork.placeAnchorPlaceRowsVisited += places.length\n' +
+      '    const byId = new Map(places.map(place => {\n' +
+      '      window.__liveRenderWork.placeAnchorMapRowsVisited += 1\n' +
+      '      return [place.id, place]\n' +
+      '    }))\n' +
+      '    const childIds = new Set(children.map(place => {\n' +
+      '      window.__liveRenderWork.placeAnchorChildRowsVisited += 1\n' +
+      '      return place.id\n' +
+      '    }))',
+    )
+    const placeAnchorWalkPattern = /^(\s*)while \(current && !seen\.has\(current\.id\)\) \{$/gmu
+    if ((body.match(placeAnchorWalkPattern) ?? []).length !== 1) {
+      throw new Error('expected one place anchor resolution loop in the served Live client')
+    }
+    body = body.replace(placeAnchorWalkPattern, (match, indent: string) =>
+      match + '\n' + indent +
+      '  window.__liveRenderWork.placeAnchorResolutionSteps += 1')
+    const replayCatchUpBranch = '    if (!animates) {'
+    if (body.split(replayCatchUpBranch).length !== 2) {
+      throw new Error('expected one replay catch-up branch in the served Live client')
+    }
+    body = body.replace(
+      replayCatchUpBranch,
+      '    window.__liveRenderWork.replayCatchUpRecords += caughtUpAdditions.length\n' +
+      replayCatchUpBranch,
+    )
+    const replayStartPattern = /^(\s*)starts\.push\(Object\.freeze\(\{ actor, key, duration \}\)\)$/gmu
+    if ((body.match(replayStartPattern) ?? []).length !== 2) {
+      throw new Error('expected two replay start recordings in the served Live client')
+    }
+    body = body.replace(replayStartPattern, (match, indent: string) =>
+      match + '\n' +
+      indent + 'window.__liveReplayStarts.push(Object.freeze({\n' +
+      indent + '  key, actor,\n' +
+      indent + "  fromPlaceId: String(active[actor]?.fromPlaceId || ''),\n" +
+      indent + "  toPlaceId: String(active[actor]?.toPlaceId || ''),\n" +
+      indent + '}))')
+    const thingPresentationStart =
+      '    const things = liveDisplayedThings(snapshot, placeId, focusId, includeDescendants)'
+    if (body.split(thingPresentationStart).length !== 2) {
+      throw new Error('expected one thing presentation build in the served Live client')
+    }
+    body = body.replace(thingPresentationStart,
+      '    window.__liveRenderWork.thingPresentations += 1\n' + thingPresentationStart)
+    await route.fulfill({ response, body })
+  })
+}
+
+async function resetLiveRenderWork(page: Page): Promise<void> {
+  await page.evaluate(empty => {
+    Object.assign((window as Window & {
+      __liveRenderWork: Record<string, number>
+    }).__liveRenderWork, empty)
+  }, emptyLiveRenderWork())
+}
+
+async function readLiveRenderWork(page: Page): Promise<LiveRenderWork> {
+  return page.evaluate(() => ({
+    ...(window as Window & {
+      __liveRenderWork: LiveRenderWork
+    }).__liveRenderWork,
+  }))
+}
+
+type LiveChildFraming = Readonly<{
+  detailedChildren: number
+  mountedChildren: number
+  safeOpenButtons: number
+  scale: number
+}>
+
+async function readLiveChildFraming(page: Page): Promise<LiveChildFraming> {
+  return page.locator('.live-plot').evaluateAll(plots => {
+    const viewport = document.querySelector('#live-viewport') as HTMLElement | null
+    const stage = document.querySelector('#live-stage') as HTMLElement | null
+    if (!viewport || !stage) {
+      return { detailedChildren: 0, mountedChildren: 0, safeOpenButtons: 0, scale: 0 }
+    }
+    const viewportBox = viewport.getBoundingClientRect()
+    const safeInset = 16
+    const detailed = plots.filter(plot =>
+      (plot as HTMLElement).dataset.liveDetail === 'true')
+    const mounted = detailed.filter(plot =>
+      (plot as HTMLElement).dataset.liveDetailMounted === 'true' &&
+      Boolean(plot.querySelector('.live-plot-terrain')))
+    const safeOpenButtons = mounted.filter(plot => {
+      const open = plot.querySelector('.live-plot-open')
+      if (!open) return false
+      const box = open.getBoundingClientRect()
+      const centerX = box.left + box.width / 2
+      const centerY = box.top + box.height / 2
+      return box.width > 0 && box.height > 0 &&
+        centerX >= viewportBox.left + safeInset &&
+        centerX <= viewportBox.right - safeInset &&
+        centerY >= viewportBox.top + safeInset &&
+        centerY <= viewportBox.bottom - safeInset
+    })
+    return {
+      detailedChildren: detailed.length,
+      mountedChildren: mounted.length,
+      safeOpenButtons: safeOpenButtons.length,
+      scale: Number(stage.dataset.liveScale),
+    }
+  })
+}
+
 async function panLiveTargetIntoView(page: Page, target: Locator): Promise<void> {
   const viewport = page.locator('#live-viewport')
   await viewport.scrollIntoViewIfNeeded()
@@ -215,6 +461,7 @@ async function installReplayRoutes(
     movementOnly?: boolean
     drawingDelayMs?: number
     drawingPlaceCount?: number
+    drawingParentId?: number
     openingDelayMs?: number
     holdOpeningPage?: boolean
     holdOpeningRequest?: number
@@ -237,6 +484,7 @@ async function installReplayRoutes(
     focusedPlaceFailures?: number
     initialResidentPlaceId?: number
     crowdPlaceId?: number
+    residentCrowdSize?: number
   }> = {},
 ) {
   let published = false
@@ -245,6 +493,8 @@ async function installReplayRoutes(
   let openingEventRequests = 0
   let windowRequests = 0
   let changeRequests = 0
+  const changeCursors: Array<string | null> = []
+  const changeLimits: Array<string | null> = []
   let thingNamesUnavailable = Boolean(controls.thingFailure)
   const openingBeforeIds: Array<string | null> = []
   const thingWithinPlaceIds: Array<string | null> = []
@@ -273,35 +523,49 @@ async function installReplayRoutes(
       ? String(1_000 + controls.simultaneousMoves)
       : controls.secondArrival ? '17' : '16'
     : '10'
-  const controlledResidentRows = (marker: string) => [
-    ...replayResidentRows(
+  const controlledResidentRows = (marker: string) => {
+    const baseRows = replayResidentRows(
       now,
       marker === '10'
         ? controls.initialResidentPlaceId ?? (controls.openingMovement ? 3 : 2)
         : 4,
-    ).map(resident => {
+    )
+    const requestedRows = controls.residentCrowdSize === undefined
+      ? baseRows
+      : [
+          baseRows[0]!,
+          ...Array.from({ length: controls.residentCrowdSize }, (_, index) => ({
+            id: 20 + index,
+            handle: `harbor-${index + 1}`,
+            current_place_id: 3,
+            joined_at: new Date(now - 86_400_000 - index).toISOString(),
+            asleep: false,
+          })),
+        ]
+    return [
+      ...requestedRows.map(resident => {
       const placed = controls.secondArrival && resident.id === replayCrowd[0]!.id
         ? { ...resident, current_place_id: marker === '10' ? 2 : 4 }
-        : resident
-      const crowded = controls.crowdPlaceId && replayCrowd.some(candidate =>
-        candidate.id === resident.id)
+          : resident
+        const crowded = controls.crowdPlaceId && resident.id !== 5
         ? { ...placed, current_place_id: controls.crowdPlaceId }
-        : placed
-      return controls.maximumHandle && resident.id === replayCrowd[3]!.id
-        ? { ...crowded, handle: controls.maximumHandle }
-        : crowded
-    }),
-    ...Array.from({ length: controls.simultaneousMoves ?? 0 }, (_, index) => ({
-      id: 1_000 + index,
-      handle: `walker-burst-${index + 1}`,
-      current_place_id: 3,
-      joined_at: new Date(now - 172_800_000 - index).toISOString(),
-      asleep: false,
-    })),
-  ]
+          : placed
+        return controls.maximumHandle && resident.id === replayCrowd[3]!.id
+          ? { ...crowded, handle: controls.maximumHandle }
+          : crowded
+      }),
+      ...Array.from({ length: controls.simultaneousMoves ?? 0 }, (_, index) => ({
+        id: 1_000 + index,
+        handle: `walker-burst-${index + 1}`,
+        current_place_id: 3,
+        joined_at: new Date(now - 172_800_000 - index).toISOString(),
+        asleep: false,
+      })),
+    ]
+  }
   const drawingPlaces = Array.from({ length: controls.drawingPlaceCount ?? 0 }, (_, index) => ({
     id: 100 + index,
-    parent_id: 1,
+    parent_id: controls.drawingParentId ?? 1,
     name: `Drawing plot ${index + 1}`,
   }))
   const directoryPlaces = [...replayPlaces, ...drawingPlaces]
@@ -393,24 +657,31 @@ async function installReplayRoutes(
       return
     }
     const ordinarySnapshot = replaySnapshot(now, marker !== '10', marker)
+    const drawingRows = drawingPlaces.map(extra => ({
+      ...extra,
+      owner: 'drawing-owner',
+      purpose: '',
+      front_matter: [],
+      places: 0,
+      things: 0,
+      notes: 0,
+      moderated: false,
+      children: [],
+    }))
+    const appendDrawingPlaces = place => ({
+      ...place,
+      places: place.places + (place.id === (controls.drawingParentId ?? 1)
+        ? drawingPlaces.length
+        : 0),
+      children: [
+        ...place.children.map(appendDrawingPlaces),
+        ...(place.id === (controls.drawingParentId ?? 1) ? drawingRows : []),
+      ],
+    })
     const baseSnapshot = drawingPlaces.length
       ? {
           ...ordinarySnapshot,
-          places: ordinarySnapshot.places.map(place => ({
-            ...place,
-            places: place.places + drawingPlaces.length,
-            children: [...place.children, ...drawingPlaces.map(extra => ({
-              ...extra,
-              owner: 'drawing-owner',
-              purpose: '',
-              front_matter: [],
-              places: 0,
-              things: 0,
-              notes: 0,
-              moderated: false,
-              children: [],
-            }))],
-          })),
+          places: ordinarySnapshot.places.map(appendDrawingPlaces),
           totals: {
             ...ordinarySnapshot.totals,
             places: ordinarySnapshot.totals.places + drawingPlaces.length,
@@ -470,7 +741,10 @@ async function installReplayRoutes(
   })
   await page.route('**/api/changes**', async route => {
     changeRequests += 1
-    const since = new URL(route.request().url()).searchParams.get('since')
+    const url = new URL(route.request().url())
+    const since = url.searchParams.get('since')
+    changeCursors.push(since)
+    changeLimits.push(url.searchParams.get('limit'))
     if (since === null) {
       await route.fulfill({ json: { change_marker: currentMarker() } })
       return
@@ -486,19 +760,47 @@ async function installReplayRoutes(
       } })
       return
     }
+    if (since !== null && published && controls.simultaneousMoves) {
+      const publishedMarker = currentMarker()
+      const startIndex = since === '10' ? 0 : Number(since) - 1_000
+      if (Number.isSafeInteger(startIndex) && startIndex >= 0 &&
+          startIndex < controls.simultaneousMoves) {
+        const endIndex = Math.min(startIndex + 200, controls.simultaneousMoves)
+        const publishedChanges = Array.from(
+          { length: endIndex - startIndex },
+          (_, offset) => {
+            const index = startIndex + offset
+            const crossesCatchUpCutoff = controls.simultaneousMoves === 1_600 &&
+              (index === 1_399 || index === 1_400)
+            return {
+              change_id: String(1_001 + index),
+              created_at: new Date(now).toISOString(),
+              kind: 'action',
+              actor: crossesCatchUpCutoff
+                ? 'walker-burst-1401'
+                : `walker-burst-${index + 1}`,
+              detail: {
+                action: 'move', status: 'applied',
+                from_place_id: index === 1_399 ? 3 : 2,
+                to_place_id: index === 1_399 ? 2 : 3,
+              },
+            }
+          },
+        )
+        const nextSince = String(1_000 + endIndex)
+        await route.fulfill({ json: {
+          change_marker: publishedMarker,
+          unchanged: false,
+          has_more: endIndex < controls.simultaneousMoves,
+          next_since: nextSince,
+          changes: publishedChanges,
+        } })
+        return
+      }
+    }
     if (since === '10' && published) {
       const publishedMarker = currentMarker()
-      const publishedChanges = controls.simultaneousMoves
-        ? Array.from({ length: controls.simultaneousMoves }, (_, index) => ({
-            change_id: String(1_001 + index),
-            created_at: new Date(now).toISOString(),
-            kind: 'action',
-            actor: `walker-burst-${index + 1}`,
-            detail: {
-              action: 'move', status: 'applied', from_place_id: 2, to_place_id: 3,
-            },
-          }))
-        : [{
+      const publishedChanges = [{
             change_id: '11', created_at: new Date(now - (
               controls.staggeredArrivalDeadlines ? 1_792_300 : 0
             )).toISOString(), kind: 'action',
@@ -746,6 +1048,8 @@ async function installReplayRoutes(
     openingBeforeIds: () => [...openingBeforeIds],
     windowRequests: () => windowRequests,
     changeRequests: () => changeRequests,
+    changeCursors: () => [...changeCursors],
+    changeLimits: () => [...changeLimits],
     activeNoteRequests: () => activeNoteRequests,
     maximumNoteRequests: () => maximumNoteRequests,
     activeDrawingRequests: () => activeDrawingRequests,
@@ -796,6 +1100,16 @@ async function liveResidentPositions(plot: Locator) {
       }
     })
   })
+}
+
+async function liveResidentLocalPositions(plot: Locator) {
+  return plot.evaluate(node => [...node.querySelectorAll<HTMLElement>('.live-walker')]
+    .map(shell => ({
+      key: shell.querySelector<HTMLElement>('[data-live-resident-handle]')
+        ?.dataset.liveResidentHandle ?? '',
+      x: Number.parseFloat(shell.style.left),
+      y: Number.parseFloat(shell.style.top),
+    })))
 }
 
 async function liveThingPositions(plot: Locator) {
@@ -1244,6 +1558,306 @@ test('a cancelled touch does not consume the next keyboard activation', async ({
   await open.focus()
   await open.evaluate(node => (node as HTMLButtonElement).click())
   await expect(page).toHaveURL(/\/window\/live\?place=2$/u)
+})
+
+test('Live expands 167 residents with one bounded layout pass and no new public reads', async ({ page }) => {
+  await page.setViewportSize({ width: 923, height: 648 })
+  await installLiveRenderWorkRecorder(page)
+  const fixture = await installReplayRoutes(page, Date.now(), 'complete', 0, {
+    crowdPlaceId: 2,
+    initialResidentPlaceId: 3,
+    moveBurst: 24,
+    residentCrowdSize: 167,
+  })
+  const readCounts = () => ({
+    window: fixture.windowRequests(),
+    residents: fixture.residentPageRequests(),
+    events: fixture.openingEventRequests(),
+    focusedPlace: fixture.focusedPlaceRequests(),
+    things: fixture.thingPageRequests(),
+  })
+  const childExpansionWork = Object.freeze({
+    renders: 1,
+    stageSurveys: 1,
+    residentLayouts: 10,
+    largeResidentLayouts: 1,
+    residentRowsVisited: 188,
+    residentAnchorMembershipChecks: 8,
+    residentAnchorMembershipRowsVisited: 168,
+    placeAnchorCalls: 38,
+    placeAnchorLookupBuilds: 1,
+    placeAnchorPlaceRowsVisited: 4,
+    placeAnchorMapRowsVisited: 4,
+    placeAnchorChildRowsVisited: 2,
+    placeAnchorResolutionSteps: 2,
+    replayCatchUpRecords: 0,
+    residentReplayPoints: 28,
+    moveGeometries: 20,
+    thingPresentations: 3,
+    plotBuilds: 2,
+    rosterRenders: 1,
+  })
+  const focusedExpansionWork = Object.freeze({
+    renders: 1,
+    stageSurveys: 1,
+    residentLayouts: 2,
+    largeResidentLayouts: 1,
+    residentRowsVisited: 173,
+    residentAnchorMembershipChecks: 1,
+    residentAnchorMembershipRowsVisited: 167,
+    placeAnchorCalls: 31,
+    placeAnchorLookupBuilds: 1,
+    placeAnchorPlaceRowsVisited: 4,
+    placeAnchorMapRowsVisited: 4,
+    placeAnchorChildRowsVisited: 0,
+    placeAnchorResolutionSteps: 2,
+    replayCatchUpRecords: 0,
+    residentReplayPoints: 21,
+    moveGeometries: 20,
+    thingPresentations: 1,
+    plotBuilds: 0,
+    rosterRenders: 1,
+  })
+
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  await expect.poll(fixture.thingPageRequests).toBe(1)
+
+  const cinder = page.locator('.live-plot[data-place-id="2"]')
+  const childMore = cinder.getByRole('button', { name: 'Show 163 more residents' })
+  await expect(childMore).toBeVisible()
+  const childResidentsBefore = (await liveResidentLocalPositions(cinder)).map(({ key, x, y }) => ({
+    key,
+    x: Math.round(x * 100) / 100,
+    y: Math.round(y * 100) / 100,
+  }))
+  const childThingsBefore = (await liveThingPositions(cinder)).map(({ key, x, y }) => ({
+    key,
+    x: Math.round(x * 100) / 100,
+    y: Math.round(y * 100) / 100,
+  }))
+  const childPlotsBefore = await page.locator('.live-plot').evaluateAll(plots => plots.map(plot => {
+    const element = plot as HTMLElement
+    return {
+      id: element.dataset.placeId,
+      x: element.dataset.livePlotX,
+      y: element.dataset.livePlotY,
+      width: element.dataset.livePlotWidth,
+      height: element.dataset.livePlotHeight,
+    }
+  }))
+  const childStageBefore = await page.locator('#live-stage').evaluate(stage => ({
+    width: Number((stage as HTMLElement).dataset.liveStageWidth),
+    height: Number((stage as HTMLElement).dataset.liveStageHeight),
+  }))
+  const childReadsBefore = readCounts()
+  await resetLiveRenderWork(page)
+  await childMore.click()
+  const childWork = await readLiveRenderWork(page)
+  expect(childWork).toEqual(childExpansionWork)
+
+  await expect(cinder.locator('.live-walker')).toHaveCount(167)
+  await expect(cinder.locator('.live-resident-more')).toHaveCount(0)
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  const childResidentsAfter = (await liveResidentLocalPositions(cinder)).map(({ key, x, y }) => ({
+    key,
+    x: Math.round(x * 100) / 100,
+    y: Math.round(y * 100) / 100,
+  }))
+  expect(childResidentsAfter.filter(resident => childResidentsBefore.some(before =>
+    before.key === resident.key))).toEqual(childResidentsBefore)
+  expect((await liveThingPositions(cinder)).map(({ key, x, y }) => ({
+    key,
+    x: Math.round(x * 100) / 100,
+    y: Math.round(y * 100) / 100,
+  }))).toEqual(childThingsBefore)
+  expect(await page.locator('.live-plot').evaluateAll(plots => plots.map(plot => {
+    const element = plot as HTMLElement
+    return {
+      id: element.dataset.placeId,
+      x: element.dataset.livePlotX,
+      y: element.dataset.livePlotY,
+      width: element.dataset.livePlotWidth,
+      height: element.dataset.livePlotHeight,
+    }
+  }))).toEqual(childPlotsBefore)
+  const childStageAfter = await page.locator('#live-stage').evaluate(stage => ({
+    width: Number((stage as HTMLElement).dataset.liveStageWidth),
+    height: Number((stage as HTMLElement).dataset.liveStageHeight),
+  }))
+  expect(childStageAfter.width).toBe(childStageBefore.width)
+  expect(childStageAfter.height).toBeGreaterThan(childStageBefore.height)
+  await expect(cinder.locator('.live-portrait[aria-label^="Focus on "]')).toHaveCount(167)
+  await cinder.locator('[data-live-resident-handle="harbor-167"]').focus()
+  await expect(cinder.locator('[data-live-resident-handle="harbor-167"]')).toBeFocused()
+  expect(readCounts()).toEqual(childReadsBefore)
+
+  await page.goto('/window/live?place=2')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  await expect.poll(fixture.thingPageRequests).toBe(2)
+  const rootMore = page.locator('.live-root-walkers').getByRole(
+    'button', { name: 'Show 163 more residents' },
+  )
+  await expect(rootMore).toBeVisible()
+  const rootReadsBefore = readCounts()
+  await resetLiveRenderWork(page)
+  await rootMore.click()
+  const rootResidentWork = await readLiveRenderWork(page)
+  await expect(page.locator('.live-root-walkers .live-walker')).toHaveCount(167)
+  await expect(page.locator('.live-root-walkers .live-resident-more')).toHaveCount(0)
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  expect(readCounts()).toEqual(rootReadsBefore)
+  expect(rootResidentWork).toEqual(focusedExpansionWork)
+
+  const residentsBeforeThingExpansion = (await liveResidentPositions(
+    page.locator('.live-root-walkers'),
+  )).map(({ key, x, y }) => ({
+    key,
+    x: Math.round(x * 100) / 100,
+    y: Math.round(y * 100) / 100,
+  }))
+  const rootThingMore = page.locator('.live-root-thing-shelf').getByRole(
+    'button', { name: 'Show 2 more things' },
+  )
+  await panLiveTargetIntoView(page, rootThingMore)
+  const thingReadsBefore = readCounts()
+  await resetLiveRenderWork(page)
+  await rootThingMore.click()
+  const rootThingWork = await readLiveRenderWork(page)
+  await expect(page.locator('.live-root-thing-shelf .live-thing-specimen')).toHaveCount(7)
+  await expect(page.locator('.live-root-thing-shelf .live-thing-more')).toHaveCount(0)
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  expect((await liveResidentPositions(page.locator('.live-root-walkers')))
+    .map(({ key, x, y }) => ({
+      key,
+      x: Math.round(x * 100) / 100,
+      y: Math.round(y * 100) / 100,
+    }))).toEqual(residentsBeforeThingExpansion)
+  expect(readCounts()).toEqual(thingReadsBefore)
+  expect(rootThingWork).toEqual(focusedExpansionWork)
+})
+
+test('Live frames a detailed First Town child on initial load and Center', async ({ page }) => {
+  await installReplayRoutes(page, Date.now(), 'complete', 0, {
+    drawingPlaceCount: 217,
+    drawingParentId: 2,
+    residentCrowdSize: 6,
+    crowdPlaceId: 2,
+    initialResidentPlaceId: 3,
+  })
+  const results: Array<Readonly<{
+    viewport: string
+    initial: LiveChildFraming
+    centered: LiveChildFraming
+  }>> = []
+
+  for (const viewport of [
+    { name: 'desktop', width: 923, height: 648 },
+    { name: 'mobile', width: 390, height: 844 },
+  ] as const) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height })
+    await page.goto('/window/live?place=2')
+    await expect(page.locator('#live-history-status')).toContainText('history is complete')
+    await expect(page.locator('.live-plot')).toHaveCount(217)
+    await expect(page.locator('.live-root-walkers .live-walker')).toHaveCount(6)
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /fit/i })).toHaveCount(0)
+    await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() =>
+      requestAnimationFrame(() => resolve()))))
+
+    const initial = await readLiveChildFraming(page)
+    await page.getByRole('button', { name: 'Center live view' }).click()
+    const centered = await readLiveChildFraming(page)
+    results.push({ viewport: viewport.name, initial, centered })
+  }
+
+  expect(results.every(result => [result.initial, result.centered].every(frame =>
+    frame.detailedChildren >= 1 && frame.mountedChildren >= 1 &&
+    frame.safeOpenButtons >= 1 && frame.scale === 1)), JSON.stringify(results, null, 2)).toBe(true)
+})
+
+test('Live ignores a stale raised parent when framing its drilled child plate', async ({ page }) => {
+  await page.setViewportSize({ width: 923, height: 648 })
+  await installReplayRoutes(page, Date.now(), 'complete', 0, {
+    drawingPlaceCount: 217,
+    drawingParentId: 2,
+    residentCrowdSize: 6,
+    crowdPlaceId: 2,
+    initialResidentPlaceId: 3,
+  })
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const parentPlot = page.locator('.live-plot[data-place-id="2"]')
+  const parentOpen = parentPlot.locator('.live-plot-open')
+  await panLiveTargetIntoView(page, parentOpen)
+  await parentOpen.dispatchEvent('pointerdown', { pointerType: 'touch' })
+  await parentOpen.dispatchEvent('click', { pointerType: 'touch' })
+  await expect(parentPlot).toHaveAttribute('data-live-raised', 'true')
+
+  await page.getByRole('button', { name: 'Center live view' }).click()
+  await expect.poll(() => parentOpen.evaluate(open => {
+    const box = open.getBoundingClientRect()
+    const viewport = document.querySelector('#live-viewport')!.getBoundingClientRect()
+    return box.width > 0 && box.height > 0 &&
+      box.left >= viewport.left && box.right <= viewport.right &&
+      box.top >= viewport.top && box.bottom <= viewport.bottom
+  })).toBe(true)
+
+  await parentOpen.dispatchEvent('pointerdown', { pointerType: 'touch' })
+  await parentOpen.dispatchEvent('click', { pointerType: 'touch' })
+  await expect(page).toHaveURL(/\/window\/live\?place=2$/u)
+  await expect(page.locator('.live-plot')).toHaveCount(217)
+  const initial = await readLiveChildFraming(page)
+  await page.getByRole('button', { name: 'Center live view' }).click()
+  const centered = await readLiveChildFraming(page)
+  expect([initial, centered].every(frame =>
+    frame.detailedChildren >= 1 && frame.mountedChildren >= 1 &&
+    frame.safeOpenButtons >= 1 && frame.scale === 1), JSON.stringify({
+      initial,
+      centered,
+    }, null, 2)).toBe(true)
+})
+
+test('Live ignores an outside focus when framing First Town', async ({ page }) => {
+  await page.setViewportSize({ width: 923, height: 648 })
+  await installReplayRoutes(page, Date.now(), 'complete', 0, {
+    drawingPlaceCount: 217,
+    drawingParentId: 2,
+    residentCrowdSize: 6,
+    crowdPlaceId: 2,
+    initialResidentPlaceId: 3,
+  })
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const resident = page.locator('[data-live-resident-handle="map-walker"]').first()
+  await panLiveTargetIntoView(page, resident)
+  await resident.click()
+  await expect(page.locator('#live-focus-status')).toContainText('Focused on map-walker')
+  await page.getByRole('button', { name: 'Center live view' }).click()
+  await expect.poll(() => resident.evaluate(node => {
+    const box = node.getBoundingClientRect()
+    const viewport = document.querySelector('#live-viewport')!.getBoundingClientRect()
+    return box.width > 0 && box.height > 0 &&
+      box.left >= viewport.left && box.right <= viewport.right &&
+      box.top >= viewport.top && box.bottom <= viewport.bottom
+  })).toBe(true)
+
+  const parentOpen = page.locator('.live-plot[data-place-id="2"] .live-plot-open')
+  await panLiveTargetIntoView(page, parentOpen)
+  await parentOpen.click()
+  await expect(page).toHaveURL(/\/window\/live\?place=2$/u)
+  await expect(page.locator('[data-live-resident-scope="outside"]'))
+    .toContainText('map-walker')
+  await expect(page.locator('.live-plot')).toHaveCount(217)
+  const initial = await readLiveChildFraming(page)
+  await page.getByRole('button', { name: 'Center live view' }).click()
+  const centered = await readLiveChildFraming(page)
+  expect([initial, centered].every(frame =>
+    frame.detailedChildren >= 1 && frame.mountedChildren >= 1 &&
+    frame.safeOpenButtons >= 1 && frame.scale === 1), JSON.stringify({
+      initial,
+      centered,
+    }, null, 2)).toBe(true)
 })
 
 test('Live Show more reveals every loaded resident and thing instead of leaving a dead badge', async ({ page }) => {
@@ -2702,18 +3316,19 @@ test('two arrivals into one crowded plot settle on their own trail endpoints', a
   const durations = await replays.evaluateAll(nodes => nodes.map(node =>
     Number((node as HTMLElement).dataset.replayDuration)))
   expect(durations.every(duration => duration >= 3_200 && duration <= 8_000)).toBe(true)
-  await page.clock.runFor(9_000)
+  await page.clock.runFor(Math.max(...durations) + 20)
   await expect(replays).toHaveCount(0)
 
   for (const handle of ['map-walker', replayCrowd[0]!.handle]) {
     const walker = page.locator(
-      `[data-place-id="3"] [data-live-resident-handle="${handle}"]`,
-    ).first()
+      `.live-replay-portrait:not([data-replay-duration]) ` +
+      `[data-live-resident-handle="${handle}"]`,
+    )
     const trail = page.locator(`.live-trail[aria-label^="${handle} moved"]`)
     await expect(walker).toHaveCount(1)
     await expect(trail).toHaveCount(1)
     const point = await walker.evaluate(node => {
-      const shell = node.closest('.live-walker') as HTMLElement
+      const shell = node.closest('.live-walker, .live-replay-portrait') as HTMLElement
       const stage = node.closest('.live-stage') as HTMLElement
       const ground = stage.getBoundingClientRect()
       const box = shell.getBoundingClientRect()
@@ -2726,6 +3341,8 @@ test('two arrivals into one crowded plot settle on their own trail endpoints', a
     expect(Math.abs(point.x - Number(await trail.getAttribute('x2')))).toBeLessThan(1)
     expect(Math.abs(point.y - Number(await trail.getAttribute('y2')))).toBeLessThan(1)
   }
+  await page.clock.runFor(900)
+  await expect(page.locator('.live-replay-portrait')).toHaveCount(0)
 })
 
 test('a later crowded arrival keeps its full absorption window', async ({ page }) => {
@@ -3248,15 +3865,23 @@ test('reduced motion shows new records statically without replay animation', asy
   const fixture = await installReplayRoutes(page, now)
   await page.goto('/window#view=live')
   await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const harbor = page.locator('.live-plot[data-place-id="3"]')
+  const stableResidentsBefore = await liveResidentLocalPositions(harbor)
 
   fixture.publish()
   await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))
   await expect(page.locator('.live-trail')).toHaveCount(1)
   await expect(page.locator('.live-footnote-mark')).toHaveCount(2)
-  await expect(page.locator('.live-speech-bubble')).toHaveText('L'.repeat(59) + '…')
+  const latestNoteMark = page.locator('.live-footnote-mark[data-live-key="change:13"]')
+  await expect(latestNoteMark).toBeVisible()
+  await expect(latestNoteMark).toHaveAccessibleName("Show map-walker's note in the plate ledger")
+  const bubble = latestNoteMark.locator('.live-speech-bubble')
+  await expect(bubble).toBeVisible()
+  await expect(bubble).toHaveText('L'.repeat(59) + '…')
   await expect(page.locator('.live-replay-portrait')).toHaveCount(0)
   await expect(page.locator('.live-thing-specimen.live-pulse')).toHaveCount(0)
-  await expect(page.locator('.live-speech-bubble')).toHaveCSS('animation-name', 'none')
+  await expect(bubble).toHaveCSS('animation-name', 'none')
+  expect(await liveResidentLocalPositions(harbor)).toEqual(stableResidentsBefore)
 })
 
 test('the plate hard-caps trail ink and removes it at the fade edge without trimming the ledger', async ({ page }) => {
@@ -3364,6 +3989,232 @@ test('sixty-four simultaneous walks complete in one painted batch', async ({ pag
   expect(completionMutations).toBeLessThanOrEqual(2)
   await expect(page.locator('.live-ledger-row')).toHaveCount(64)
   await expect(page.locator('.live-trail')).toHaveCount(64)
+})
+
+test('eight legal change pages settle 1,600 actors without rebuilding crowd membership', async ({ page }) => {
+  test.setTimeout(60_000)
+  const now = Date.now()
+  const actorCount = 1_600
+  const drawingPlaceCount = 215
+  const detailedPlotCount = 217
+  const placeRowCount = replayPlaces.length + drawingPlaceCount
+  const residentRowBudget = actorCount * 16 + 10_000
+  const anchorMembershipRowBudget = actorCount * 16 + 10_000
+  const expectedPageCursors = [
+    '10', '1200', '1400', '1600', '1800', '2000', '2200', '2400',
+  ]
+  const expectedTransientReplayKeys = Array.from(
+    { length: 200 }, (_, index) => `change:${2_401 + index}`,
+  )
+  const stableResidentPositions = async () => (await liveResidentLocalPositions(
+    page.locator('.live-plot[data-place-id="3"]'),
+  )).map(({ key, x, y }) => ({
+    key,
+    x: Math.round(x * 100) / 100,
+    y: Math.round(y * 100) / 100,
+  }))
+  const fixedPlotPositions = () => page.locator('.live-plot').evaluateAll(plots =>
+    plots.map(plot => {
+      const element = plot as HTMLElement
+      return {
+        id: element.dataset.placeId,
+        x: element.dataset.livePlotX,
+        y: element.dataset.livePlotY,
+        width: element.dataset.livePlotWidth,
+        height: element.dataset.livePlotHeight,
+      }
+    }))
+  await page.clock.install({ time: new Date(now) })
+  await installLiveRenderWorkRecorder(page)
+  const fixture = await installReplayRoutes(page, now, 'complete', 0, {
+    simultaneousMoves: actorCount,
+    drawingPlaceCount,
+  })
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  await expect(page.locator('.live-replay-portrait')).toHaveCount(0)
+  const stableResidentsBefore = await stableResidentPositions()
+  const fixedPlotsBefore = await fixedPlotPositions()
+  expect(fixedPlotsBefore).toHaveLength(detailedPlotCount)
+  expect(stableResidentsBefore.length).toBeGreaterThan(0)
+  expect(stableResidentsBefore.every(resident =>
+    !resident.key.startsWith('walker-burst-'))).toBe(true)
+
+  await resetLiveRenderWork(page)
+  await page.evaluate(({ residentBudget, anchorBudget }) => {
+    const heldWindow = window as Window & {
+      __liveResidentRowBudget?: number
+      __liveResidentRowBudgetExceededAt?: number | null
+      __liveResidentAnchorRowBudget?: number
+      __liveResidentAnchorRowBudgetExceededAt?: number | null
+    }
+    heldWindow.__liveResidentRowBudget = residentBudget
+    heldWindow.__liveResidentRowBudgetExceededAt = null
+    heldWindow.__liveResidentAnchorRowBudget = anchorBudget
+    heldWindow.__liveResidentAnchorRowBudgetExceededAt = null
+  }, { residentBudget: residentRowBudget, anchorBudget: anchorMembershipRowBudget })
+  const changeCursorOffset = fixture.changeCursors().length
+  await publishReplayChanges(page, fixture)
+  await expect.poll(
+    () => fixture.changeCursors().slice(changeCursorOffset),
+    { timeout: 45_000 },
+  ).toEqual(expectedPageCursors)
+  expect(fixture.changeLimits().slice(changeCursorOffset)).toEqual(
+    expectedPageCursors.map(() => '200'),
+  )
+
+  const replays = page.locator('.live-replay-portrait')
+  await expect(page.locator('.live-ledger-row')).toHaveCount(actorCount, { timeout: 45_000 })
+  await expect(replays).toHaveCount(expectedTransientReplayKeys.length)
+  const stableResidentsDuring = await stableResidentPositions()
+  const fixedPlotsDuring = await fixedPlotPositions()
+  await page.clock.fastForward(2_000)
+  type TransientReplay = Readonly<{
+    key: string
+    actor: string
+    fromPlaceId: string
+    toPlaceId: string
+  }>
+  let transientReplays: TransientReplay[] = []
+  await expect.poll(async () => {
+    transientReplays = await page.evaluate(() => [...((window as Window & {
+      __liveReplayStarts?: TransientReplay[]
+    }).__liveReplayStarts ?? [])])
+    return transientReplays.length
+  }).toBe(expectedTransientReplayKeys.length)
+  const transientReplayKeys = transientReplays.map(replay => replay.key)
+  expect(transientReplayKeys).toEqual(expectedTransientReplayKeys)
+  expect(transientReplayKeys).not.toContain('change:2400')
+  expect(transientReplays[0]).toEqual({
+    key: 'change:2401',
+    actor: 'walker-burst-1401',
+    fromPlaceId: '2',
+    toPlaceId: '3',
+  })
+  const transientReplayCount = transientReplayKeys.length
+  const newestTrail = page.locator('.live-trail[data-live-key="change:2600"]')
+  await expect(newestTrail).toHaveAttribute(
+    'aria-label', 'walker-burst-1600 moved from 2 to 3',
+  )
+  expect(transientReplays.at(-1)).toEqual({
+    key: 'change:2600',
+    actor: 'walker-burst-1600',
+    fromPlaceId: '2',
+    toPlaceId: '3',
+  })
+  await expect(replays).toHaveCount(0, { timeout: 20_000 })
+  await expect(page.locator('.live-trail')).toHaveCount(96)
+  const stableResidentsAfter = await stableResidentPositions()
+  const fixedPlotsAfter = await fixedPlotPositions()
+
+  const ledgerRows = await page.locator('.live-ledger-row').evaluateAll(rows =>
+    rows.map(row => ({
+      key: (row as HTMLElement).dataset.liveKey,
+      copy: row.querySelector('.live-ledger-copy')?.textContent ?? '',
+    })))
+  const expectedLedgerKeys = Array.from(
+    { length: actorCount }, (_, index) => `change:${2_600 - index}`,
+  )
+  const repeatedActorLedger = ledgerRows
+    .filter(row => row.copy.startsWith('walker-burst-1401 moved:'))
+  expect(repeatedActorLedger).toEqual([{
+    key: 'change:2401',
+    copy: 'walker-burst-1401 moved: Cinder lane → Harbor room',
+  }, {
+    key: 'change:2400',
+    copy: 'walker-burst-1401 moved: Harbor room → Cinder lane',
+  }])
+  const rosterOutcomes = await page.locator('#live-roster .resident-row').evaluateAll(rows =>
+    rows.flatMap(row => {
+      const handle = row.querySelector<HTMLElement>('[data-live-resident-handle]')
+        ?.dataset.liveResidentHandle
+      return handle?.startsWith('walker-burst-')
+        ? [{ handle, atHarbor: row.textContent?.includes('Harbor room') === true }]
+        : []
+    }))
+  const rosterActorSet = new Set(rosterOutcomes.map(outcome => outcome.handle))
+  const missingRosterActors = Array.from({ length: actorCount }, (_, index) =>
+    `walker-burst-${index + 1}`).filter(actor => !rosterActorSet.has(actor))
+  const wrongCurrentPlaces = rosterOutcomes
+    .filter(outcome => !outcome.atHarbor)
+    .map(outcome => outcome.handle)
+
+  const work = await readLiveRenderWork(page)
+  const exceeded = await page.evaluate(() => {
+    const heldWindow = window as Window & {
+      __liveResidentRowBudgetExceededAt?: number | null
+      __liveResidentAnchorRowBudgetExceededAt?: number | null
+    }
+    return {
+      residentRows: heldWindow.__liveResidentRowBudgetExceededAt ?? null,
+      anchorMembershipRows: heldWindow.__liveResidentAnchorRowBudgetExceededAt ?? null,
+    }
+  })
+  const crowdedLayoutBudget = work.renders * 2
+  const anchorMembershipCheckBudget = actorCount * Math.max(2, work.renders * 2)
+  const placeAnchorLookupBudget = work.renders * 2
+  const placeAnchorPlaceRowBudget = placeRowCount * placeAnchorLookupBudget
+  const placeAnchorChildRowBudget = detailedPlotCount * placeAnchorLookupBudget
+  const placeAnchorResolutionBudget = work.renders * 32
+  expect(work.largeResidentLayouts <= crowdedLayoutBudget &&
+    work.residentRowsVisited <= residentRowBudget &&
+    exceeded.residentRows === null &&
+    work.replayCatchUpRecords === actorCount - 200 &&
+    transientReplayCount <= 200 &&
+    work.residentAnchorMembershipChecks <= anchorMembershipCheckBudget &&
+    work.residentAnchorMembershipRowsVisited <= anchorMembershipRowBudget &&
+    exceeded.anchorMembershipRows === null &&
+    work.placeAnchorLookupBuilds <= placeAnchorLookupBudget &&
+    work.placeAnchorPlaceRowsVisited <= placeAnchorPlaceRowBudget &&
+    work.placeAnchorMapRowsVisited <= placeAnchorPlaceRowBudget &&
+    work.placeAnchorChildRowsVisited <= placeAnchorChildRowBudget &&
+    work.placeAnchorResolutionSteps <= placeAnchorResolutionBudget &&
+    stableResidentsDuring.length === stableResidentsBefore.length &&
+    stableResidentsDuring.every((resident, index) =>
+      JSON.stringify(resident) === JSON.stringify(stableResidentsBefore[index])) &&
+    stableResidentsAfter.length === stableResidentsBefore.length &&
+    stableResidentsAfter.every((resident, index) =>
+      JSON.stringify(resident) === JSON.stringify(stableResidentsBefore[index])) &&
+    JSON.stringify(fixedPlotsDuring) === JSON.stringify(fixedPlotsBefore) &&
+    JSON.stringify(fixedPlotsAfter) === JSON.stringify(fixedPlotsBefore) &&
+    JSON.stringify(ledgerRows.map(row => row.key)) === JSON.stringify(expectedLedgerKeys) &&
+    ledgerRows.some(row => row.copy.startsWith('walker-burst-1600 moved:')) &&
+    rosterOutcomes.length === actorCount && missingRosterActors.length === 0 &&
+    wrongCurrentPlaces.length === 0, JSON.stringify({
+      renders: work.renders,
+      largeResidentLayouts: work.largeResidentLayouts,
+      crowdedLayoutBudget,
+      residentRowsVisited: work.residentRowsVisited,
+      residentRowBudget,
+      residentRowBudgetExceededAt: exceeded.residentRows,
+      replayCatchUpRecords: work.replayCatchUpRecords,
+      residentAnchorMembershipChecks: work.residentAnchorMembershipChecks,
+      anchorMembershipCheckBudget,
+      residentAnchorMembershipRowsVisited: work.residentAnchorMembershipRowsVisited,
+      anchorMembershipRowBudget,
+      anchorMembershipRowBudgetExceededAt: exceeded.anchorMembershipRows,
+      placeAnchorCalls: work.placeAnchorCalls,
+      placeAnchorLookupBuilds: work.placeAnchorLookupBuilds,
+      placeAnchorLookupBudget,
+      placeAnchorPlaceRowsVisited: work.placeAnchorPlaceRowsVisited,
+      placeAnchorMapRowsVisited: work.placeAnchorMapRowsVisited,
+      placeAnchorPlaceRowBudget,
+      placeAnchorChildRowsVisited: work.placeAnchorChildRowsVisited,
+      placeAnchorChildRowBudget,
+      placeAnchorResolutionSteps: work.placeAnchorResolutionSteps,
+      placeAnchorResolutionBudget,
+      transientReplayCount,
+      transientReplayKeys: transientReplayKeys.slice(0, 3)
+        .concat(['…'], transientReplayKeys.slice(-3)),
+      stableResidentsBefore,
+      stableResidentsDuring,
+      stableResidentsAfter,
+      ledgerRowCount: ledgerRows.length,
+      repeatedActorLedger,
+      rosterActorCount: rosterOutcomes.length,
+      missingRosterActors: missingRosterActors.slice(0, 10),
+      wrongCurrentPlaces: wrongCurrentPlaces.slice(0, 10),
+    }, null, 2)).toBe(true)
 })
 
 test('a moving resident returning to readable ground receives a bounded label refresh', async ({ page }) => {

--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -1302,6 +1302,7 @@ export const WINDOW_JS = `(() => {
   const LIVE_DRAWING_FETCH_CONCURRENCY = 4
   const LIVE_DRAWING_QUEUE_LIMIT = 32
   const LIVE_OPENING_PAGE_LIMIT = 200
+  const LIVE_REPLAY_BACKLOG_LIMIT = LIVE_OPENING_PAGE_LIMIT
   const LIVE_PORTRAIT_LIMIT = 6
   const LIVE_THING_LIMIT = 6
   const LIVE_FOCUS_STORAGE_KEY = '1f3d9:window:live-focus'
@@ -2493,15 +2494,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       node.dataset.liveDetail = String(detailed)
       if (detailed && placeId && livePlotDetailContext) {
         const place = livePlotDetailContext.children.find(candidate => candidate.id === placeId)
-        if (place) mountLivePlaceDetail(
-          node,
-          livePlotDetailContext.snapshot,
-          livePlotDetailContext.focus,
-          place,
-          livePlotDetailContext.bubbles,
-          livePlotDetailContext.records,
-          livePlotDetailContext.interactionThings,
-        )
+        if (place) mountLivePlaceDetail(node, livePlotDetailContext, place)
       } else if (!detailed) {
         unmountLivePlaceDetail(node)
       }
@@ -2599,7 +2592,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
     return target ? revealLiveStageTarget(target, center) : false
   }
 
-  function liveDefaultCenterTarget(snapshot, focus, survey) {
+  function liveDefaultCenterTarget(snapshot, focus, survey, renderContext = null) {
     const focusedResident = state.live.focusResident
       ? displayedResidents(snapshot).find(resident =>
           resident.handle === state.live.focusResident)
@@ -2611,6 +2604,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         focusedResident.handle,
         focus,
         liveChildren(snapshot, focus),
+        renderContext,
       )
       if (focusedPoint) return focusedPoint
     }
@@ -2635,10 +2629,44 @@ ${WINDOW_CLIENT_SAFETY_JS}
         y: firstChild.y + firstChild.height / 2,
       })
     }
-    return Object.freeze({
+    const ordinaryTarget = Object.freeze({
       x: Math.min(survey.width, LIVE_DIRECT_GROUND_WIDTH) / 2,
       y: Math.min(survey.height, WINDOW_LIVE_DIRECT_COMMONS_HEIGHT) / 2,
     })
+    if (!firstChild || !nodes.liveViewport) return ordinaryTarget
+    const ordinaryCamera = liveCameraForStageTarget(ordinaryTarget, true)
+    if (!ordinaryCamera) return ordinaryTarget
+    const ordinaryViewport = Object.freeze({
+      left: -ordinaryCamera.offsetX / ordinaryCamera.scale,
+      top: -ordinaryCamera.offsetY / ordinaryCamera.scale,
+      right: (nodes.liveViewport.clientWidth - ordinaryCamera.offsetX) /
+        ordinaryCamera.scale,
+      bottom: (nodes.liveViewport.clientHeight - ordinaryCamera.offsetY) /
+        ordinaryCamera.scale,
+    })
+    if (windowLiveVisiblePlotIds(
+      survey.plots,
+      survey.expandedGrounds,
+      ordinaryViewport,
+      LIVE_PLOT_OVERSCAN,
+    ).length) return ordinaryTarget
+    return Object.freeze({
+      x: firstChild.x + firstChild.width / 2,
+      y: firstChild.y + firstChild.height / 2,
+      preservesChildDetail: true,
+      childDetailPlaceId: firstChild.id,
+    })
+  }
+
+  function liveChildDetailRevealTargets(target) {
+    const placeId = safeId(target?.childDetailPlaceId)
+    if (!target?.preservesChildDetail || !placeId || !nodes.livePlates) return []
+    return [
+      ...nodes.livePlates.querySelectorAll(
+        '.live-plot[data-place-id="' + String(placeId) + '"] .live-plot-open',
+      ),
+      ...nodes.livePlates.querySelectorAll('.live-root-walkers .live-speech-bubble'),
+    ]
   }
 
   function liveCenterTarget() {
@@ -2665,6 +2693,10 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const focus = liveFocusPlace(state.snapshot)
       const resident = displayedResidents(state.snapshot).find(candidate =>
         candidate.handle === state.live.focusResident)
+      const renderContext = livePlotDetailContext?.snapshot === state.snapshot &&
+        focus && livePlotDetailContext.focus.id === focus.id
+        ? livePlotDetailContext
+        : null
       if (focus && resident) {
         const point = liveResidentReplayPoint(
           state.snapshot,
@@ -2672,6 +2704,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
           resident.handle,
           focus,
           liveChildren(state.snapshot, focus),
+          renderContext,
         )
         if (point) return point
       }
@@ -2679,10 +2712,15 @@ ${WINDOW_CLIENT_SAFETY_JS}
     if (state.snapshot) {
       const focus = liveFocusPlace(state.snapshot)
       if (focus) {
+        const renderContext = livePlotDetailContext?.snapshot === state.snapshot &&
+          livePlotDetailContext.focus.id === focus.id
+          ? livePlotDetailContext
+          : null
         return liveDefaultCenterTarget(
           state.snapshot,
           focus,
-          liveStageSurvey(livePlaceRows(state.snapshot), focus.id),
+          renderContext?.survey || liveStageSurvey(livePlaceRows(state.snapshot), focus.id),
+          renderContext,
         )
       }
     }
@@ -2707,6 +2745,11 @@ ${WINDOW_CLIENT_SAFETY_JS}
     if (!centered) return
     applyLiveCamera({ ...centered, panStart: null, pinchStart: null })
     if (liveCameraFrame) {
+      window.cancelAnimationFrame(liveCameraFrame)
+      liveCameraFrame = 0
+      commitLiveCamera()
+    }
+    if (revealLiveElements(liveChildDetailRevealTargets(target)) && liveCameraFrame) {
       window.cancelAnimationFrame(liveCameraFrame)
       liveCameraFrame = 0
       commitLiveCamera()
@@ -4305,7 +4348,14 @@ ${WINDOW_CLIENT_SAFETY_JS}
         seen.size === state.live.replaySeenKeys.length &&
         revealed.size === state.live.replayRevealedKeys.length) return
 
-    if (!animate || liveMotionReduced()) {
+    const animates = animate && !liveMotionReduced()
+    const retainedAdditions = animates
+      ? additions.slice(-LIVE_REPLAY_BACKLOG_LIMIT)
+      : additions
+    const caughtUpAdditions = animates
+      ? additions.slice(0, Math.max(0, additions.length - retainedAdditions.length))
+      : []
+    if (!animates) {
       const trailStarts = { ...state.live.trailStarts }
       for (const record of additions) {
         if (liveRecordType(record) === 'move') trailStarts[liveTraceKey(record)] = now
@@ -4323,7 +4373,13 @@ ${WINDOW_CLIENT_SAFETY_JS}
     const queues = Object.fromEntries(Object.entries(state.live.replayQueues)
       .map(([actor, queue]) => [actor, [...queue]]))
     const positions = { ...state.live.replayPositions }
-    for (const record of additions) {
+    const trailStarts = { ...state.live.trailStarts }
+    for (const record of caughtUpAdditions) {
+      const key = liveTraceKey(record)
+      revealed.add(key)
+      if (liveRecordType(record) === 'move') trailStarts[key] = now
+    }
+    for (const record of retainedAdditions) {
       queues[record.actor] = Object.freeze([...(queues[record.actor] || []), record])
       if (!Object.hasOwn(positions, record.actor) && liveRecordType(record) === 'move') {
         positions[record.actor] = record.detail.from_place_id
@@ -4335,6 +4391,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       replayPositions: Object.freeze(positions),
       replaySeenKeys: Object.freeze([...seen]),
       replayRevealedKeys: Object.freeze([...revealed]),
+      trailStarts: Object.freeze(trailStarts),
     } }
   }
 
@@ -4363,23 +4420,41 @@ ${WINDOW_CLIENT_SAFETY_JS}
     } }
   }
 
-  function livePlaceAnchor(placeId, focusId, children) {
-    if (!placeId) return null
-    if (placeId === focusId) return focusId
+  function livePlaceAnchorLookup(focusId, children) {
     const places = state.snapshot
       ? livePlaceRows(state.snapshot)
       : state.directory.loaded ? state.directory.places : []
     const byId = new Map(places.map(place => [place.id, place]))
     const childIds = new Set(children.map(place => place.id))
-    const seen = new Set()
-    let current = byId.get(placeId)
-    while (current && !seen.has(current.id)) {
-      if (childIds.has(current.id)) return current.id
-      if (current.parent_id === focusId) return current.id
-      seen.add(current.id)
-      current = current.parent_id ? byId.get(current.parent_id) : null
-    }
-    return null
+    const anchors = new Map()
+    return Object.freeze({
+      resolve(placeId) {
+        if (anchors.has(placeId)) return anchors.get(placeId)
+        const seen = new Set()
+        let current = byId.get(placeId)
+        let anchor = null
+        while (current && !seen.has(current.id)) {
+          if (childIds.has(current.id) || current.parent_id === focusId) {
+            anchor = current.id
+            break
+          }
+          seen.add(current.id)
+          current = current.parent_id ? byId.get(current.parent_id) : null
+        }
+        anchors.set(placeId, anchor)
+        return anchor
+      },
+    })
+  }
+
+  function livePlaceAnchor(placeId, focusId, children, renderContext = null) {
+    if (!placeId) return null
+    if (placeId === focusId) return focusId
+    const buildLookup = () => livePlaceAnchorLookup(focusId, children)
+    const lookup = renderContext
+      ? renderContext.remember('place-anchor-lookup:' + String(focusId), buildLookup)
+      : buildLookup()
+    return lookup.resolve(placeId)
   }
 
   function liveDrawingKey(type, id) {
@@ -6518,7 +6593,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
   function livePortraitShell(portrait, bubble, className = 'live-portrait-wrap') {
     const shell = element('span', className)
     shell.append(portrait)
-    if (bubble) shell.append(liveSpeechBubbleNode(bubble))
+    if (bubble && !liveMotionReduced()) shell.append(liveSpeechBubbleNode(bubble))
     return shell
   }
 
@@ -6541,7 +6616,79 @@ ${WINDOW_CLIENT_SAFETY_JS}
     return Math.max(680, height)
   }
 
-  function liveResidentLayout(residents, placeId, focus, children, pinnedIds) {
+  function liveCreateRenderContext(
+    snapshot,
+    focus,
+    children,
+    survey,
+  ) {
+    const values = new Map()
+    return Object.freeze({
+      snapshot,
+      focus,
+      children,
+      survey,
+      expandedGrounds: survey.expandedGrounds,
+      remember(key, build) {
+        if (values.has(key)) return values.get(key)
+        const value = build()
+        values.set(key, value)
+        return value
+      },
+    })
+  }
+
+  function liveRenderResidentIndex(snapshot, renderContext = null) {
+    const build = () => {
+      const residents = Object.freeze(displayedResidents(snapshot))
+      const byHandle = new Map(residents.map(resident => [resident.handle, resident]))
+      const byId = new Map(residents.map(resident => [resident.id, resident]))
+      return Object.freeze({
+        residents,
+        residentByHandle: handle => byHandle.get(handle) || null,
+        residentById: id => byId.get(id) || null,
+      })
+    }
+    return renderContext
+      ? renderContext.remember('resident-index', build)
+      : build()
+  }
+
+  function liveResidentLayout(
+    residents,
+    placeId,
+    focus,
+    children,
+    pinnedIds,
+    renderContext = null,
+    cacheable = true,
+    persistPoints = true,
+    persistVisibleIds = persistPoints,
+    surfaceLayout = null,
+  ) {
+    if (renderContext && cacheable) {
+      const key = 'resident-layout:' + String(persistPoints) + ':' +
+        String(persistVisibleIds) + ':' +
+        String(placeId) + ':' +
+        residents.map(resident => resident.id).join(',') + ':' +
+        (pinnedIds || []).join(',') + ':' +
+        (surfaceLayout
+          ? [surfaceLayout.surfaceWidth, surfaceLayout.surfaceHeight,
+              surfaceLayout.inlineOffsetY].join(',')
+          : '')
+      return renderContext.remember(key, () => liveResidentLayout(
+        residents,
+        placeId,
+        focus,
+        children,
+        pinnedIds,
+        renderContext,
+        false,
+        persistPoints,
+        persistVisibleIds,
+        surfaceLayout,
+      ))
+    }
     const ordered = [...residents.filter(resident => !resident.asleep),
       ...residents.filter(resident => resident.asleep)]
     const isRoot = placeId === focus.id
@@ -6572,31 +6719,42 @@ ${WINDOW_CLIENT_SAFETY_JS}
     )
     const visibleResidents = selection.visible
     const border = focus.parent_id === null ? 4 : 3
-    const survey = liveStageSurvey(livePlaceRows(state.snapshot), focus.id)
-    const surfaceWidth = isRoot
-      ? windowLiveDirectGroundWidth(survey.width, LIVE_DIRECT_GROUND_WIDTH)
-      : expanded ? 480 : plot.width
+    const survey = renderContext?.survey ||
+      liveStageSurvey(livePlaceRows(state.snapshot), focus.id)
+    const surfaceWidth = surfaceLayout
+      ? surfaceLayout.surfaceWidth
+      : isRoot
+        ? windowLiveDirectGroundWidth(survey.width, LIVE_DIRECT_GROUND_WIDTH)
+        : expanded ? 480 : plot.width
     const minimumHeight = isRoot ? 680 : expanded ? 320 : plot.height
     const itemWidth = 56
     const itemHeight = 56
     const thingItemWidth = isRoot ? 144 : 94
     const margin = isRoot ? 12 : 6
-    const surfaceHeight = isRoot
-      ? rootExpanded ? liveDirectGroundHeight(placeId, surfaceWidth) : minimumHeight
-      : !expanded
-      ? minimumHeight
-      : Math.max(
-          minimumHeight,
-          windowLiveScatterSurfaceHeight(
-            0,
-            surfaceWidth,
-            visibleResidents.length,
-            itemWidth,
-            itemHeight,
-            margin,
-            selection.overflowCount > 0,
-          ),
+    const stablePointHeadroom = expanded && !isRoot
+      ? Math.min(
+          LIVE_PORTRAIT_LIMIT,
+          Object.keys(liveResidentPointsByPlaceId[String(placeId)] || {}).length,
         )
+      : 0
+    const surfaceHeight = surfaceLayout
+      ? surfaceLayout.surfaceHeight
+      : isRoot
+        ? rootExpanded ? liveDirectGroundHeight(placeId, surfaceWidth) : minimumHeight
+        : !expanded
+          ? minimumHeight
+          : Math.max(
+              minimumHeight,
+              windowLiveScatterSurfaceHeight(
+                0,
+                surfaceWidth,
+                visibleResidents.length + stablePointHeadroom,
+                itemWidth,
+                itemHeight,
+                margin,
+                selection.overflowCount > 0,
+              ),
+            )
     const reserved = isRoot
       ? windowLiveRootReservations(surfaceWidth, surfaceHeight)
       : Object.freeze([])
@@ -6626,16 +6784,20 @@ ${WINDOW_CLIENT_SAFETY_JS}
         !expanded && !state.live.expandedThingPlaceIds.includes(placeId)
       ),
     )
-    liveResidentPointsByPlaceId = Object.freeze({
-      ...liveResidentPointsByPlaceId,
-      [String(placeId)]: separated,
-    })
+    if (persistPoints) {
+      liveResidentPointsByPlaceId = Object.freeze({
+        ...liveResidentPointsByPlaceId,
+        [String(placeId)]: separated,
+      })
+    }
     const expandedGround = !isRoot && expanded
       ? survey.expandedGrounds[String(placeId)] || null
       : null
-    const inlineOffsetY = expandedGround?.residentTop
-      ? expandedGround.residentTop - plot.y
-      : 0
+    const inlineOffsetY = surfaceLayout
+      ? surfaceLayout.inlineOffsetY
+      : expandedGround?.residentTop
+        ? expandedGround.residentTop - plot.y
+        : 0
     const visible = Object.freeze(visibleResidents.flatMap(resident => {
       const localPoint = separated[String(resident.id)]
       if (!localPoint) return []
@@ -6648,11 +6810,13 @@ ${WINDOW_CLIENT_SAFETY_JS}
       return [Object.freeze({ resident, localPoint, stagePoint })]
     }))
     const visibleIds = new Set(visible.map(entry => entry.resident.id))
-    liveResidentVisibleIdsByPlaceId = Object.freeze({
-      ...liveResidentVisibleIdsByPlaceId,
-      [String(placeId)]: Object.freeze(visible.map(entry => entry.resident.id)),
-    })
-    return Object.freeze({
+    if (persistVisibleIds) {
+      liveResidentVisibleIdsByPlaceId = Object.freeze({
+        ...liveResidentVisibleIdsByPlaceId,
+        [String(placeId)]: Object.freeze(visible.map(entry => entry.resident.id)),
+      })
+    }
+    const layout = Object.freeze({
       visible,
       hidden: Object.freeze(ordered.filter(resident => !visibleIds.has(resident.id))),
       overflowCount: Math.max(0, ordered.length - visible.length),
@@ -6664,6 +6828,15 @@ ${WINDOW_CLIENT_SAFETY_JS}
         ? Object.freeze({ x: surfaceWidth - 58, y: surfaceHeight - 18 })
         : Object.freeze({ x: plot.x + plot.width - 28, y: plot.y + plot.height - 10 }),
     })
+    if (renderContext) {
+      for (const entry of visible) {
+        renderContext.remember(
+          'resident-point:' + String(placeId) + ':' + entry.resident.handle,
+          () => entry.stagePoint,
+        )
+      }
+    }
+    return layout
   }
 
   function livePinnedResidentIds(snapshot, records, placeId) {
@@ -6702,46 +6875,137 @@ ${WINDOW_CLIENT_SAFETY_JS}
       .map(thing => thing.id))
   }
 
-  function liveFocusedPlotIds(snapshot, focus, children, records, interactionThings) {
+  function liveFocusedPlotIds(
+    snapshot,
+    focus,
+    children,
+    records,
+    interactionThings,
+    renderContext = null,
+  ) {
     if (state.live.proofScene) return Object.freeze(children.map(place => place.id))
     const focused = new Set()
     const pinnedResidents = new Set(livePinnedResidentIds(snapshot, records, focus.id))
     for (const resident of displayedResidents(snapshot)) {
       if (!pinnedResidents.has(resident.id)) continue
-      const anchorId = livePlaceAnchor(resident.current_place_id, focus.id, children)
+      const anchorId = livePlaceAnchor(
+        resident.current_place_id, focus.id, children, renderContext)
       if (anchorId && anchorId !== focus.id) focused.add(anchorId)
     }
     const pinnedThings = new Set(livePinnedThingIds(
       snapshot, records, focus.id, interactionThings))
     for (const thing of interactionThings) {
       if (!pinnedThings.has(thing.id)) continue
-      const anchorId = livePlaceAnchor(thing.place_id, focus.id, children)
+      const anchorId = livePlaceAnchor(thing.place_id, focus.id, children, renderContext)
       if (anchorId && anchorId !== focus.id) focused.add(anchorId)
     }
     return Object.freeze([...focused])
   }
 
-  function liveResidentReplayPoint(snapshot, placeId, actor, focus, children) {
-    const anchorId = livePlaceAnchor(placeId, focus.id, children)
+  function liveResidentReplayPoint(
+    snapshot,
+    placeId,
+    actor,
+    focus,
+    children,
+    renderContext = null,
+    cacheable = true,
+  ) {
+    const anchorId = livePlaceAnchor(placeId, focus.id, children, renderContext)
     if (!anchorId) return null
-    const resident = displayedResidents(snapshot).find(candidate => candidate.handle === actor)
+    if (renderContext && cacheable) {
+      return renderContext.remember(
+        'resident-point:' + String(anchorId) + ':' + actor,
+        () => liveResidentReplayPoint(
+          snapshot, placeId, actor, focus, children, renderContext, false),
+      )
+    }
+    const residentIndex = liveRenderResidentIndex(snapshot, renderContext)
+    const resident = residentIndex.residentByHandle(actor)
     if (!resident) return null
-    const anchoredResidents = anchorId === focus.id
-      ? displayedResidents(snapshot).filter(candidate =>
-          candidate.current_place_id === focus.id &&
-          (!state.resident || candidate.handle === state.resident))
-      : residentsAt(snapshot, anchorId)
-    const residents = anchoredResidents.some(candidate => candidate.handle === actor)
-      ? anchoredResidents
-      : [...anchoredResidents, resident]
-    const records = visibleLiveRecords(snapshot, focus, children)
-    const pinnedIds = livePinnedResidentIds(snapshot, records, anchorId)
+    const buildAnchoredResidents = () => {
+      const placeIds = anchorId === focus.id
+        ? new Set([focus.id])
+        : placeScopeSet(anchorId, snapshot)
+      return Object.freeze(residentIndex.residents.filter(candidate =>
+        placeIds.has(candidate.current_place_id) &&
+        (!state.resident || candidate.handle === state.resident)))
+    }
+    const anchoredResidents = renderContext
+      ? renderContext.remember(
+          'resident-replay-rows:' + String(anchorId),
+          buildAnchoredResidents,
+        )
+      : buildAnchoredResidents()
+    const buildAnchoredResidentIds = () =>
+      new Set(anchoredResidents.map(candidate => candidate.id))
+    const anchoredResidentIds = renderContext
+      ? renderContext.remember(
+          'resident-replay-ids:' + String(anchorId),
+          buildAnchoredResidentIds,
+        )
+      : buildAnchoredResidentIds()
+    const records = renderContext?.records || visibleLiveRecords(
+      snapshot, focus, children, renderContext)
+    const buildPinnedIds = () => livePinnedResidentIds(snapshot, records, anchorId)
+    const pinnedIds = renderContext
+      ? renderContext.remember(
+          'resident-replay-pins:' + String(anchorId),
+          buildPinnedIds,
+        )
+      : buildPinnedIds()
+    const buildBaseLayout = () => liveResidentLayout(
+      anchoredResidents,
+      anchorId,
+      focus,
+      children,
+      pinnedIds,
+      renderContext,
+      true,
+      true,
+      true,
+    )
+    const baseLayout = renderContext
+      ? renderContext.remember(
+          'resident-replay-base:' + String(anchorId),
+          buildBaseLayout,
+        )
+      : buildBaseLayout()
+    const basePoint = baseLayout.visible
+      .find(entry => entry.resident.id === resident.id)?.stagePoint
+    if (basePoint) return basePoint
+
+    const totalWithActor = baseLayout.visible.length + baseLayout.overflowCount +
+      (anchoredResidentIds.has(resident.id) ? 0 : 1)
+    const layerCapacity = baseLayout.expanded
+      ? Math.min(LIVE_PORTRAIT_LIMIT, totalWithActor)
+      : totalWithActor > LIVE_PORTRAIT_LIMIT
+        ? Math.max(1, LIVE_PORTRAIT_LIMIT - 2)
+        : Math.min(LIVE_PORTRAIT_LIMIT, totalWithActor)
+    const layerIds = []
+    for (const id of [
+      resident.id,
+      ...pinnedIds,
+      ...baseLayout.visible.map(entry => entry.resident.id),
+    ]) {
+      if (layerIds.length >= layerCapacity) break
+      if (!layerIds.includes(id)) layerIds.push(id)
+    }
+    const layerResidents = Object.freeze(layerIds.flatMap(id => {
+      const candidate = residentIndex.residentById(id)
+      return candidate ? [candidate] : []
+    }))
     const layout = liveResidentLayout(
-      residents,
+      layerResidents,
       anchorId,
       focus,
       children,
       Object.freeze([resident.id, ...pinnedIds.filter(id => id !== resident.id)]),
+      renderContext,
+      false,
+      false,
+      false,
+      baseLayout,
     )
     return layout.visible.find(entry => entry.resident.handle === actor)?.stagePoint ||
       layout.badgePoint
@@ -6767,13 +7031,23 @@ ${WINDOW_CLIENT_SAFETY_JS}
     control.style.minWidth = '0'
   }
 
-  function livePortraitGrid(residents, label, bubbles, placeId, pinnedIds, className = 'live-portrait-grid') {
+  function livePortraitGrid(
+    residents,
+    label,
+    bubbles,
+    placeId,
+    pinnedIds,
+    className = 'live-portrait-grid',
+    renderContext = null,
+  ) {
     const grid = element('div', className)
     grid.setAttribute('aria-label', label)
-    const focus = state.snapshot ? liveFocusPlace(state.snapshot) : null
-    const children = focus && state.snapshot ? liveChildren(state.snapshot, focus) : []
+    const focus = renderContext?.focus || (state.snapshot ? liveFocusPlace(state.snapshot) : null)
+    const children = renderContext?.children ||
+      (focus && state.snapshot ? liveChildren(state.snapshot, focus) : [])
     if (!focus) return grid
-    const layout = liveResidentLayout(residents, placeId, focus, children, pinnedIds)
+    const layout = liveResidentLayout(
+      residents, placeId, focus, children, pinnedIds, renderContext)
     if (placeId === focus.id) {
       grid.style.width = String(layout.surfaceWidth) + 'px'
       grid.style.height = String(layout.surfaceHeight) + 'px'
@@ -6909,7 +7183,23 @@ ${WINDOW_CLIENT_SAFETY_JS}
     focusId,
     includeDescendants = false,
     interactionThings = null,
+    renderContext = null,
+    cacheable = true,
   ) {
+    if (renderContext && cacheable) {
+      const key = 'thing-presentation:' + String(placeId) + ':' +
+        String(focusId) + ':' + String(includeDescendants)
+      return renderContext.remember(key, () => liveThingPresentation(
+        snapshot,
+        placeId,
+        records,
+        focusId,
+        includeDescendants,
+        interactionThings,
+        renderContext,
+        false,
+      ))
+    }
     const things = liveDisplayedThings(snapshot, placeId, focusId, includeDescendants)
     const pinnedIds = livePinnedThingIds(snapshot, records, placeId, interactionThings)
     const exactTotal = liveExactThingTotal(
@@ -6974,9 +7264,17 @@ ${WINDOW_CLIENT_SAFETY_JS}
     focusId,
     includeDescendants = false,
     interactionThings = null,
+    renderContext = null,
   ) {
     const presentation = liveThingPresentation(
-      snapshot, place.id, records, focusId, includeDescendants, interactionThings)
+      snapshot,
+      place.id,
+      records,
+      focusId,
+      includeDescendants,
+      interactionThings,
+      renderContext,
+    )
     const { things, pinnedIds, exactTotal, selection } = presentation
     if (!things.length && exactTotal !== null && exactTotal === 0) return null
     if (!things.length && exactTotal === null) return null
@@ -6989,7 +7287,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       state.live.expandedResidentPlaceIds.includes(place.id) ||
       state.live.expandedThingPlaceIds.includes(place.id)
     )
-    const survey = liveStageSurvey(livePlaceRows(snapshot), focusId)
+    const survey = renderContext?.survey || liveStageSurvey(livePlaceRows(snapshot), focusId)
     const childPlot = isRoot ? null : survey.plots.find(candidate => candidate.id === place.id)
     const itemWidth = isRoot ? 144 : 94
     const itemHeight = 56
@@ -7155,19 +7453,11 @@ ${WINDOW_CLIENT_SAFETY_JS}
     const filters = liveThingFilters(focusId)
     const entry = historyEntry('things', filters)
     if (entry.hasMore && !entry.loading) await loadHistory('things', filters)
-    if (state.snapshot) renderLive(state.snapshot)
   }
 
-  function mountLivePlaceDetail(
-    card,
-    snapshot,
-    focus,
-    place,
-    bubbles,
-    records,
-    interactionThings,
-  ) {
+  function mountLivePlaceDetail(card, renderContext, place) {
     if (card.dataset.liveDetailMounted === 'true') return
+    const { snapshot, focus, bubbles, records, interactionThings } = renderContext
     const open = card.querySelector(':scope > .live-plot-open')
     if (!open) return
     const drawing = state.live.drawings[liveDrawingKey('place', place.id)]
@@ -7198,9 +7488,12 @@ ${WINDOW_CLIENT_SAFETY_JS}
         bubbles,
         place.id,
         livePinnedResidentIds(snapshot, records, place.id),
+        'live-portrait-grid',
+        renderContext,
       ))
     }
-    const shelf = liveThingShelf(snapshot, place, records, focus.id, true, interactionThings)
+    const shelf = liveThingShelf(
+      snapshot, place, records, focus.id, true, interactionThings, renderContext)
     if (shelf) card.append(shelf)
     card.dataset.liveDetailMounted = 'true'
   }
@@ -7212,17 +7505,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
     card.dataset.liveDetailMounted = 'false'
   }
 
-  function livePlacePlot(
-    snapshot,
-    focus,
-    place,
-    plot,
-    bubbles,
-    records,
-    interactionThings,
-    detailed,
-    focused,
-  ) {
+  function livePlacePlot(renderContext, place, plot, detailed, focused) {
+    const { snapshot, focus } = renderContext
     const card = element('article', 'live-plot')
     card.dataset.placeId = String(place.id)
     card.dataset.livePlotX = String(plot.x)
@@ -7250,8 +7534,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
     card.dataset.undrawn = 'false'
     card.dataset.placeKind = focus.parent_id === null ? 'continent' : 'place'
     card.append(open)
-    if (detailed || focused) mountLivePlaceDetail(
-      card, snapshot, focus, place, bubbles, records, interactionThings)
+    if (detailed || focused) mountLivePlaceDetail(card, renderContext, place)
     return card
   }
 
@@ -7273,7 +7556,16 @@ ${WINDOW_CLIENT_SAFETY_JS}
         if (!residentsExpanded && !thingsExpanded) return []
         const residentHeight = residentsExpanded
           ? Math.max(320, windowLiveScatterSurfaceHeight(
-              0, 480, residentsAt(state.snapshot, plot.id).length, 56, 56, 6))
+              0,
+              480,
+              residentsAt(state.snapshot, plot.id).length + Math.min(
+                LIVE_PORTRAIT_LIMIT,
+                Object.keys(liveResidentPointsByPlaceId[String(plot.id)] || {}).length,
+              ),
+              56,
+              56,
+              6,
+            ))
           : 0
         const things = thingsExpanded
           ? liveDisplayedThings(state.snapshot, plot.id, parentId, true)
@@ -7465,16 +7757,42 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }) : null
   }
 
-  function liveReplayPoint(placeId, focus, children) {
-    const anchor = livePlaceAnchor(placeId, focus.id, children)
+  function liveReplayPoint(placeId, focus, children, renderContext = null) {
+    const anchor = livePlaceAnchor(placeId, focus.id, children, renderContext)
     return liveAnchorPoint(anchor, focus.id, children)
   }
 
-  function liveReplayMoveGeometry(record, snapshot, focus, children) {
+  function liveReplayMoveGeometry(
+    record,
+    snapshot,
+    focus,
+    children,
+    renderContext = null,
+    cacheable = true,
+  ) {
+    if (renderContext && cacheable) {
+      return renderContext.remember(
+        'move-geometry:' + liveTraceKey(record),
+        () => liveReplayMoveGeometry(
+          record, snapshot, focus, children, renderContext, false),
+      )
+    }
     const from = liveResidentReplayPoint(
-      snapshot, record.detail.from_place_id, record.actor, focus, children)
+      snapshot,
+      record.detail.from_place_id,
+      record.actor,
+      focus,
+      children,
+      renderContext,
+    )
     const to = liveResidentReplayPoint(
-      snapshot, record.detail.to_place_id, record.actor, focus, children)
+      snapshot,
+      record.detail.to_place_id,
+      record.actor,
+      focus,
+      children,
+      renderContext,
+    )
     if (!from || !to || (from.x === to.x && from.y === to.y)) return null
     return Object.freeze({ from, to })
   }
@@ -7504,6 +7822,10 @@ ${WINDOW_CLIENT_SAFETY_JS}
     const replayReadyAtByActor = { ...state.live.replayReadyAtByActor }
     const focus = state.snapshot ? liveFocusPlace(state.snapshot) : null
     const children = focus && state.snapshot ? liveChildren(state.snapshot, focus) : []
+    const renderContext = livePlotDetailContext?.snapshot === state.snapshot &&
+      livePlotDetailContext.focus.id === focus?.id
+      ? livePlotDetailContext
+      : null
     const now = Date.now()
     const absorptionDeadlines = new Map()
     let changed = false
@@ -7511,7 +7833,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const held = active[completion.actor]
       if (!held || held.key !== completion.key) continue
       const absorbingPlaceId = held.type === 'move' && focus
-        ? livePlaceAnchor(held.toPlaceId, focus.id, children)
+        ? livePlaceAnchor(held.toPlaceId, focus.id, children, renderContext)
         : null
       delete active[completion.actor]
       if (held.type === 'move') {
@@ -7524,7 +7846,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         }
       }
       if (!state.live.replayQueues[completion.actor]?.length) {
-        delete positions[completion.actor]
+        if (!absorbingPlaceId) delete positions[completion.actor]
         delete replayReadyAtByActor[completion.actor]
       } else {
         const pendingCount = Object.values(state.live.replayQueues)
@@ -7551,29 +7873,57 @@ ${WINDOW_CLIENT_SAFETY_JS}
     } }
     if (state.view === 'live' && state.snapshot) renderLive(state.snapshot)
     for (const [placeId, absorptionEndsAt] of absorptionDeadlines) {
+      const absorbedActors = Object.entries(positions)
+        .filter(([actor, placeIdAtRest]) =>
+          !active[actor] &&
+          !state.live.replayQueues[actor]?.length &&
+          livePlaceAnchor(
+            placeIdAtRest, focus.id, children, renderContext) === Number(placeId))
+        .map(([actor]) => actor)
       window.setTimeout(() => {
         if (state.live.absorptionEndsAtByPlaceId[placeId] !== absorptionEndsAt) return
         const remaining = { ...state.live.absorptionEndsAtByPlaceId }
+        const remainingPositions = { ...state.live.replayPositions }
         delete remaining[placeId]
+        for (const actor of absorbedActors) {
+          if (!state.live.replayActive[actor] &&
+              !state.live.replayQueues[actor]?.length) delete remainingPositions[actor]
+        }
         state = { ...state, live: {
           ...state.live,
           absorptionEndsAtByPlaceId: Object.freeze(remaining),
+          replayPositions: Object.freeze(remainingPositions),
         } }
         if (state.view === 'live' && state.snapshot) renderLive(state.snapshot)
       }, LIVE_ABSORPTION_MS)
     }
   }
 
-  function liveReplayThingIsDisplayed(record, snapshot, focus, children) {
+  function liveReplayThingIsDisplayed(
+    record,
+    snapshot,
+    focus,
+    children,
+    renderContext = null,
+  ) {
     if (liveRecordType(record) !== 'use') return false
     const placeId = record.detail.place_id
-    const anchorId = livePlaceAnchor(placeId, focus.id, children)
+    const anchorId = livePlaceAnchor(placeId, focus.id, children, renderContext)
     if (!anchorId) return false
     const includeDescendants = anchorId !== focus.id
-    const records = visibleLiveRecords(snapshot, focus, children)
-    const interactionThings = liveFocusInteractionThings(snapshot, focus, records)
+    const records = renderContext?.records || visibleLiveRecords(
+      snapshot, focus, children, renderContext)
+    const interactionThings = renderContext?.interactionThings ||
+      liveFocusInteractionThings(snapshot, focus, records)
     const presentation = liveThingPresentation(
-      snapshot, anchorId, records, focus.id, includeDescendants, interactionThings)
+      snapshot,
+      anchorId,
+      records,
+      focus.id,
+      includeDescendants,
+      interactionThings,
+      renderContext,
+    )
     const matches = thing => thing.id === record.detail.source_thing_id &&
       (thing.place_id === placeId || thing.recorded_place_id === placeId)
     return presentation.selection.visible.some(matches) ||
@@ -7595,6 +7945,11 @@ ${WINDOW_CLIENT_SAFETY_JS}
     const focus = liveFocusPlace(state.snapshot)
     if (!focus) return
     const children = liveChildren(state.snapshot, focus)
+    const renderContext = livePlotDetailContext?.snapshot === state.snapshot &&
+      livePlotDetailContext.focus.id === focus.id
+      ? livePlotDetailContext
+      : null
+    const residentIndex = liveRenderResidentIndex(state.snapshot, renderContext)
     const now = Date.now()
     const queues = Object.fromEntries(Object.entries(state.live.replayQueues)
       .map(([actor, queue]) => [actor, [...queue]]))
@@ -7658,7 +8013,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
         const record = queue[0]
         const type = liveRecordType(record)
         const key = liveTraceKey(record)
-        const point = liveReplayPoint(liveRecordPlaceId(record), focus, children)
+        const point = liveReplayPoint(
+          liveRecordPlaceId(record), focus, children, renderContext)
         if (type === 'note' && point) {
           const noteId = record.detail.note_id
           const entry = state.live.noteBodies[String(noteId)]
@@ -7670,10 +8026,10 @@ ${WINDOW_CLIENT_SAFETY_JS}
         }
 
         if (type === 'move') {
-          const resident = displayedResidents(state.snapshot)
-            .find(candidate => candidate.handle === actor)
+          const resident = residentIndex.residentByHandle(actor)
           const geometry = resident
-            ? liveReplayMoveGeometry(record, state.snapshot, focus, children)
+            ? liveReplayMoveGeometry(
+                record, state.snapshot, focus, children, renderContext)
             : null
           if (!geometry) {
             queue = queue.slice(1)
@@ -7720,7 +8076,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
         changed = true
         revealed.add(key)
         const canReplayHere = point && (type !== 'use' ||
-          liveReplayThingIsDisplayed(record, state.snapshot, focus, children))
+          liveReplayThingIsDisplayed(
+            record, state.snapshot, focus, children, renderContext))
         if (!canReplayHere) continue
         const naturalDuration = type === 'note' ? LIVE_NOTE_REPLAY_MS : LIVE_PULSE_MS
         const ordinaryDurationCap = longestActorQueue > 1
@@ -7776,17 +8133,27 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }
   }
 
-  function renderLiveReplayPortraits(layer, snapshot, focus, children, bubbles) {
+  function renderLiveReplayPortraits(
+    layer,
+    snapshot,
+    focus,
+    children,
+    bubbles,
+    renderContext = null,
+  ) {
+    const residentIndex = liveRenderResidentIndex(snapshot, renderContext)
     for (const [actor, placeId] of Object.entries(state.live.replayPositions)) {
       if (state.resident && actor !== state.resident) continue
-      const resident = displayedResidents(snapshot).find(candidate => candidate.handle === actor)
+      const resident = residentIndex.residentByHandle(actor)
       if (!resident) continue
       const held = state.live.replayActive[actor]
-      let point = liveResidentReplayPoint(snapshot, placeId, actor, focus, children)
+      let point = liveResidentReplayPoint(
+        snapshot, placeId, actor, focus, children, renderContext)
       let destination = null
       let remaining = 0
       if (held?.type === 'move') {
-        const geometry = liveReplayMoveGeometry(held.record, snapshot, focus, children)
+        const geometry = liveReplayMoveGeometry(
+          held.record, snapshot, focus, children, renderContext)
         if (!geometry) continue
         const progress = Math.max(0, Math.min(1,
           (Date.now() - held.startedAt) / held.duration))
@@ -7838,7 +8205,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }
   }
 
-  function visibleLiveRecords(snapshot, focus, children) {
+  function visibleLiveRecords(snapshot, focus, children, renderContext = null) {
     const now = Date.now()
     return liveRecords().filter(record => {
       const type = liveRecordType(record)
@@ -7848,11 +8215,14 @@ ${WINDOW_CLIENT_SAFETY_JS}
       }
       if (type === 'move') {
         return Boolean(
-          livePlaceAnchor(record.detail.from_place_id, focus.id, children) ||
-          livePlaceAnchor(record.detail.to_place_id, focus.id, children)
+          livePlaceAnchor(
+            record.detail.from_place_id, focus.id, children, renderContext) ||
+          livePlaceAnchor(
+            record.detail.to_place_id, focus.id, children, renderContext)
         )
       }
-      return Boolean(livePlaceAnchor(liveRecordPlaceId(record), focus.id, children))
+      return Boolean(livePlaceAnchor(
+        liveRecordPlaceId(record), focus.id, children, renderContext))
     })
   }
 
@@ -7911,7 +8281,15 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }, Math.max(0, nextExpiry - Date.now()) + 1)
   }
 
-  function renderLiveTraceLayer(snapshot, focus, children, records, bubbles, survey) {
+  function renderLiveTraceLayer(
+    snapshot,
+    focus,
+    children,
+    records,
+    bubbles,
+    survey,
+    renderContext = null,
+  ) {
     const layer = element('div', 'live-trace-layer')
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
     svg.classList.add('live-traces')
@@ -7948,7 +8326,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
         record.at.getTime(), Date.now(), liveRecordLifetime(record))
       if (type === 'move') {
         if (!trailKeys.has(key)) continue
-        const geometry = liveReplayMoveGeometry(record, snapshot, focus, children)
+        const geometry = liveReplayMoveGeometry(
+          record, snapshot, focus, children, renderContext)
         const from = geometry?.from
         const to = geometry?.to
         if (!from || !to || (from.x === to.x && from.y === to.y)) continue
@@ -7979,7 +8358,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         continue
       }
       const placeId = liveRecordPlaceId(record)
-      const anchor = livePlaceAnchor(placeId, focus.id, children)
+      const anchor = livePlaceAnchor(placeId, focus.id, children, renderContext)
       const point = liveAnchorPoint(anchor, focus.id, children)
       if (!point) continue
       if (type === 'note') {
@@ -7992,6 +8371,10 @@ ${WINDOW_CLIENT_SAFETY_JS}
         mark.style.opacity = String(recordOpacity)
         mark.setAttribute('aria-label', 'Show ' + record.actor + "'s note in the plate ledger")
         bindLiveHighlight(mark, key, 'mark')
+        const bubble = bubbles.get(record.actor)
+        if (liveMotionReduced() && bubble?.record === record) {
+          mark.append(liveSpeechBubbleNode(bubble))
+        }
         layer.append(mark)
       } else if (type === 'make' && state.live.replayActive[record.actor]?.key === key) {
         const pulse = element('span', 'live-action-mark live-pulse', type === 'make' ? '+' : '×')
@@ -8006,7 +8389,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
       }
     }
     layer.prepend(svg)
-    renderLiveReplayPortraits(layer, snapshot, focus, children, bubbles)
+    renderLiveReplayPortraits(
+      layer, snapshot, focus, children, bubbles, renderContext)
     return layer
   }
 
@@ -8538,18 +8922,27 @@ ${WINDOW_CLIENT_SAFETY_JS}
     const thingFilters = liveThingFilters(focus.id)
     const thingsPage = historyEntry('things', thingFilters)
     const children = liveChildren(snapshot, focus)
-    const records = visibleLiveRecords(snapshot, focus, children)
+    const survey = liveStageSurvey(livePlaceRows(snapshot), focus.id)
+    const renderContextBase = liveCreateRenderContext(snapshot, focus, children, survey)
+    const records = visibleLiveRecords(snapshot, focus, children, renderContextBase)
     const interactionThings = liveFocusInteractionThings(snapshot, focus, records)
     const bubbles = liveSpeechBubbles(records)
-    const survey = liveStageSurvey(livePlaceRows(snapshot), focus.id)
     const directResidents = displayedResidents(snapshot).filter(resident =>
       resident.current_place_id === focus.id &&
       (!state.resident || resident.handle === state.resident))
+    const renderContext = Object.freeze({
+      ...renderContextBase,
+      records,
+      interactionThings,
+      bubbles,
+    })
+    livePlotDetailContext = renderContext
     const stageId = String(focus.id)
     const stageChanged = liveCamera.stageId !== stageId
+    let defaultCenterTarget = null
     if (stageChanged && nodes.liveViewport) {
-      const target = liveDefaultCenterTarget(snapshot, focus, survey)
-      const centered = liveCameraForStageTarget(target, true)
+      defaultCenterTarget = liveDefaultCenterTarget(snapshot, focus, survey, renderContext)
+      const centered = liveCameraForStageTarget(defaultCenterTarget, true)
       if (centered) {
         liveCamera = Object.freeze({
           ...liveCamera,
@@ -8562,11 +8955,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
     }
     const detailedPlotIds = liveDetailedPlotIds(survey.plots, survey.expandedGrounds)
     const focusedPlotIds = liveFocusedPlotIds(
-      snapshot, focus, children, records, interactionThings)
-    livePlotDetailContext = Object.freeze({
-      snapshot, focus, children, bubbles, records, interactionThings,
-      expandedGrounds: survey.expandedGrounds,
-    })
+      snapshot, focus, children, records, interactionThings, renderContext)
     renderLiveBreadcrumbs(snapshot, focus)
 
     nodes.liveStage.style.setProperty('--live-stage-width', String(survey.width) + 'px')
@@ -8609,8 +8998,12 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const place = children.find(candidate => candidate.id === plot.id)
       if (place) {
         plateParts.push(livePlacePlot(
-          snapshot, focus, place, plot, bubbles, records, interactionThings,
-          detailedPlotIds.has(plot.id), focusedPlotIds.includes(plot.id)))
+          renderContext,
+          place,
+          plot,
+          detailedPlotIds.has(plot.id),
+          focusedPlotIds.includes(plot.id),
+        ))
       }
     }
     const proofLoad = liveProofLoadNode(focus, survey)
@@ -8623,10 +9016,11 @@ ${WINDOW_CLIENT_SAFETY_JS}
         focus.id,
         livePinnedResidentIds(snapshot, records, focus.id),
         'live-walker-layer live-root-walkers',
+        renderContext,
       ))
     }
     const focusShelf = liveThingShelf(
-      snapshot, focus, records, focus.id, false, interactionThings)
+      snapshot, focus, records, focus.id, false, interactionThings, renderContext)
     if (focusShelf) {
       focusShelf.classList.add('live-focus-thing-shelf', 'live-root-thing-shelf')
       plateParts.push(focusShelf)
@@ -8637,7 +9031,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
           ? 'No smaller public places are drawn inside this room.'
           : 'Nobody is here right now. The room keeps its things.'))
     }
-    plateParts.push(renderLiveTraceLayer(snapshot, focus, children, records, bubbles, survey))
+    plateParts.push(renderLiveTraceLayer(
+      snapshot, focus, children, records, bubbles, survey, renderContext))
     nodes.livePlates.replaceChildren(...plateParts)
     scheduleLiveResidentLabels(true)
     scheduleLiveTrailExpiry()
@@ -8647,12 +9042,17 @@ ${WINDOW_CLIENT_SAFETY_JS}
       const preferredKey = state.live.focusResident
         ? 'resident:' + state.live.focusResident
         : state.live.raisedItemKey
+      const preferredTargets = preferredKey
+        ? [...nodes.livePlates.querySelectorAll(
+            '[data-live-item-key="' + CSS.escape(preferredKey) + '"]')]
+        : []
       const firstPaintTargets = state.live.proofScene && state.live.proofFailure
         ? [...nodes.livePlates.querySelectorAll('[data-focus-key="live-proof-retry"]')]
-        : preferredKey
-          ? [...nodes.livePlates.querySelectorAll(
-              '[data-live-item-key="' + CSS.escape(preferredKey) + '"]')]
-          : liveRevealTargetsForPlace(focus.id)
+        : preferredTargets.length
+          ? preferredTargets
+          : defaultCenterTarget?.preservesChildDetail
+            ? liveChildDetailRevealTargets(defaultCenterTarget)
+            : liveRevealTargetsForPlace(focus.id)
       revealLiveElements(firstPaintTargets)
     }
     renderLiveLedger(snapshot, focus, children, records)


### PR DESCRIPTION
## Summary
- keep crowded Live View expansion responsive with one render-scoped layout and stable resident/thing positions
- pace extreme multi-page activity by settling older records, replaying the newest 200 in order, and preserving complete current state/history
- frame First Town on useful child places when the ordinary home view would mount none, while preserving valid focus/raised targets
- keep reduced-motion speech accessible without moving unrelated residents

## Proof
- exact 167-resident Show-more: all residents inline, no dialog or extra reads, stable coordinates
- exact 1,600-record / 217-place stress: all eight pages requested; 1,400 caught up; exact replay suffix change:2401..change:2600; zero portraits after 2 seconds; all 1,600 current/history outcomes preserved
- place-map builds 17,820 -> 7; place-row visits 3,902,580 -> 1,533
- First Town desktop/mobile initial and Center each show mounted, safely openable child places at scale 1
- Live E2E 63/63; Live unit 45/45; typecheck; diff check; npm audit 0 vulnerabilities

## Scope
Two files only. No schema, migration, API, payment, identity, or documentation contract change.