### PR TITLE
fix: gift accept/refuse hang on Vercel from touching c.req.raw.body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ A change is done when ALL of these are true, and not before:
 6. **Nothing new is dead or duplicated.** No unused exports, no logic remade
    that existed elsewhere, no abstraction with one caller, no option nothing
    varies. The simplest shape that fully works is the deliverable.
+7. **On the request path, read the body only through `c.req.text()`/
+   `json()`/`arrayBuffer()`, never touch `c.req.raw.body`, `.clone()`,
+   `.formData()`, or `c.req.parseBody()`** — even a presence check (`c.req.raw.body
+   == null`) makes @hono/node-server build a real Request whose body is
+   `Readable.toWeb(incoming)`, which never delivers on Vercel's Node runtime
+   and cannot be reproduced against a local Node server (the gift
+   accept/refuse hang; same root cause as market repo 1f3ea issue #39 / PR #40).
 
 ## Payment reliability
 

--- a/src/prepaid-credit-routes.ts
+++ b/src/prepaid-credit-routes.ts
@@ -102,11 +102,20 @@ function bodyBoundFailure(
   }, 400)
 }
 
-async function emptyActionBodyFailure(
+/**
+ * Exported so a test can drive it directly with a fake Context that models
+ * the @hono/node-server raw.body/text() coupling — see the comment inside.
+ */
+export async function emptyActionBodyFailure(
   c: Context,
   action: 'accept' | 'refuse',
 ): Promise<Response | null> {
-  if (c.req.raw.body == null) return null
+  // Read only through the framework: touching c.req.raw.body — even this
+  // presence check — makes @hono/node-server build its real Request from
+  // Readable.toWeb(incoming) and hand every later c.req.text() read to that
+  // stream, which never delivers on Vercel's Node runtime (proven on the
+  // sibling market repo, 1f3ea issue #39 / PR #40). An absent body already
+  // reads as an empty string below and is handled by the trim() check.
   const body = await boundedBody(c)
   if (body.state !== 'ok') return bodyBoundFailure(c, body.state)
   if (body.raw.trim() === '') return null

--- a/test/prepaid-credit-routes.test.ts
+++ b/test/prepaid-credit-routes.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
 import test from 'node:test'
 import { Hono, type Context } from 'hono'
-import { mountPrepaidCreditGiftRoutes } from '../src/prepaid-credit-routes.ts'
+import { emptyActionBodyFailure, mountPrepaidCreditGiftRoutes } from '../src/prepaid-credit-routes.ts'
 
 const GIFT_ID = `city_gift_${'ab'.repeat(16)}`
 const CLAIM_TOKEN = `gift_claim_${'cd'.repeat(32)}`
@@ -348,4 +348,94 @@ test('gift body-bound refusals name their real causes, never a field rule', asyn
     String((await oversized.json() as { error: string }).error),
     /limited to 1024 bytes/u,
   )
+})
+
+// Regression guard for the production hang: on Vercel, @hono/node-server's
+// fast path reads c.req.text()/json()/arrayBuffer() in well under 1ms, but
+// touching c.req.raw.body even once (a `== null` presence check included)
+// makes it build a real Request whose body is Readable.toWeb(incoming); every
+// later body read then defers to that stream, which never delivers on
+// Vercel's Node runtime (proven on the sibling market repo: 1f3ea issue #39,
+// PR #40, same @hono/node-server 2.1.0, same Vercel Node 24 runtime). A
+// fetch-backed test (`app.request(...)`, used above) cannot reproduce this —
+// undici's Request has no such coupling — so this test models the coupling
+// directly against a fake Context standing in for node-server's real one.
+function nodeServerLikeContext(
+  bodyText: string,
+  headers: Readonly<Record<string, string>> = {},
+): { context: Context; rawBodyWasTouched(): boolean } {
+  let rawBodyTouched = false
+  const raw = {
+    get body(): unknown {
+      rawBodyTouched = true
+      // The real getter returns a live ReadableStream (or null for a
+      // genuinely bodyless request); any truthy stand-in proves the touch.
+      return bodyText.length > 0 ? {} : null
+    },
+  }
+  // Mirrors node-server's actual behavior once raw.body has been read: the
+  // fast-path text()/arrayBuffer() defer to the now-cached real Request's
+  // stream reader, which on Vercel never settles.
+  const settle = (): Promise<string> => rawBodyTouched
+    ? new Promise<string>(() => { /* never settles — this is the hang */ })
+    : Promise.resolve(bodyText)
+  const req = {
+    header: (name: string) => headers[name.toLowerCase()],
+    text: () => settle(),
+    raw,
+  }
+  const context = {
+    req,
+    json: (body: unknown, status = 200) => new Response(JSON.stringify(body), { status }),
+  } as unknown as Context
+  return { context, rawBodyWasTouched: () => rawBodyTouched }
+}
+
+async function withPromptDeadline<T>(promise: Promise<T>, label: string): Promise<T> {
+  const DEADLINE_MS = 200
+  let timer: ReturnType<typeof setTimeout>
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(
+      `${label} did not settle within ${DEADLINE_MS}ms — something touched c.req.raw.body`,
+    )), DEADLINE_MS)
+  })
+  try {
+    return await Promise.race([promise, deadline])
+  } finally {
+    clearTimeout(timer!)
+  }
+}
+
+test('gift action empty-body check never touches c.req.raw.body and always answers promptly', async () => {
+  const contentLengthFor = (text: string) => String(Buffer.byteLength(text, 'utf8'))
+
+  const empty = nodeServerLikeContext('')
+  const emptyResult = await withPromptDeadline(
+    emptyActionBodyFailure(empty.context, 'accept'),
+    'an empty body',
+  )
+  assert.equal(emptyResult, null)
+  assert.equal(empty.rawBodyWasTouched(), false)
+
+  const emptyObject = nodeServerLikeContext('{}', { 'content-length': contentLengthFor('{}') })
+  const emptyObjectResult = await withPromptDeadline(
+    emptyActionBodyFailure(emptyObject.context, 'accept'),
+    'a {} body',
+  )
+  assert.equal(emptyObjectResult, null)
+  assert.equal(emptyObject.rawBodyWasTouched(), false)
+
+  const nonEmptyText = '{"note":"hi"}'
+  const nonEmpty = nodeServerLikeContext(nonEmptyText, { 'content-length': contentLengthFor(nonEmptyText) })
+  const nonEmptyResult = await withPromptDeadline(
+    emptyActionBodyFailure(nonEmpty.context, 'refuse'),
+    'a non-empty body',
+  )
+  assert.ok(nonEmptyResult)
+  assert.equal(nonEmptyResult?.status, 400)
+  assert.match(
+    String((await nonEmptyResult?.json() as { error: string }).error),
+    /gift refuse accepts an empty body only/u,
+  )
+  assert.equal(nonEmpty.rawBodyWasTouched(), false)
 })


