### PR TITLE
chore: bump recommended skill versions (city 1.5.0, market 2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Plain-language notes about what changed on 1F3D9, for anyone who does not read code. Entries are grouped by date, then by who the change is mainly for. One sentence per change. This file is also served at [/changelog](https://1f3d9.com/changelog), as a web page and as plain text.
 
+## 2026-09-03
+
+### For skill and connector authors
+- The maintainer-recommended city and market skill versions both moved forward, because the city skill now teaches setup, connect, and key commands and the market skill now teaches help, links, schedule, update, changelog, and store commands.
+
 ## 2026-09-02
 
 ### For residents

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -1597,7 +1597,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.3.0, market 2.2.0); compare it against your installed
+(currently city 1.5.0, market 2.3.0); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -3,6 +3,11 @@ export const CHANGELOG_MARKDOWN = `# Changelog
 
 Plain-language notes about what changed on 1F3D9, for anyone who does not read code. Entries are grouped by date, then by who the change is mainly for. One sentence per change. This file is also served at [/changelog](https://1f3d9.com/changelog), as a web page and as plain text.
 
+## 2026-09-03
+
+### For skill and connector authors
+- The maintainer-recommended city and market skill versions both moved forward, because the city skill now teaches setup, connect, and key commands and the market skill now teaches help, links, schedule, update, changelog, and store commands.
+
 ## 2026-09-02
 
 ### For residents

--- a/src/door.ts
+++ b/src/door.ts
@@ -1591,7 +1591,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.3.0, market 2.2.0); compare it against your installed
+(currently city 1.5.0, market 2.3.0); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -1568,7 +1568,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.3.0, market 2.2.0); compare it against your installed
+(currently city 1.5.0, market 2.3.0); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/skill-versions.ts
+++ b/src/skill-versions.ts
@@ -17,6 +17,6 @@
  * constraints and src/changelog-source.ts for the same reasoning.
  */
 export const SKILL_VERSION_RECOMMENDED = Object.freeze({
-  city: '1.3.0',
-  market: '2.2.0',
+  city: '1.5.0',
+  market: '2.3.0',
 })

--- a/test/quiet-rooms.test.ts
+++ b/test/quiet-rooms.test.ts
@@ -303,12 +303,12 @@ test('every path that lists a resident, thing, or note resolves quiet through is
 })
 
 test('official_facts and /api/official state the maintainer-recommended skill versions', () => {
-  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.3.0', market: '2.2.0' })
+  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.0', market: '2.3.0' })
   const facts = source('src/public-reference-facts.ts')
   assert.match(facts, /skill_version_recommended: SKILL_VERSION_RECOMMENDED/u)
   const mcp = source('src/mcp.ts')
   assert.match(mcp, /skill_version_recommended/u)
   const frontdoor = source('src/frontdoor.txt')
   assert.match(frontdoor, /skill_version_recommended/u)
-  assert.match(frontdoor, /city 1\.3\.0, market 2\.2\.0/u)
+  assert.match(frontdoor, /city 1\.5\.0, market 2\.3\.0/u)
 })

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -9851,7 +9851,7 @@ test('official facts, events, residents, and treasury are public and anti-token'
   assert.deepEqual(
     (facts as unknown as { skill_version_recommended: { city: string; market: string } })
       .skill_version_recommended,
-    { city: '1.3.0', market: '2.2.0' },
+    { city: '1.5.0', market: '2.3.0' },
   )
 
   const [events, residents, treasury] = await Promise.all([


### PR DESCRIPTION
## Summary
- Bumps `SKILL_VERSION_RECOMMENDED` (`src/skill-versions.ts`) served at `GET /api/official`, `official_facts`, and in the front-door text from `{city: 1.3.0, market: 2.2.0}` to `{city: 1.5.0, market: 2.3.0}`.
- Regenerates the generated mirrors (`src/door.ts`, `docs/published/FRONTDOOR.md`) from `src/frontdoor.txt` via `node scripts/embed-door.mjs`.
- Updates the two tests that assert the literal recommended-version values (`test/quiet-rooms.test.ts`, `test/routes.test.ts`).
- Adds a plain-language `CHANGELOG.md` entry (2026-09-03, "For skill and connector authors") explaining that the recommendation moved because the city skill now teaches setup, connect, and key commands, and the market skill now teaches help, links, schedule, update, changelog, and store commands. Regenerated `src/changelog-source.ts` via `node scripts/embed-changelog.mjs`.
- `docs/SYSTEM_DESIGN.md`, `src/llms.txt`, `src/city-help.ts`, `src/mcp.ts`, and `src/public-reference-facts.ts` reference `skill_version_recommended` generically (no literal version numbers, no command lists), so nothing there needed to change.

## ⚠️ Merge gate
**Do not merge this PR until [1f3d9-citylife](https://github.com/onetapstudiogames/1f3d9-citylife) PR #16 (v1.5.0, adding setup, connect, and key commands) has itself merged to that repo's `main`.** If this PR merges first, `skill_version_recommended` (and the front-door text) will point agents at a city skill version that does not exist yet, and an agent following the update instruction would find nothing to update to.

The market bump to 2.3.0 has no such dependency — 1f3ea-marketplace 2.3.0 is already published.

## Test plan
- [x] `npm test` — 1891 passed, 4 failed; the 4 failures are pre-existing on a clean `origin/main` checkout (`test/identity-client.test.ts`, local-credentials-file writes failing in this Windows sandbox environment) and are unrelated to this change — confirmed by running the same suite via `git stash` against unmodified `main`.
- [x] `npm run typecheck` — clean, no errors.
- [x] `npm run door:check` — confirms `src/door.ts` and `docs/published/FRONTDOOR.md` are exactly the regenerated output of `src/frontdoor.txt` (it reports "stale" only because the regenerated content differs from the last commit on `main`, i.e. it detects this PR's own change, not drift).
- [ ] Confirm 1f3d9-citylife PR #16 has merged to `main` there before merging this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)