### PR TITLE
Fix mobile place roster text overlap

### DIFF
--- a/e2e/public-window.spec.ts
+++ b/e2e/public-window.spec.ts
@@ -51,6 +51,14 @@ async function copiedShareLinks(page: Page): Promise<readonly string[]> {
   ])
 }
 
+function boxesIntersect(
+  left: { readonly x: number; readonly y: number; readonly width: number; readonly height: number },
+  right: { readonly x: number; readonly y: number; readonly width: number; readonly height: number },
+): boolean {
+  return left.x < right.x + right.width && left.x + left.width > right.x &&
+    left.y < right.y + right.height && left.y + left.height > right.y
+}
+
 test('public window links to the dated public snapshot archive', async ({ page }) => {
   await page.goto('/window')
   const link = page.getByRole('link', { name: 'Public snapshots' })
@@ -134,6 +142,95 @@ test('public window shows lazy thumbnail portraits beside roster and room names'
   expect(thumbnailPaths).toContain('/api/drawing/resident/49/thumb.png?rev=9')
   expect(thumbnailPaths).toContain('/api/drawing/thing/401/thumb.png?rev=9')
   expect(thumbnailPaths).toContain('/api/drawing/kind/77/thumb.png?rev=9')
+})
+
+test('phone roster rows keep wrapping location text below names', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.route('**/api/window*', async route => {
+    const response = await route.fetch()
+    const body = await response.json() as {
+      readonly places?: ReadonlyArray<Record<string, unknown>>
+      readonly [key: string]: unknown
+    }
+    if (!body.places) {
+      await route.fulfill({ response })
+      return
+    }
+    await route.fulfill({
+      response,
+      json: {
+        ...body,
+        places: body.places.map(place => place.id === 11 ? {
+          ...place,
+          name: 'frontier valley / the corrigenda room / the long lantern gallery',
+        } : place),
+      },
+    })
+  })
+
+  await page.goto('/window/place/11')
+  await expect(page.locator('#window-status')).toContainText('Watching')
+
+  const placeRow = page.locator('#place-occupants .person-card')
+    .filter({ hasText: 'browser-resident' })
+  const placeHandle = placeRow.locator('.resident-follow')
+  const placeMeta = placeRow.locator('.resident-number')
+  await expect(placeRow).toBeVisible()
+  const [placeHandleBox, placeMetaBox] = await Promise.all([
+    placeHandle.boundingBox(),
+    placeMeta.boundingBox(),
+  ])
+  expect(placeHandleBox).not.toBeNull()
+  expect(placeMetaBox).not.toBeNull()
+  expect(boxesIntersect(placeHandleBox!, placeMetaBox!)).toBe(false)
+  expect(placeMetaBox!.y).toBeGreaterThanOrEqual(
+    placeHandleBox!.y + placeHandleBox!.height - 0.5,
+  )
+  expect(await placeMeta.evaluate(element => {
+    const range = document.createRange()
+    range.selectNodeContents(element)
+    return range.getClientRects().length
+  })).toBeGreaterThanOrEqual(2)
+
+  const placePortraitBox = await placeRow.locator('.entity-portrait').boundingBox()
+  expect(placePortraitBox).not.toBeNull()
+  expect(placePortraitBox!.y).toBeLessThan(placeHandleBox!.y + placeHandleBox!.height)
+  expect(placePortraitBox!.y + placePortraitBox!.height).toBeGreaterThan(placeHandleBox!.y)
+
+  const thing = page.locator('#place-things .thing-card').filter({ hasText: 'field_lantern' })
+  const [thingNameBox, thingMetaBox] = await Promise.all([
+    thing.locator('h4').boundingBox(),
+    thing.locator('.thing-meta').boundingBox(),
+  ])
+  expect(thingNameBox).not.toBeNull()
+  expect(thingMetaBox).not.toBeNull()
+  expect(boxesIntersect(thingNameBox!, thingMetaBox!)).toBe(false)
+  expect(thingMetaBox!.y).toBeGreaterThanOrEqual(thingNameBox!.y + thingNameBox!.height - 0.5)
+
+  await page.getByRole('tab', { name: 'Map', exact: true }).click()
+  const rosterRow = page.locator('#resident-roster .resident-row')
+    .filter({ hasText: 'browser-resident' })
+  await expect(rosterRow).toBeVisible()
+  const rosterMeta = rosterRow.locator('.resident-number')
+  await rosterMeta.evaluate(element => {
+    element.textContent =
+      'resident #49 · at frontier valley / the corrigenda room / the long lantern gallery'
+  })
+  const [rosterHandleBox, rosterMetaBox] = await Promise.all([
+    rosterRow.locator('.resident-follow').boundingBox(),
+    rosterMeta.boundingBox(),
+  ])
+  expect(rosterHandleBox).not.toBeNull()
+  expect(rosterMetaBox).not.toBeNull()
+  expect(boxesIntersect(rosterHandleBox!, rosterMetaBox!)).toBe(false)
+  expect(rosterMetaBox!.y).toBeGreaterThanOrEqual(
+    rosterHandleBox!.y + rosterHandleBox!.height - 0.5,
+  )
+  expect(await rosterMeta.evaluate(element => {
+    const range = document.createRange()
+    range.selectNodeContents(element)
+    return range.getClientRects().length
+  })).toBeGreaterThanOrEqual(2)
 })
 
 test('each visible view has one share button that copies its absolute clean URL', async ({ page }) => {

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -2269,6 +2269,21 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   .place-card > .place-watch { grid-column: 2; }
   .place-card > .place-owner { grid-column: 2; }
   .place-facts { grid-column: 1 / -1; grid-row: auto; text-align: start; }
+  .roster-group .resident-row, .person-card {
+    grid-template-columns: 2rem minmax(0, 1fr);
+    align-items: start;
+  }
+  .roster-group .resident-row > .entity-portrait,
+  .person-card > .entity-portrait { grid-column: 1; grid-row: 1 / span 2; }
+  .roster-group .resident-row > .resident-follow,
+  .person-card > .resident-follow { grid-column: 2; grid-row: 1; max-width: 100%; }
+  .roster-group .resident-row > .resident-number,
+  .person-card > .resident-number {
+    grid-column: 2;
+    grid-row: 2;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
   .archive-form { grid-template-columns: 1fr; }
   .archive-query-field { grid-column: auto; }
   .archive-card { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Problem
At phone widths, a long resident location path could take the grid's available width and overlap the resident handle.

## Fix
- Stack the handle above its meta line below 40rem for PLACE occupant cards and MAP roster rows.
- Keep the portrait beside the handle and allow long meta text to wrap safely.
- Leave desktop grid rules unchanged.
- Add a 390px Playwright regression covering PLACE, the reused MAP roster grammar, portrait alignment, and the already-stacked thing name/meta grammar.

## Verification
- `npm run typecheck` — passed
- `npm test` — passed (1,690 tests)
- `npx playwright test e2e/public-window.spec.ts` — passed (20 tests)
- `git diff --check` — passed
- Independent code re-review — no remaining findings
- `bash scripts/deploy.sh --prepare` — stopped at release prerequisites with `GATE_EXIT=1`: this fresh clone does not have the operator confirmations that `LATER_HOLDER_CURSOR_KEY` and the existing migrations were verified in Vercel Preview and Production. The gate verified the branch was clean and exactly pushed before stopping.

`docs/DECISIONS.md` is unchanged.