### PR TITLE
fix: isolate child processes from Git hook environment

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -64,6 +64,11 @@ bar for payment-path changes.
 
 ## Gotchas that have bitten before
 
+- Git hooks export repository-scoping `GIT_*` variables. The test runner strips
+  all of them before starting suites, and any test or script that starts Git or
+  npm must pass `withoutInheritedGitEnvironment()` from
+  `scripts/child-process-environment.ts` to the child. `cwd` alone does not
+  isolate a nested repository from an inherited Git environment.
 - `/api/window` keeps a 30-second module cache. A test that warms it must
   backdate `Date.now` or every later test in the process reads poisoned data.
 - Fakes don't validate SQL (see layer 1). Postgres suites are the authority.

--- a/scripts/child-process-environment.ts
+++ b/scripts/child-process-environment.ts
@@ -1,0 +1,7 @@
+export function withoutInheritedGitEnvironment(
+  environment: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(environment).filter(([name]) => !/^GIT_/iu.test(name)),
+  )
+}

--- a/scripts/export-public-snapshot.ts
+++ b/scripts/export-public-snapshot.ts
@@ -11,6 +11,7 @@ import {
   publicOfficialFacts,
   publicPhysicsFacts,
 } from '../src/public-reference-facts.ts'
+import { withoutInheritedGitEnvironment } from './child-process-environment.ts'
 
 const SNAPSHOT_ROLE = 'city_snapshot_export'
 const SNAPSHOT_VIEW_COLUMNS = Object.freeze(['class_name', 'record_id', 'sort_key', 'payload'])
