### PR TITLE
fix: add Neon cleanup rehearsal

### DIFF
--- a/docs/runbooks/ENVIRONMENT.md
+++ b/docs/runbooks/ENVIRONMENT.md
@@ -28,6 +28,11 @@ The public repository's weekly `Cost tripwire` workflow reads provider metadata 
 never receives application or database credentials. Configure these values under
 **GitHub repository Settings → Secrets and variables → Actions**:
 
+Before adding `NEON_API_KEY` to GitHub, set it and `NEON_PROJECT_ID` in your shell and
+rehearse once with a real closed PR's head ref: `node --experimental-strip-types
+scripts/neon-preview-cleanup.ts --dry-run --head-ref "feature/cost-safe"`. The rehearsal
+lists and re-proves the exact Neon branch but makes no delete call.
+
 | Kind | Name | Purpose |
 |---|---|---|
 | Secret | `VERCEL_TOKEN` | Vercel access token allowed to read the team's FOCUS billing charges. |

--- a/scripts/cost-tripwire.ts
+++ b/scripts/cost-tripwire.ts
@@ -1,6 +1,7 @@
 import { appendFile, readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { resolve } from 'node:path'
+import { safeErrorDetail } from './safe-error-detail.ts'
 
 const ALERT_MULTIPLIER = 3
 const MAX_RESPONSE_BYTES = 5 * 1024 * 1024
@@ -213,11 +214,6 @@ export function compareCostMetrics(input: Readonly<{
   })
 }
 
-function safeDetail(error: unknown): string {
-  const raw = error instanceof Error ? error.message : 'unknown error'
-  return raw.replace(/[\r\n\x00-\x1f]+/gu, ' ').replace(/https?:\/\/\S+/gu, '[URL redacted]').slice(0, 240)
-}
-
 async function readBoundedResponse(response: Response, provider: string): Promise<string> {
   const declared = Number(response.headers.get('content-length') ?? 0)
   if (declared > MAX_RESPONSE_BYTES) throw new Error(`${provider} response exceeded size limit`)
@@ -383,7 +379,7 @@ export async function runCostTripwire(input: Readonly<{
     summary = summarizeFocusBilling(parseFocusBillingJsonl(text))
     statuses.push({ provider: 'Vercel', status: 'ok', detail: 'Seven complete UTC days read.' })
   } catch (error) {
-    statuses.push({ provider: 'Vercel', status: 'failed', detail: safeDetail(error) })
+    statuses.push({ provider: 'Vercel', status: 'failed', detail: safeErrorDetail(error) })
   }
 
   if (!environment.NEON_API_KEY || !environment.NEON_PROJECT_ID) {
@@ -393,7 +389,7 @@ export async function runCostTripwire(input: Readonly<{
     previewBranchCount = branches.filter(name => name.startsWith('preview/')).length
     statuses.push({ provider: 'Neon', status: 'ok', detail: 'All active branches read.' })
   } catch (error) {
-    statuses.push({ provider: 'Neon', status: 'failed', detail: safeDetail(error) })
+    statuses.push({ provider: 'Neon', status: 'failed', detail: safeErrorDetail(error) })
   }
 
   const comparison = compareCostMetrics({
@@ -434,7 +430,7 @@ function parseArguments(arguments_: readonly string[]): Readonly<{ dryRun: boole
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : ''
 if (invokedPath === fileURLToPath(import.meta.url)) {
   runCostTripwire(parseArguments(process.argv.slice(2))).catch(error => {
-    console.error(`Cost tripwire failed: ${safeDetail(error)}`)
+    console.error(`Cost tripwire failed: ${safeErrorDetail(error)}`)
     process.exitCode = 1
   })
 }

--- a/scripts/neon-preview-cleanup.ts
+++ b/scripts/neon-preview-cleanup.ts
@@ -1,6 +1,7 @@
 import { appendFile, readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { resolve } from 'node:path'
+import { safeErrorDetail } from './safe-error-detail.ts'
 
 type NeonBranch = Readonly<{ id: string; name: string; primary: boolean }>
 const SHARED_BRANCH = 'preview/shared-vercel-testing'
@@ -15,7 +16,6 @@ export function selectPreviewBranchForClosedPullRequest(
 ): Readonly<{ id: string; name: string }> | null {
   if (!headReference || /[\x00-\x1f]/u.test(headReference)) return null
   const expected = `preview/${headReference}`
-  if (expected === SHARED_BRANCH || expected === 'main' || !expected.startsWith('preview/')) return null
   const matches = branches.filter(branch => branch.name === expected)
   if (matches.length > 1) throw new Error('Multiple Neon branches match the closed pull request')
   const match = matches[0]
@@ -64,6 +64,8 @@ async function listBranches(projectId: string, token: string, fetcher: typeof fe
 }
 
 export async function runNeonPreviewCleanup(input: Readonly<{
+  dryRun?: boolean
+  headReference?: string
   environment?: NodeJS.ProcessEnv
   event?: unknown
   fetcher?: typeof fetch
@@ -83,19 +85,26 @@ export async function runNeonPreviewCleanup(input: Readonly<{
     await writeSummary('Neon preview cleanup: SKIPPED — NEON_API_KEY or NEON_PROJECT_ID is absent.')
     return
   }
-  if (!input.event && !eventPath) throw new Error('GITHUB_EVENT_PATH is absent')
-  const event: unknown = input.event ?? JSON.parse(await readFile(eventPath!, 'utf8'))
-  const pullRequest = isObject(event) && isObject(event.pull_request) ? event.pull_request : undefined
-  const head = pullRequest && isObject(pullRequest.head) ? pullRequest.head : undefined
-  const headReference = head?.ref
-  if (typeof headReference !== 'string') throw new Error('Closed pull request head ref is absent')
-  const headRepository = head && isObject(head.repo) ? head.repo.full_name : undefined
-  if (typeof environment.GITHUB_REPOSITORY !== 'string' || typeof headRepository !== 'string') {
-    throw new Error('Closed pull request repository identity is absent')
+  if (input.headReference !== undefined && !input.dryRun) {
+    throw new Error('A direct head ref is allowed only in rehearsal mode')
   }
-  if (headRepository !== environment.GITHUB_REPOSITORY) {
-    await writeSummary('Neon preview cleanup: SKIPPED — the closed PR came from a fork.')
-    return
+
+  let headReference = input.headReference
+  if (headReference === undefined) {
+    if (!input.event && !eventPath) throw new Error('GITHUB_EVENT_PATH is absent')
+    const event: unknown = input.event ?? JSON.parse(await readFile(eventPath!, 'utf8'))
+    const pullRequest = isObject(event) && isObject(event.pull_request) ? event.pull_request : undefined
+    const head = pullRequest && isObject(pullRequest.head) ? pullRequest.head : undefined
+    headReference = typeof head?.ref === 'string' ? head.ref : undefined
+    if (headReference === undefined) throw new Error('Closed pull request head ref is absent')
+    const headRepository = head && isObject(head.repo) ? head.repo.full_name : undefined
+    if (typeof environment.GITHUB_REPOSITORY !== 'string' || typeof headRepository !== 'string') {
+      throw new Error('Closed pull request repository identity is absent')
+    }
+    if (headRepository !== environment.GITHUB_REPOSITORY) {
+      await writeSummary('Neon preview cleanup: SKIPPED — the closed PR came from a fork.')
+      return
+    }
   }
 
   const target = selectPreviewBranchForClosedPullRequest(headReference, await listBranches(projectId, token, fetcher))
@@ -117,6 +126,11 @@ export async function runNeonPreviewCleanup(input: Readonly<{
     throw new Error('Neon branch changed before deletion; refusing cleanup')
   }
 
+  if (input.dryRun) {
+    await writeSummary(`Neon preview cleanup: would have deleted ${target.name}; nothing was deleted.`)
+    return
+  }
+
   const deleteResponse = await request(branchUrl, token, fetcher, { method: 'DELETE' })
   if (deleteResponse.status === 404) {
     await writeSummary(`Neon preview cleanup: ${target.name} was already absent during deletion.`)
@@ -128,11 +142,23 @@ export async function runNeonPreviewCleanup(input: Readonly<{
   await writeSummary(`Neon preview cleanup: requested deletion of ${target.name}.`)
 }
 
+export function parseNeonPreviewCleanupArguments(arguments_: readonly string[]): Readonly<{
+  dryRun: true
+  headReference: string
+}> {
+  if (arguments_.length === 3 && arguments_[0] === '--dry-run' &&
+      arguments_[1] === '--head-ref' && arguments_[2]) {
+    return Object.freeze({ dryRun: true, headReference: arguments_[2] })
+  }
+  throw new Error('Usage: node --experimental-strip-types scripts/neon-preview-cleanup.ts --dry-run --head-ref <closed-pr-head-ref>')
+}
+
 const invokedPath = process.argv[1] ? resolve(process.argv[1]) : ''
 if (invokedPath === fileURLToPath(import.meta.url)) {
-  runNeonPreviewCleanup().catch(error => {
-    const message = error instanceof Error ? error.message.replace(/[\r\n]+/gu, ' ').slice(0, 240) : 'unknown error'
-    const line = `Neon preview cleanup: FAILED — ${message}`
+  Promise.resolve().then(() => runNeonPreviewCleanup(
+    process.argv.length > 2 ? parseNeonPreviewCleanupArguments(process.argv.slice(2)) : undefined,
+  )).catch(error => {
+    const line = `Neon preview cleanup: FAILED — ${safeErrorDetail(error)}`
     const write = process.env.GITHUB_STEP_SUMMARY
       ? appendFile(process.env.GITHUB_STEP_SUMMARY, `${line}\n`)
       : Promise.resolve()

--- a/scripts/safe-error-detail.ts
+++ b/scripts/safe-error-detail.ts
@@ -1,0 +1,4 @@
+export function safeErrorDetail(error: unknown): string {
+  const raw = error instanceof Error ? error.message : 'unknown error'
+  return raw.replace(/[\r\n\x00-\x1f]+/gu, ' ').replace(/https?:\/\/\S+/gu, '[URL redacted]').slice(0, 240)
+}

--- a/test/cost-tripwire-workflows.test.ts
+++ b/test/cost-tripwire-workflows.test.ts
@@ -30,6 +30,7 @@ test('preview cleanup runs only for closed PRs and keeps secrets out of shell te
   assert.match(workflow, /NEON_API_KEY:\s*\$\{\{ secrets\.NEON_API_KEY \}\}/u)
   assert.match(workflow, /GITHUB_EVENT_PATH/u)
   assert.match(workflow, /neon-preview-cleanup/u)
+  assert.doesNotMatch(workflow, /neon-preview-cleanup[^\n]*--dry-run/u)
   assert.doesNotMatch(workflow, /github\.event\.pull_request\.head\.ref/u)
   assert.doesNotMatch(workflow, /run:[^\n]*(?:secrets\.|NEON_API_KEY)/u)
 })

--- a/test/neon-preview-cleanup.test.ts
+++ b/test/neon-preview-cleanup.test.ts
@@ -1,9 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  parseNeonPreviewCleanupArguments,
   runNeonPreviewCleanup,
   selectPreviewBranchForClosedPullRequest,
 } from '../scripts/neon-preview-cleanup.ts'
+import { safeErrorDetail } from '../scripts/safe-error-detail.ts'
 
 const branches = Object.freeze([
   Object.freeze({ id: 'br-main', name: 'main', primary: true }),
@@ -19,7 +21,10 @@ test('cleanup selects only the exact non-primary branch for the closed PR', () =
 })
 
 test('cleanup refuses protected, near-match, duplicate, and malformed targets', () => {
-  assert.equal(selectPreviewBranchForClosedPullRequest('shared-vercel-testing', branches), null)
+  assert.throws(
+    () => selectPreviewBranchForClosedPullRequest('shared-vercel-testing', branches),
+    /protected/i,
+  )
   assert.equal(selectPreviewBranchForClosedPullRequest('feature/cost', branches), null)
   assert.equal(selectPreviewBranchForClosedPullRequest('', branches), null)
   assert.throws(
@@ -59,6 +64,68 @@ test('cleanup proves the exact branch again before deleting by ID', async () => 
   assert.deepEqual(requests.map(value => value.method), ['GET', 'GET', 'DELETE'])
   assert.match(requests[2]!.url, /\/branches\/br-feature$/u)
   assert.deepEqual(logs, ['Neon preview cleanup: requested deletion of preview/feature/cost-safe.'])
+})
+
+test('rehearsal proves the exact branch but makes no DELETE request', async () => {
+  const requests: Array<{ url: string; method: string }> = []
+  const logs: string[] = []
+  await runNeonPreviewCleanup({
+    dryRun: true,
+    headReference: 'feature/cost-safe',
+    environment: { NEON_API_KEY: 'key', NEON_PROJECT_ID: 'project' },
+    log: line => { logs.push(line) },
+    fetcher: (async (input, init) => {
+      const method = init?.method ?? 'GET'
+      const url = String(input)
+      requests.push({ url, method })
+      if (url.endsWith('/branches?limit=100')) return new Response(JSON.stringify({
+        branches: [{ id: 'br-feature', name: 'preview/feature/cost-safe', primary: false }],
+        pagination: {},
+      }), { status: 200 })
+      return new Response(JSON.stringify({
+        branch: { id: 'br-feature', name: 'preview/feature/cost-safe', primary: false },
+      }), { status: 200 })
+    }) as typeof fetch,
+  })
+
+  assert.deepEqual(requests.map(value => value.method), ['GET', 'GET'])
+  assert.deepEqual(logs, [
+    'Neon preview cleanup: would have deleted preview/feature/cost-safe; nothing was deleted.',
+  ])
+})
+
+test('terminal arguments require rehearsal mode and one head ref', () => {
+  assert.deepEqual(
+    parseNeonPreviewCleanupArguments(['--dry-run', '--head-ref', 'feature/cost-safe']),
+    { dryRun: true, headReference: 'feature/cost-safe' },
+  )
+  for (const arguments_ of [
+    [],
+    ['--head-ref', 'feature/cost-safe'],
+    ['--dry-run'],
+    ['--dry-run', '--head-ref', 'feature/cost-safe', 'extra'],
+  ]) assert.throws(() => parseNeonPreviewCleanupArguments(arguments_), /usage/i)
+})
+
+test('a direct head ref can never select live deletion', async () => {
+  let requests = 0
+  await assert.rejects(runNeonPreviewCleanup({
+    headReference: 'feature/cost-safe',
+    environment: { NEON_API_KEY: 'key', NEON_PROJECT_ID: 'project' },
+    log: () => {},
+    fetcher: (async () => {
+      requests += 1
+      throw new Error('must not fetch')
+    }) as typeof fetch,
+  }), /only in rehearsal mode/i)
+  assert.equal(requests, 0)
+})
+
+test('shared error detail removes URLs and control characters', () => {
+  assert.equal(
+    safeErrorDetail(new Error('failed at https://example.test/path?token=secret\nnext line')),
+    'failed at [URL redacted] next line',
+  )
 })
 
 test('cleanup reports a DELETE race as already absent', async () => {


### PR DESCRIPTION
## Problem
The Neon preview cleanup could only be exercised destructively, so its first real-project selection would also be its first delete attempt. Its computed-name guard included impossible checks, and its top-level errors did not use the cost tripwire's URL/control-character redaction.

## Goal
Give operators a safe terminal rehearsal against a closed PR head ref while keeping the GitHub workflow destructive by default.

## Changes
- add `--dry-run --head-ref <ref>` rehearsal mode
- keep list, exact selection, and by-ID proof shared with live cleanup
- return before DELETE with an explicit nothing-was-deleted line
- reject direct head refs outside rehearsal mode
- remove the unreachable computed-name guard
- share one error-detail redactor between both cost scripts
- document the pre-secret rehearsal command

## Verification
- `npm run typecheck` — pass
- `npm test` — pass
- `npm run test:coverage` — pass
- independent code review — no findings
- independent security review — no findings
- no real Neon calls were made
- `bash scripts/deploy.sh --prepare` — stopped at the environment prerequisite `LATER_HOLDER_CURSOR_KEY`; `GATE_EXIT=1`