### PR TITLE
fix: read thing upgrade body once

### DIFF
--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -305,6 +305,7 @@ export function parseDrawingVariants(value: unknown): DrawingVariantsParseResult
 export async function readBoundedJsonObject(
   request: Request,
   maximumBytes: number,
+  options: Readonly<{ allowEmpty?: boolean }> = {},
 ): Promise<BoundedJsonResult> {
   // Hand-driving request.body's reader never resolves on Vercel's Node
   // bridge (the PR #115 class) — only the framework read is safe, with the
@@ -320,6 +321,9 @@ export async function readBoundedJsonObject(
       ok: false,
       error: `body must be no larger than ${maximumBytes} UTF-8 bytes`,
     })
+  }
+  if (bytes.byteLength === 0 && options.allowEmpty) {
+    return Object.freeze({ ok: true, body: Object.freeze({}) as Record<string, unknown> })
   }
 
   let value: unknown

--- a/src/world.ts
+++ b/src/world.ts
@@ -195,15 +195,7 @@ function drawingVariantName(value: unknown): string | null | 'invalid' {
 }
 
 async function optionalDrawingBody(request: Request): Promise<BoundedJsonResult> {
-  try {
-    const bytes = new Uint8Array(await request.clone().arrayBuffer())
-    if (bytes.byteLength === 0) {
-      return Object.freeze({ ok: true as const, body: Object.freeze({}) as Record<string, unknown> })
-    }
-  } catch {
-    return Object.freeze({ ok: false as const, error: 'body could not be read' })
-  }
-  return await readBoundedJsonObject(request, DRAWING_RECORD_BODY_MAX_BYTES)
+  return await readBoundedJsonObject(request, DRAWING_RECORD_BODY_MAX_BYTES, { allowEmpty: true })
 }
 
 function publicPlaceWriteRow(row: PlaceRow): Readonly<Record<string, unknown>> {

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -5663,6 +5663,44 @@ test('things pin their birth revision and only their owner may voluntarily upgra
   })
 })
 
+test('thing upgrade reads an empty body once while required thing edit still rejects it', async () => {
+  reset({
+    scenario: 'thing revision',
+    thingOwnerId: 7,
+    thingKindId: 3,
+    thingCurrentRevision: 1,
+    kindRevision: 2,
+  })
+  const request = new Request('http://localhost/api/thing/41/upgrade', {
+    method: 'POST',
+    headers: authHeaders(),
+  })
+  const readBody = request.arrayBuffer.bind(request)
+  let bodyReads = 0
+  Object.defineProperty(request, 'arrayBuffer', {
+    value: async () => {
+      bodyReads += 1
+      return await readBody()
+    },
+  })
+  Object.defineProperty(request, 'clone', {
+    value: () => {
+      throw new Error('thing upgrade must not clone its request body')
+    },
+  })
+
+  const response = await app.request(request)
+  assert.equal(response.status, 200, await response.clone().text())
+  assert.equal(bodyReads, 1)
+
+  const requiredEdit = await app.request('/api/thing/41', {
+    method: 'PATCH',
+    headers: authHeaders(),
+  })
+  assert.equal(requiredEdit.status, 400)
+  assert.deepEqual(await requiredEdit.json(), { error: 'body must be a JSON object' })
+})
+
 test('a typed thing owner deliberately selects base or a named variant on its pinned revision', async () => {
   const variants = [{
     name: 'ember',


### PR DESCRIPTION
## Summary
- fix the production `POST /api/thing/:id/upgrade` hang at its request boundary
- read the optional upgrade body once instead of reading a cloned request and then the original
- keep empty bodies valid only for upgrade; required-body routes still reject them

## Root cause
Vercel's Node request bridge does not complete the cloned-body read used by `optionalDrawingBody`. Authentication completed in 0.22s, the exact database auth update completed in 91ms under rollback, and no lock or database activity existed while the request hung. An invalid upgrade body also hung before the first thing query, isolating the double body read.

## Proof
- RED: a clone-forbidden empty upgrade returned 400 `body could not be read`
- GREEN: the same upgrade returns 200 with exactly one `arrayBuffer` read and no clone
- focused route and drawing tests: 18/18
- `npm run typecheck`
- `git diff --check`

No migrations or contract changes.