@@ -62,6 +63,7 @@ function sourceCommitFromGit(): string {
   const commit = execFileSync('git', ['rev-parse', 'HEAD'], {
     cwd: new URL('..', import.meta.url),
     encoding: 'utf8',
+    env: withoutInheritedGitEnvironment(),
     windowsHide: true,
   }).trim()
   if (!/^[0-9a-f]{40}$/u.test(commit)) throw new Error('Git did not return a full lowercase source commit')

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -19,6 +19,7 @@ import {
   responseJson,
   verifyNeonDatabaseTarget,
 } from './database-target.ts'
+import { withoutInheritedGitEnvironment } from './child-process-environment.ts'
 
 export { publicSearchIndexRecoveryStatements } from './public-search-index-migration.ts'
 
@@ -162,6 +163,7 @@ type GitCommand = (args: readonly string[]) => string
 const directGitCommand: GitCommand = args => execFileSync('git', [...args], {
   cwd: new URL('..', import.meta.url),
   encoding: 'utf8',
+  env: withoutInheritedGitEnvironment(),
   windowsHide: true,
   shell: false,
 })

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { withoutInheritedGitEnvironment } from './child-process-environment.ts'
 
 const TEST_FILE_PATTERN = 'test/*.test.ts'
 const TEMPORARY_DIRECTORY_PREFIX = '1f3d9-test-suite-'
@@ -77,6 +78,7 @@ export function buildTestEnvironment(
   options: EnvironmentOptions = {},
 ): NodeJS.ProcessEnv {
   const platform = options.platform ?? process.platform
+  const inheritedEnvironment = withoutInheritedGitEnvironment(baseEnvironment)
   const replacedNames = new Set([
     'node_test_context',
     'temp',
@@ -85,7 +87,7 @@ export function buildTestEnvironment(
     ...(platform === 'win32' ? ['path'] : []),
   ])
   const retainedEnvironment = Object.fromEntries(
-    Object.entries(baseEnvironment).filter(
+    Object.entries(inheritedEnvironment).filter(
       ([key]) => !replacedNames.has(key.toLowerCase()),
     ),
   )
@@ -101,7 +103,7 @@ export function buildTestEnvironment(
     throw new Error('Git Bash directory is required to run tests on Windows')
   }
 
-  const existingPath = findEnvironmentValue(baseEnvironment, 'PATH')
+  const existingPath = findEnvironmentValue(inheritedEnvironment, 'PATH')
   const path = existingPath
     ? `${options.gitBashDirectory}${delimiter}${existingPath}`
     : options.gitBashDirectory
@@ -109,17 +111,11 @@ export function buildTestEnvironment(
   return { ...redirectedEnvironment, PATH: path }
 }
 
-function withoutGitHookEnvironment(environment: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  return Object.fromEntries(
-    Object.entries(environment).filter(([name]) => !name.startsWith('GIT_')),
-  )
-}
-
 function resolveGitBashDirectory(environment: NodeJS.ProcessEnv): string {
   const gitExecPath = execFileSync('git', ['--exec-path'], {
     cwd: tmpdir(),
     encoding: 'utf8',
-    env: withoutGitHookEnvironment(environment),
+    env: withoutInheritedGitEnvironment(environment),
   }).trim()
   const bashExecutable = resolve(gitExecPath, '..', '..', '..', 'bin', 'bash.exe')
 

--- a/test/deploy-safety.test.ts
+++ b/test/deploy-safety.test.ts
@@ -23,6 +23,7 @@ import {
   verifyPreviewDatabaseTarget,
   verifyProductionDatabaseTarget,
 } from '../scripts/migrate.ts'
+import { withoutInheritedGitEnvironment } from '../scripts/child-process-environment.ts'
 
 const deployScript = readFileSync(new URL('../scripts/deploy.sh', import.meta.url), 'utf8')
 const ciWorkflow = readFileSync(new URL('../.github/workflows/ci.yml', import.meta.url), 'utf8')
@@ -126,14 +127,6 @@ const paymentLateFinalityRecheckMigrationUrl = new URL(
   '../db/migrations/20260825_payment_late_finality_recheck.sql',
   import.meta.url,
 )
-
-function withoutGitHookEnvironment(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  const environment = { ...process.env }
-  for (const name of Object.keys(environment)) {
-    if (name.startsWith('GIT_')) delete environment[name]
-  }
-  return { ...environment, ...overrides }
-}
 
 function finalNonEmptyLine(output: string): string | undefined {
   return output
@@ -408,10 +401,11 @@ function createPreparationFixture(): PreparationFixture {
   const hooks = createPreparationFixtureRoot('1f3d9-deploy-hooks-')
   const bin = createPreparationFixtureRoot('1f3d9-deploy-bin-')
   const commandLog = join(bin, 'npm.log')
-  const gitEnvironment = withoutGitHookEnvironment({
+  const gitEnvironment = {
+    ...withoutInheritedGitEnvironment(),
     GIT_CONFIG_NOSYSTEM: '1',
     GIT_CONFIG_GLOBAL: 'NUL',
-  })
+  }
   const git = (...args: string[]) => execFileSync(
     'git',
     ['-c', `core.hooksPath=${hooks}`, '-C', root, ...args],
@@ -426,7 +420,7 @@ function createPreparationFixture(): PreparationFixture {
   const bashRemoteRoot = spawnSync('bash', ['-lc', 'pwd'], {
     cwd: remoteRoot,
     encoding: 'utf8',
-    env: withoutGitHookEnvironment(),
+    env: withoutInheritedGitEnvironment(),
   }).stdout.trim()
   mkdirSync(join(root, 'scripts'))
   mkdirSync(join(root, 'node_modules'))
@@ -452,12 +446,12 @@ function createPreparationFixture(): PreparationFixture {
   const bashBin = spawnSync('bash', ['-lc', 'pwd'], {
     cwd: bin,
     encoding: 'utf8',
-    env: withoutGitHookEnvironment(),
+    env: withoutInheritedGitEnvironment(),
   }).stdout.trim()
   const bashRoot = spawnSync('bash', ['-lc', 'pwd'], {
     cwd: root,
     encoding: 'utf8',
-    env: withoutGitHookEnvironment(),
+    env: withoutInheritedGitEnvironment(),
   }).stdout.trim()
   const wrapper = join(bin, 'run-prepare.sh')
   writeFileSync(wrapper, [
@@ -507,7 +501,7 @@ function createPreparationFixture(): PreparationFixture {
       ], {
         cwd: root,
         encoding: 'utf8',
-        env: withoutGitHookEnvironment(),
+        env: withoutInheritedGitEnvironment(),
       })
     },
     cleanup: () => {
@@ -524,7 +518,7 @@ test('manual deploy invocation fails closed with GitHub-to-Vercel guidance', t =
   const result = spawnSync('bash', ['scripts/deploy.sh'], {
     cwd: fixture.root,
     encoding: 'utf8',
-    env: withoutGitHookEnvironment(),
+    env: withoutInheritedGitEnvironment(),
   })
 
   assert.notEqual(result.status, 0)

--- a/test/embed-door.test.ts
+++ b/test/embed-door.test.ts
@@ -10,11 +10,13 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import test from 'node:test'
+import { withoutInheritedGitEnvironment } from '../scripts/child-process-environment.ts'
 
 const generatorPath = fileURLToPath(new URL('../scripts/embed-door.mjs', import.meta.url))
+const projectRoot = fileURLToPath(new URL('..', import.meta.url))
 
 const createFixture = (
   frontdoorDocument: string,
@@ -29,13 +31,20 @@ const createFixture = (
   return root
 }
 
-const runGenerator = (root: string) => spawnSync(process.execPath, [generatorPath], {
+const runGenerator = (
+  root: string,
+  environment: NodeJS.ProcessEnv = process.env,
+) => spawnSync(process.execPath, [generatorPath], {
   cwd: root,
   encoding: 'utf8',
+  env: withoutInheritedGitEnvironment(environment),
   windowsHide: true,
 })
 
-const runDoorCheck = (root: string) => {
+const runDoorCheck = (
+  root: string,
+  environment: NodeJS.ProcessEnv = process.env,
+) => {
   const command = process.platform === 'win32'
     ? process.env.ComSpec ?? 'cmd.exe'
     : 'npm'
@@ -46,9 +55,21 @@ const runDoorCheck = (root: string) => {
   return spawnSync(command, arguments_, {
     cwd: root,
     encoding: 'utf8',
+    env: withoutInheritedGitEnvironment(environment),
     windowsHide: true,
   })
 }
+
+const runGit = (
+  root: string,
+  arguments_: readonly string[],
+  environment: NodeJS.ProcessEnv = process.env,
+) => spawnSync('git', [...arguments_], {
+  cwd: root,
+  encoding: 'utf8',
+  env: withoutInheritedGitEnvironment(environment),
+  windowsHide: true,
+})
 
 test('embed-door regenerates the fenced published mirror without changing its wrapper', () => {
   const original = '# Wrapper\n\nKeep before.\n\n```\nSTALE COPY\n```\n\nKeep after.\n'
@@ -98,24 +119,61 @@ test('embed-door refuses invalid published mirror fences before writing outputs'
   }
 })
 
-test('door:check fails stale tracked mirrors clearly and passes synchronized mirrors', () => {
+test('door:check isolates nested Git from a poisoned parent while checking mirrors', () => {
   const original = '# Wrapper\n\n```\nOLD FRONT DOOR\n```\n'
   const root = createFixture(original, 'OLD FRONT DOOR\n')
+  const victimRoot = mkdtempSync(join(tmpdir(), '1f3d9-git-env-victim-'))
 
   try {
+    // The canary setup stays independent of the sanitizer under test, so a
+    // regression can target only this disposable repository.
+    const fixtureBaseEnvironment = Object.fromEntries(
+      Object.entries(process.env).filter(([name]) => !/^GIT_/iu.test(name)),
+    )
+    const victimGitDirectory = join(victimRoot, '.git')
+    mkdirSync(victimGitDirectory)
+    writeFileSync(join(victimGitDirectory, 'HEAD'), 'ref: refs/heads/main\n')
+    const victimConfig = join(victimGitDirectory, 'config')
+    writeFileSync(victimConfig, [
+      '[core]',
+      '\trepositoryformatversion = 0',
+      '\tbare = false',
+      '[test]',
+      '\tguard = untouched',
+      '',
+    ].join('\n'))
+    const victimConfigBefore = readFileSync(victimConfig, 'utf8')
+    const projectGitDirectory = runGit(projectRoot, [
+      'rev-parse',
+      '--path-format=absolute',
+      '--git-common-dir',
+    ])
+    assert.equal(projectGitDirectory.status, 0, projectGitDirectory.stderr)
+    const projectConfig = join(projectGitDirectory.stdout.trim(), 'config')
+    const projectConfigBefore = readFileSync(projectConfig, 'utf8')
+    const poisonedEnvironment = {
+      ...fixtureBaseEnvironment,
+      GIT_DIR: victimGitDirectory,
+      GIT_WORK_TREE: victimRoot,
+    }
+
     mkdirSync(join(root, 'scripts'))
     copyFileSync(generatorPath, join(root, 'scripts', 'embed-door.mjs'))
     copyFileSync(
       fileURLToPath(new URL('../package.json', import.meta.url)),
       join(root, 'package.json'),
     )
-    const initialGeneration = runGenerator(root)
+    const initialGeneration = runGenerator(root, poisonedEnvironment)
     assert.equal(initialGeneration.status, 0, initialGeneration.stderr)
-    assert.equal(spawnSync('git', ['init', '--quiet'], { cwd: root }).status, 0)
-    assert.equal(spawnSync('git', ['add', '.'], { cwd: root }).status, 0)
+    assert.equal(runGit(root, ['init', '--quiet'], poisonedEnvironment).status, 0)
+    assert.equal(runGit(root, ['add', '.'], poisonedEnvironment).status, 0)
+    assert.equal(existsSync(join(root, '.git')), true)
+    const fixtureTopLevel = runGit(root, ['rev-parse', '--show-toplevel'], poisonedEnvironment)
+    assert.equal(fixtureTopLevel.status, 0, fixtureTopLevel.stderr)
+    assert.equal(resolve(fixtureTopLevel.stdout.trim()), resolve(root))
 
     writeFileSync(join(root, 'src', 'frontdoor.txt'), 'NEW FRONT DOOR\n')
-    const staleCheck = runDoorCheck(root)
+    const staleCheck = runDoorCheck(root, poisonedEnvironment)
     assert.notEqual(staleCheck.status, 0)
     assert.match(
       `${staleCheck.stdout}${staleCheck.stderr}`,
@@ -123,21 +181,24 @@ test('door:check fails stale tracked mirrors clearly and passes synchronized mir
     )
 
     assert.equal(
-      spawnSync('git', [
+      runGit(root, [
         'add',
         'src/frontdoor.txt',
         'src/door.ts',
         'docs/published/FRONTDOOR.md',
-      ], { cwd: root }).status,
+      ], poisonedEnvironment).status,
       0,
     )
-    const synchronizedCheck = runDoorCheck(root)
+    const synchronizedCheck = runDoorCheck(root, poisonedEnvironment)
     assert.equal(
       synchronizedCheck.status,
       0,
       `${synchronizedCheck.stdout}${synchronizedCheck.stderr}`,
     )
+    assert.equal(readFileSync(victimConfig, 'utf8'), victimConfigBefore)
+    assert.equal(readFileSync(projectConfig, 'utf8'), projectConfigBefore)
   } finally {
     rmSync(root, { force: true, recursive: true })
+    rmSync(victimRoot, { force: true, recursive: true })
   }
 })

--- a/test/test-runner.test.ts
+++ b/test/test-runner.test.ts
@@ -17,6 +17,7 @@ import {
   parseTestRunnerArguments,
   withIsolatedTestEnvironment,
 } from '../scripts/run-tests.ts'
+import { withoutInheritedGitEnvironment } from '../scripts/child-process-environment.ts'
 
 const packageJson = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
@@ -92,6 +93,7 @@ test('isolated environment redirects every temp variable and prefers Git Bash on
     'C:\\suite-temp',
     {
       KEEP_ME: 'yes',
+      GIT_DIR: 'C:\\poisoned-git-dir',
       NODE_TEST_CONTEXT: 'child-v8',
       Path: 'C:\\Windows\\System32',
       TEMP: 'C:\\old-temp',
@@ -113,7 +115,30 @@ test('isolated environment redirects every temp variable and prefers Git Bash on
   )
   assert.equal(environment.Path, undefined)
   assert.equal(environment.NODE_TEST_CONTEXT, undefined)
+  assert.equal(environment.GIT_DIR, undefined)
   assert.equal(environment.KEEP_ME, 'yes')
+})
+
+test('child process environments drop every inherited Git variable without mutating the parent', () => {
+  const poisonedEnvironment = {
+    KEEP_ME: 'yes',
+    GIT_DIR: 'poisoned-dir',
+    GIT_WORK_TREE: 'poisoned-work-tree',
+    GIT_INDEX_FILE: 'poisoned-index',
+    GIT_OBJECT_DIRECTORY: 'poisoned-objects',
+    GIT_ALTERNATE_OBJECT_DIRECTORIES: 'poisoned-alternate-objects',
+    GIT_PREFIX: 'poisoned-prefix',
+    GIT_COMMON_DIR: 'poisoned-common-dir',
+    GIT_NAMESPACE: 'poisoned-namespace',
+    GIT_CEILING_DIRECTORIES: 'poisoned-ceiling',
+    Git_Future_Scope: 'poisoned-future-scope',
+  }
+  const originalEnvironment = { ...poisonedEnvironment }
+
+  assert.deepEqual(withoutInheritedGitEnvironment(poisonedEnvironment), {
+    KEEP_ME: 'yes',
+  })
+  assert.deepEqual(poisonedEnvironment, originalEnvironment)
 })
 
 function runOldDeployFixture(shouldFail: boolean): Readonly<{


### PR DESCRIPTION
## Summary

- add one immutable, case-insensitive child environment sanitizer that removes every inherited `GIT_*` variable
- use it for the test runner, every embed-door child, deploy-safety fixture children, migration Git checks, and snapshot-export Git checks
- document the rule for future Git/npm child processes

## Incident class closed

A Git hook can export repository-scoping variables such as `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE`. Child Git commands honor those variables before `cwd`, so a test intending to initialize a disposable repository can instead reinitialize or stage against the hook caller's real/shared repository. That is how `core.worktree` and indexes across linked worktrees can be poisoned.

The shared helper removes the entire inherited `GIT_*` class, including mixed-case names on Windows and future variables, rather than maintaining a fragile list. The regression test supplies a disposable poisoned parent repository, proves the nested repository is the fixture, and checks both the canary config and the real shared `--git-common-dir` config byte-for-byte.

Door embedding and stale/synchronized mirror behavior are unchanged.

## Verification

- `npm run typecheck` — pass
- `npm test` — 1,616 passed
- `npm run test:postgres` — 228 passed
- `npm run test:e2e` — 180 passed
- `npm run door:check` — pass
- `npm audit --audit-level=high` — 0 vulnerabilities
- `git diff --check` — pass
- independent code and security re-reviews — no findings
- tracked tree sanity — 410 files (409 baseline plus the shared helper)

The clean pushed candidate was verified by `scripts/deploy.sh --prepare`, but the release gate stopped before rerunning tests because this task cannot truthfully acknowledge the external `LATER_HOLDER_CURSOR_KEY` state in Vercel Preview and Production: `GATE_EXIT=1`. No readiness value was fabricated. No live-service run applies to this internal test-harness safety change.