### PR DESCRIPTION
## Proven cause

Live defect on production (12s cap): `POST /api/city-credit/gifts/<id>/accept`
and `/refuse` never answer (000 after 12s) for an authenticated resident,
while `POST .../redirect` on the same router answers 400 in 0.16s.

On Vercel, the incoming request arrives already complete, so
`@hono/node-server`'s fast path (`readBodyWithFastPath`) reads
`c.req.text()`/`json()`/`arrayBuffer()` in well under 1ms. But **any** touch
of `c.req.raw.body` — even a presence check like
`if (c.req.raw.body == null)` — runs the `body` getter, which calls
`getRequestCache()`. That builds and caches node-server's real `Request`
whose body is `Readable.toWeb(incoming)` (see
`node_modules/@hono/node-server/dist/index.mjs` around lines 219–260 and
350–385: `readBodyWithFastPath` and the `body`/`getRequestCache` getters).
Once that real `Request` is cached, `readBodyWithFastPath` defers every
later body read to `request[requestCache][method]()` — reading through that
cached Request's stream, which never delivers on Vercel's Node runtime. A
local Node server does not reproduce it, because the stream does deliver
there.

This is the same root cause already proven and fixed today on the sibling
market repo: **1f3ea issue #39 / PR #40**, same `@hono/node-server` 2.1.0,
same Vercel Node 24 runtime.

## The fix

`src/prepaid-credit-routes.ts`'s `emptyActionBodyFailure` was the only
request-path touch of `c.req.raw.body` in this repo:

```ts
if (c.req.raw.body == null) return null
```

Removed. An absent body already reads as an empty string through
`c.req.text()` (used by `boundedBody`), and the existing
`body.raw.trim() === ''` check already returns `null` for it — every
caller-visible answer is unchanged, only the accidental raw-stream touch is
gone.

`src/log-drain-routes.ts` already avoids this pattern and documents it
in a comment. I grepped the rest of `src/` for
`c.req.raw.body` / `.raw.clone()` / `.raw.formData()` / `c.req.parseBody()`
on the request path and found no other occurrences. The remaining
`c.req.raw` uses are safe:
- `core.ts` — object-identity `WeakMap`/`WeakSet` keys, never touches `.body`
- `paypal-credit-routes.ts` — `c.req.raw.headers`, never `.body`
- `drawing.ts` / `world.ts` (`readBoundedJsonObject`) — already read through
  `request.arrayBuffer()` only, with a comment citing the same bug class
  (PR #115)

## Test added

`test/prepaid-credit-routes.test.ts` gets a regression guard that models the
real `@hono/node-server` coupling directly (a fetch-backed `app.request(...)`
test can't reproduce it — undici's `Request` has no such coupling): a fake
`Context` whose `raw.body` getter records that it was touched, and whose
`text()` never settles if `raw.body` was touched first but resolves normally
otherwise. It asserts `emptyActionBodyFailure` answers within 200ms for an
empty body, a `{}` body, and a non-empty body, and that `raw.body` is never
touched in any case.

`emptyActionBodyFailure` is now exported so the test can drive it directly.

## Docs

Added definition-of-done item 7 to `AGENTS.md`: on the request path, read
the body only through `c.req.text()`/`json()`/`arrayBuffer()`, never touch
`c.req.raw.body`, `.clone()`, `.formData()`, or `c.req.parseBody()`.

## Verification

- `npm run typecheck` — clean
- `npm test` — 1891/1895 pass; the 4 failures are pre-existing on a fresh
  clone of `main` (unrelated `identity-client.test.ts` local-credentials-file
  write failures specific to this Windows environment — verified by running
  the suite against a clean `main` clone before making any change)
- This fix has **not** been verified against production. Per this repo's
  payment-reliability rules, the operator should verify the deployed preview
  for this PR by calling `POST /api/city-credit/gifts/<id>/accept` (and
  `/refuse`) for an authenticated resident and confirming a prompt (non-000)
  response, the way `/redirect` already responds today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)