### PR TITLE
Live view step 2: sprites on the ground, no chips, real alpha

### DIFF
--- a/e2e/public-window-live.spec.ts
+++ b/e2e/public-window-live.spec.ts
@@ -542,6 +542,10 @@ async function installReplayRoutes(
     crowdPlaceId?: number
     residentCrowdSize?: number
     quietPlaceId?: number
+    // Step 2 proof/e2e: flip specific stock resident ids to has_drawing:
+    // false so a test can exercise the neutral-marker path deliberately,
+    // without inventing a second resident fixture.
+    undrawnResidentIds?: readonly number[]
   }> = {},
 ) {
   let published = false
@@ -610,9 +614,12 @@ async function installReplayRoutes(
         const crowded = controls.crowdPlaceId && resident.id !== 5
         ? { ...placed, current_place_id: controls.crowdPlaceId }
           : placed
-        return controls.maximumHandle && resident.id === replayCrowd[3]!.id
+        const named = controls.maximumHandle && resident.id === replayCrowd[3]!.id
           ? { ...crowded, handle: controls.maximumHandle }
           : crowded
+        return controls.undrawnResidentIds?.includes(resident.id)
+          ? { ...named, has_drawing: false }
+          : named
       }),
       ...Array.from({ length: controls.simultaneousMoves ?? 0 }, (_, index) => ({
         id: 1_000 + index,
@@ -2734,6 +2741,68 @@ test('Live stage portraits stay unboxed on the ground and when focused', async (
     outlineStyle: 'solid',
     outlineWidth: '4px',
   })
+
+  // Step 2: things on the ground carry the same promise -- no card backing
+  // behind the sprite or its name -- and the place plot never prints the
+  // removed owner chip anywhere on the plate.
+  const specimen = page.locator('.live-thing-specimen').first()
+  await specimen.scrollIntoViewIfNeeded()
+  expect(await specimen.evaluate(node => {
+    const style = getComputedStyle(node)
+    return { backgroundColor: style.backgroundColor, borderWidth: style.borderWidth,
+      boxShadow: style.boxShadow }
+  })).toEqual({ backgroundColor: 'rgba(0, 0, 0, 0)', borderWidth: '0px', boxShadow: 'none' })
+  await expect(page.locator('.live-plot-owner')).toHaveCount(0)
+})
+
+test('an undrawn resident renders exactly a neutral marker plus a shadowed name, no chip', async ({ page }) => {
+  // replayCrowd[0] (id 20, the lowest id in its room) sorts first under the
+  // documented stable-id crowding order, so it stays inside the 6-visible
+  // cap rather than folding behind "+N more". A wide viewport keeps the
+  // roster board beside, rather than over, the live plates.
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await installReplayRoutes(page, Date.now(), 'complete', 0, {
+    crowdPlaceId: 2,
+    undrawnResidentIds: [replayCrowd[0]!.id],
+  })
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+
+  const markers = page.locator('.live-walker .live-neutral-marker')
+  await expect(markers).toHaveCount(1)
+  const marker = markers.first()
+  await marker.scrollIntoViewIfNeeded()
+  await expect(marker).toHaveAttribute('role', 'img')
+  await expect(marker.locator('*')).toHaveCount(0)
+  expect(await marker.evaluate(node => {
+    const style = getComputedStyle(node)
+    return { backgroundColor: style.backgroundColor, borderWidth: style.borderWidth }
+  })).toEqual({ backgroundColor: 'rgba(0, 0, 0, 0)', borderWidth: '0px' })
+
+  const handle = await marker.evaluate(node =>
+    node.closest('.live-walker')?.getAttribute('data-live-item-key')?.replace('resident:', ''))
+  expect(handle).toBe(replayCrowd[0]!.handle)
+
+  // The name tag is hidden below the readable zoom threshold unless the
+  // sprite is focused (decision #60) -- activate the portrait's ordinary
+  // click handler directly; the floating roster board can sit over this
+  // small ground marker depending on where its plot lands, which is a
+  // z-order accident of this fixture's layout, not the behaviour under
+  // test.
+  const portrait = page.locator('.live-walker .live-portrait').filter({
+    has: page.locator('.live-neutral-marker'),
+  })
+  await portrait.evaluate(node => (node as HTMLElement).click())
+  await expect(page.locator('.live-walker[data-live-focus-resident]')).toHaveCount(1)
+  const tag = page.locator(`[data-live-resident-tag="${replayCrowd[0]!.handle}"]`)
+  await expect(tag).toHaveCount(1)
+  await expect(tag).toHaveText(replayCrowd[0]!.handle)
+  expect(await tag.evaluate(node => getComputedStyle(node).backgroundColor)).toBe(
+    'rgba(0, 0, 0, 0)',
+  )
+  await expect(page.locator('.drawing-state-label, .drawing-provenance, .drawing-live-label'))
+    .toHaveCount(0)
+  await expect(page.locator('.live-plot-owner')).toHaveCount(0)
 })
 
 test('Live opens a 40-resident fixture with 3 full drawing reads and 10 thumbnails', async ({ page }) => {
@@ -2995,6 +3064,72 @@ test('proof: quiet opening, no arrows', async ({ page }) => {
     '.live-trail[data-live-key="change:9506"]',
   )).toHaveCount(1)
   await expect(proofPanel.locator('#live-trace-arrow')).toHaveCount(0)
+})
+
+test('proof: sprites on the ground, no chips', async ({ page }) => {
+  // Side-by-side comparison the owner asked for: proof-alex (9201) carries a
+  // genuinely transparent drawing standing on the workshop's own strongly
+  // patterned (in_progress) floor; proof-cato (9203) is a Blank (all-
+  // transparent Complete) portrait; proof-bea/dara/eli/fia/gus are undrawn
+  // and fall to the small neutral marker. (This suite disables Playwright's
+  // own screenshot/trace/video capture project-wide for credential safety --
+  // see playwright.config.ts -- so this proof is the DOM-state equivalent of
+  // a screenshot.)
+  await page.setViewportSize({ width: 1280, height: 800 })
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await page.getByRole('button', { name: 'Run preview proof scene' }).click()
+  const proofPanel = page.locator('#live-panel[data-live-proof="true"]')
+  await expect(proofPanel).toBeVisible()
+
+  // Settle the scene's own retry-room load first -- exactly as the sibling
+  // "discoverable preview proof scene" test does -- before the residents
+  // badge is clicked, so the layout is stable and the roster board no
+  // longer intercepts the click.
+  const retry = page.getByRole('button', { name: 'Retry proof room' })
+  await expect(retry).toBeVisible()
+  await retry.click()
+  await expect(retry).toHaveCount(0)
+  await proofPanel.getByRole('button', { name: /Show .* more residents/u }).click()
+
+  // No chip of any kind renders on the plate -- state, provenance, or owner.
+  await expect(proofPanel.locator(
+    '.drawing-live-label, .drawing-undrawn-label, .drawing-state-label, ' +
+    '.drawing-provenance, .live-plot-owner',
+  )).toHaveCount(0)
+
+  // Alex's transparent portrait and Cato's Blank portrait share the same
+  // unboxed presentation as every other drawn sprite -- nothing paints a
+  // light rectangle behind either.
+  for (const id of [9201, 9203]) {
+    const shell = proofPanel.locator(
+      `.live-walker .entity-portrait[data-portrait-type="resident"][data-portrait-id="${id}"]`,
+    ).first()
+    await expect(shell).toHaveCount(1)
+    expect(await shell.evaluate(node => {
+      const style = getComputedStyle(node)
+      const placeholder = node.querySelector('.entity-portrait-placeholder')
+      return {
+        shellBackground: style.backgroundColor,
+        placeholderBackground: placeholder
+          ? getComputedStyle(placeholder).backgroundColor
+          : null,
+      }
+    })).toEqual({ shellBackground: 'rgba(0, 0, 0, 0)', placeholderBackground: 'rgba(0, 0, 0, 0)' })
+  }
+
+  // Every undrawn resident (bea, dara, eli, fia, gus -- 5 of the 7) renders
+  // exactly a neutral marker, never nothing and never a chip.
+  await expect(proofPanel.locator('.live-walker .live-neutral-marker')).toHaveCount(5)
+
+  // The floor those sprites stand on is the workshop's own in-progress
+  // drawing, tiled -- the "strongly patterned floor tile" the proof asks
+  // for -- and the walkers share that same plot.
+  const workshopPlot = proofPanel.locator('.live-plot').filter({
+    has: page.locator('canvas[data-drawing-presentation-state="in_progress"]'),
+  })
+  await expect(workshopPlot).toHaveCount(1)
+  await expect(workshopPlot.locator('.live-walker')).not.toHaveCount(0)
 })
 
 test('drawing details reveal exact authored readback and fetch bounded history only on request', async ({ page }) => {
@@ -5097,7 +5232,12 @@ test('the Live tab draws stored world ground and keeps surveyed plots fixed thro
   const harbor = page.locator('.live-plot[data-place-id="3"]')
   await expect(harbor).toHaveAttribute('data-undrawn', 'true')
   await expect(harbor).toHaveAttribute('data-place-kind', 'continent')
-  await expect(harbor.locator('.live-plot-owner')).toHaveText('undrawn · kept by harbor-owner')
+  // Step 2 ruling: no "kept by" owner line renders on the plate. The same
+  // fact stays reachable through the plot's unchanged drawing-detail button.
+  await expect(harbor.locator('.live-plot-owner')).toHaveCount(0)
+  await expect(harbor.getByRole('button', { name: 'Current drawing' })).toHaveAttribute(
+    'aria-label', 'Open current drawing for Harbor room',
+  )
   const cinderTerrain = page.locator('.live-plot[data-place-id="2"] .live-plot-terrain')
   await expect(cinderTerrain.locator('.drawing-authored').first()).toBeVisible()
   await expect(cinderTerrain.locator('canvas.drawing-authored')).toHaveAttribute('width', '64')
@@ -5250,8 +5390,9 @@ test('the Live tab draws stored world ground and keeps surveyed plots fixed thro
   await expect(page.locator('.live-plot[data-live-detail="true"]')).not.toHaveCount(0)
   await expect(page.locator('.live-plot[data-live-detail="false"]')).not.toHaveCount(0)
 
-  const cinderOwner = page.locator('.live-plot[data-place-id="2"] .live-plot-owner')
-  await expect(cinderOwner).toHaveCSS('pointer-events', 'none')
+  // Step 2 ruling removed the owner-line chip entirely, so there is no
+  // longer any noninteractive overlay chrome here to check for a blocked
+  // pointer-events state.
   await narrowStage.evaluate((stage, naturalHeight) => {
     const liveStage = stage as HTMLElement
     if (naturalHeight.style) {

--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -1710,6 +1710,23 @@ export const WINDOW_JS = `(() => {
     return shell
   }
 
+  // Decision #62 / step 2 ruling: the sprite on the ground is the drawing
+  // alone -- an authored thumbnail when one exists, or a small neutral
+  // marker when it does not. No state or provenance chip renders here;
+  // that stays reachable through the title attribute and the unchanged
+  // drawing-detail button (see mountLivePlaceDetail, openDrawingDetailButton).
+  function liveSpriteNode(type, id, label, hasDrawing) {
+    if (hasDrawing) {
+      return portraitNode(type, id, label, true, 'live-entity-portrait')
+    }
+    const marker = element('span',
+      'drawing-grid drawing-undrawn live-neutral-marker live-entity-portrait')
+    marker.setAttribute('role', 'img')
+    marker.title = label + ' has no drawing'
+    marker.setAttribute('aria-label', marker.title)
+    return marker
+  }
+
   function drawingRowsFor(drawing) {
     return Object.freeze(Array.from({ length: 8 }, (_, row) => drawing.indices
       .slice(row * 8, row * 8 + 8)
@@ -1845,7 +1862,12 @@ export const WINDOW_JS = `(() => {
       current_place_id: workshopId,
       joined_at: new Date(now - 86_400_000 - index * 1_000).toISOString(),
       asleep: false,
-      has_drawing: index === 0,
+      // Step 2 proof: alex (0) carries a genuinely transparent portrait over
+      // the workshop's own strongly patterned floor; cato (2) is a Blank
+      // (all-transparent Complete) portrait; every other proof resident,
+      // including bea (1, refused), stays undrawn -- the small neutral
+      // marker path this step adds.
+      has_drawing: index === 0 || index === 2,
     }))
     const things = Array.from({ length: 7 }, (_, index) => ({
       id: 9401 + index,
@@ -1959,6 +1981,16 @@ export const WINDOW_JS = `(() => {
       palette: Object.freeze([]),
       indices: Object.freeze(Array.from({ length: 64 }, () => null)),
     })
+    // Step 2 proof: a real drawing with genuinely transparent cells (every
+    // fourth square is null), so the owner can compare it against the
+    // fully-opaque alternate pattern side by side on the workshop's own
+    // strongly patterned floor.
+    const holed = Object.freeze({
+      palette: Object.freeze(['#d95c46', '#174d3c']),
+      indices: Object.freeze(Array.from(
+        { length: 64 }, (_, index) => index % 4 === 0 ? null : index % 2,
+      )),
+    })
     const held = (state, drawing, description, source, kind = {}) => Object.freeze({
       loading: false,
       loaded: true,
@@ -1985,10 +2017,12 @@ export const WINDOW_JS = `(() => {
       ['place:' + String(LIVE_PROOF_RETRY_ROOM_ID),
         held('complete', blank, 'An intentionally transparent room.', 'place')],
       ['resident:' + String(proof.residents[0].id),
-        held('complete', alternate, 'Proof Alex drew this portrait.', 'resident')],
+        held('complete', holed, 'Proof Alex drew this see-through portrait.', 'resident')],
       ['resident:' + String(proof.residents[1].id),
         held('refused', null, 'Proof Bea chose not to draw.', 'resident')],
-      ...proof.residents.slice(2).map(resident => ['resident:' + String(resident.id), undrawn()]),
+      ['resident:' + String(proof.residents[2].id),
+        held('complete', blank, 'Proof Cato left this portrait deliberately blank.', 'resident')],
+      ...proof.residents.slice(3).map(resident => ['resident:' + String(resident.id), undrawn()]),
       ['thing:' + String(proof.things[0].id),
         held('complete', pixels, 'An untyped owner drawing.', 'thing')],
       ['thing:' + String(proof.things[1].id),
@@ -2442,7 +2476,7 @@ ${WINDOW_CLIENT_SAFETY_JS}
         const visible = portraitRect.width > 0 && portraitRect.height > 0 &&
           portraitRect.right > layerRect.left && portraitRect.left < layerRect.right &&
           portraitRect.bottom > layerRect.top && portraitRect.top < layerRect.bottom
-        const tag = existingTag || element('span', 'live-resident-tag', handle)
+        const tag = existingTag || element('span', 'live-resident-tag live-item-name', handle)
         return [{
           existingTag: tag,
           focused,
@@ -4915,10 +4949,6 @@ ${WINDOW_CLIENT_SAFETY_JS}
     for (const card of nodes.livePlates?.querySelectorAll(
       '.live-plot[data-place-id="' + String(id) + '"]') || []) {
       card.dataset.undrawn = String(undrawn)
-      const owner = card.querySelector('.live-plot-owner')
-      if (!owner) continue
-      const plain = String(owner.textContent || '').replace(/^undrawn · /u, '')
-      owner.textContent = undrawn ? 'undrawn · ' + plain : plain
     }
   }
 
@@ -4963,18 +4993,6 @@ ${WINDOW_CLIENT_SAFETY_JS}
     return label + ' · ' + stateLabel + (sourceLabel ? ' · ' + sourceLabel : '')
   }
 
-  function appendLiveDrawingLabels(node, entry) {
-    const stateLabel = windowDrawingStateLabel(entry.state, entry.drawing)
-    const stateNode = element('span', 'drawing-live-label drawing-state-label', stateLabel)
-    node.append(stateNode)
-    const sourceLabel = windowDrawingSourceLabel(entry)
-    if (sourceLabel) {
-      const sourceNode = element('span', 'drawing-live-label drawing-provenance', sourceLabel)
-      sourceNode.title = sourceLabel
-      node.append(sourceNode)
-    }
-  }
-
   function drawingNode(type, id, label, columns = 1, rows = 1) {
     const key = liveDrawingKey(type, id)
     const entry = state.live.drawings[key]
@@ -4994,36 +5012,33 @@ ${WINDOW_CLIENT_SAFETY_JS}
       node.dataset.liveDrawingRows = String(safeRows)
       return node
     }
+    // Step 2 ruling: the Live surface shows the drawing alone, never a
+    // COMPLETE / IN PROGRESS / "Own drawing" state chip or provenance chip.
+    // State and source stay attached as data attributes and the accessible
+    // name (role="img" + aria-label / title) -- reachable to assistive tech
+    // and to the unchanged drawing-detail button -- just never painted as a
+    // visible label over the art.
     if (entry?.error) {
       const unavailable = element('span', 'drawing-grid drawing-undrawn drawing-unavailable')
       unavailable.setAttribute('role', 'img')
-      unavailable.setAttribute('aria-label', label + ' drawing could not be read')
-      unavailable.append(element('span', 'drawing-undrawn-label', 'drawing unavailable'))
+      unavailable.title = label + ' drawing could not be read'
+      unavailable.setAttribute('aria-label', unavailable.title)
       return identify(unavailable)
     }
     if (!entry?.loaded) {
       const loading = element('span', 'drawing-grid drawing-undrawn drawing-loading')
       loading.setAttribute('role', 'img')
-      loading.setAttribute('aria-label', 'Reading ' + label + ' drawing')
-      loading.append(element('span', 'drawing-undrawn-label', 'reading drawing'))
+      loading.title = 'Reading ' + label + ' drawing'
+      loading.setAttribute('aria-label', loading.title)
       return identify(loading)
     }
     if (entry.drawing === null) {
       const standIn = element('span',
         'drawing-grid drawing-undrawn drawing-' + entry.presentation_state)
       standIn.setAttribute('role', 'img')
-      standIn.setAttribute('aria-label', drawingAccessibleLabel(label, entry))
+      standIn.title = drawingAccessibleLabel(label, entry)
+      standIn.setAttribute('aria-label', standIn.title)
       applyDrawingData(standIn, entry)
-      const visibleState = element('span',
-        'drawing-undrawn-label drawing-state-label',
-        windowDrawingStateLabel(entry.state, entry.drawing))
-      standIn.append(visibleState)
-      const sourceLabel = windowDrawingSourceLabel(entry)
-      if (sourceLabel) {
-        const sourceNode = element('span', 'drawing-live-label drawing-provenance', sourceLabel)
-        sourceNode.title = sourceLabel
-        standIn.append(sourceNode)
-      }
       return identify(standIn)
     }
     const drawing = entry.drawing
@@ -5031,19 +5046,19 @@ ${WINDOW_CLIENT_SAFETY_JS}
     if (!sprite) {
       const unavailable = element('span', 'drawing-grid drawing-undrawn drawing-unavailable')
       unavailable.setAttribute('role', 'img')
-      unavailable.setAttribute('aria-label', label + ' drawing could not be painted')
-      unavailable.append(element('span', 'drawing-undrawn-label', 'drawing unavailable'))
+      unavailable.title = label + ' drawing could not be painted'
+      unavailable.setAttribute('aria-label', unavailable.title)
       return identify(unavailable)
     }
     const shell = element('span',
       'drawing-grid drawing-authored-shell drawing-' + entry.presentation_state)
     shell.setAttribute('role', 'img')
-    shell.setAttribute('aria-label', drawingAccessibleLabel(label, entry))
+    shell.title = drawingAccessibleLabel(label, entry)
+    shell.setAttribute('aria-label', shell.title)
     applyDrawingData(shell, entry)
     applyDrawingData(sprite, entry)
     sprite.setAttribute('aria-hidden', 'true')
     shell.append(sprite)
-    appendLiveDrawingLabels(shell, entry)
     return identify(shell)
   }
 
@@ -7854,8 +7869,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
         : 'Focus on ' + resident.handle
       portrait.setAttribute('aria-label', portrait.title)
       portrait.setAttribute('aria-pressed', String(state.live.focusResident === resident.handle))
-      portrait.append(portraitNode(
-        'resident', resident.id, resident.handle, resident.has_drawing, 'live-entity-portrait',
+      portrait.append(liveSpriteNode(
+        'resident', resident.id, resident.handle, resident.has_drawing,
       ))
       const shell = livePortraitShell(
         portrait,
@@ -8174,8 +8189,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
         bindLiveHighlight(specimen, pulse.key, 'pulse')
       }
       specimen.append(
-        portraitNode('thing', thing.id, thing.name, thing.has_drawing, 'live-entity-portrait'),
-        element('span', 'live-thing-name', thing.name),
+        liveSpriteNode('thing', thing.id, thing.name, thing.has_drawing),
+        element('span', 'live-thing-name live-item-name', thing.name),
       )
       bindLiveActivation(specimen, specimen, itemKey, null)
       shelf.append(specimen)
@@ -8247,12 +8262,8 @@ ${WINDOW_CLIENT_SAFETY_JS}
     const drawing = state.live.drawings[liveDrawingKey('place', place.id)]
     const undrawn = drawing?.loaded && drawing.drawing === null
     card.dataset.undrawn = String(Boolean(undrawn))
-    const owner = Object.hasOwn(place, 'owner')
-      ? place.owner ? (undrawn ? 'undrawn · ' : '') + 'kept by ' + place.owner : 'ownerless world ground'
-      : 'Place #' + String(place.id)
     const terrain = liveTiledDrawing(place, 'live-plot-terrain', 8, 5)
     card.prepend(terrain)
-    card.append(element('p', 'live-plot-owner', owner))
     const drawingDetail = openDrawingDetailButton(
       'place',
       place.id,

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -17,6 +17,7 @@ export const WINDOW_CSS = `:root {
   --focus: #fff19b;
   --focus-dark: #092d22;
   --cursor-tint: #d7e5dc;
+  --live-name-shadow-strength: 3px;
   --content: 82rem;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
@@ -708,12 +709,12 @@ button { color: inherit; }
   z-index: 1;
   width: max-content;
   max-width: none;
-  padding: 0.2rem 0.3rem;
+  padding: 0.15rem 0.2rem;
   overflow: visible;
-  color: var(--ink);
-  background: var(--paper-light);
-  border: 2px solid var(--line);
-  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.38);
+  color: var(--paper-light);
+  background: none;
+  border: 0;
+  box-shadow: none;
   font: 800 0.72rem/1.2 ui-monospace, "Cascadia Mono", Consolas, monospace;
   text-overflow: clip;
   white-space: nowrap;
@@ -721,14 +722,14 @@ button { color: inherit; }
 .live-resident-tag[data-live-packed="false"] { visibility: hidden; }
 .live-resident-tag[data-live-focus-resident] {
   z-index: 2;
-  background: var(--signal);
-  box-shadow: 0 0 0 2px var(--line), 3px 3px 0 rgba(0, 0, 0, 0.46);
+  color: var(--signal);
+  font-weight: 900;
 }
 .live-resident-tag[data-live-intent="true"] { z-index: 4; }
 .live-resident-tag[data-live-raised="true"] {
   z-index: 6;
-  background: var(--signal);
-  box-shadow: 0 0 0 2px var(--line), 4px 4px 0 rgba(0, 0, 0, 0.5);
+  color: var(--signal);
+  font-weight: 900;
 }
 .live-world-ground {
   position: absolute;
@@ -934,46 +935,31 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   height: 100%;
   image-rendering: pixelated;
 }
-.drawing-grid > .drawing-live-label,
-.drawing-grid > .drawing-undrawn-label {
-  position: absolute;
-  z-index: 2;
-  inset-inline: 0.12rem auto;
-  max-width: calc(100% - 0.24rem);
-  padding: 0.1rem 0.18rem;
-  overflow: hidden;
-  color: var(--ink);
-  background: rgba(255, 249, 232, 0.92);
-  font: 900 0.42rem/1.15 ui-monospace, "Cascadia Mono", Consolas, monospace;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.drawing-grid > .drawing-state-label { inset-block: 0.12rem auto; }
-.drawing-grid > .drawing-provenance { inset-block: auto 0.12rem; }
 .drawing-refused { background: repeating-linear-gradient(45deg,
   rgba(217, 92, 70, 0.13) 0 6px, rgba(255, 249, 232, 0.84) 6px 12px); }
 .drawing-in_progress { box-shadow: inset 0 0 0 2px var(--signal); }
-.drawing-blank { background: var(--paper-light); }
+/* Step 2 ruling: the Live plate never paints a chip, a hatch, or an opaque
+   backing behind a sprite -- genuinely transparent pixels show the ground
+   through. Refused/in-progress texture and the small "no drawing" marker
+   glyph below stay for the separate drawing-detail page's own presentation
+   (drawingSnapshotNode), which never nests inside #live-panel. */
+#live-panel .drawing-refused,
+#live-panel .drawing-in_progress { background: none; box-shadow: none; }
 .drawing-undrawn {
   position: relative;
   display: grid;
   place-items: center;
   min-width: 0;
-  background: repeating-linear-gradient(-45deg,
-    transparent 0 7px, rgba(157, 146, 118, 0.55) 7px 8px);
-  border: 1px dashed var(--paper-line);
+  background: transparent;
+  border: 0;
 }
-.drawing-undrawn-label {
-  max-width: 100%;
-  padding: 0.12rem;
-  overflow: hidden;
-  color: var(--muted);
-  background: rgba(255, 249, 232, 0.88);
-  font: 800 0.45rem/1.2 ui-monospace, "Cascadia Mono", Consolas, monospace;
-  letter-spacing: 0.04em;
-  text-align: center;
-  text-overflow: ellipsis;
-  text-transform: uppercase;
+.drawing-undrawn::before {
+  content: "";
+  width: 34%;
+  height: 34%;
+  background: var(--sky);
+  opacity: 0.55;
+  transform: rotate(45deg);
 }
 .drawing-loading { opacity: 0.72; }
 .drawing-unavailable { border-style: solid; }
@@ -1043,15 +1029,24 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   align-items: center;
   min-height: 3.5rem;
   padding: 0.3rem;
-  color: var(--ink);
-  background: var(--paper-light);
-  border: 2px solid var(--line);
+  color: var(--paper-light);
+  background: transparent;
+  border: 0;
   font-size: 0.6rem;
   font-weight: 800;
   text-decoration: none;
 }
 .live-thing-name { overflow-wrap: anywhere; }
-.live-thing-specimen > .entity-portrait { width: 2.5rem; height: 2.5rem; }
+/* Step 2 ruling: names sit under the sprite with a text shadow, never a
+   box. --live-name-shadow-strength is the one dial for judging legibility
+   against the floor art on the preview. */
+.live-item-name {
+  text-shadow:
+    0 1px 0 var(--night),
+    0 0 var(--live-name-shadow-strength) var(--night);
+}
+.live-thing-specimen > .entity-portrait,
+.live-thing-specimen > .drawing-grid { width: 2.5rem; height: 2.5rem; aspect-ratio: auto; }
 .live-footnote-mark, .live-action-mark {
   position: absolute;
   z-index: 3;
@@ -1230,8 +1225,6 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   aspect-ratio: auto;
 }
 .live-plot-terrain > canvas.drawing-grid { height: auto; }
-.live-plot-terrain .drawing-undrawn-label { display: none; }
-.live-plot-terrain > .drawing-grid .drawing-undrawn-label { display: block; }
 .drawing-detail-open {
   display: inline-flex;
   align-items: center;
@@ -1283,21 +1276,6 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.live-plot-owner {
-  position: absolute;
-  z-index: 7;
-  inset: 1.1rem auto auto 0.45rem;
-  max-width: calc(100% - 0.9rem);
-  margin: 0;
-  padding: 0.1rem 0.28rem;
-  overflow: hidden;
-  color: var(--ink);
-  background: rgba(255, 249, 232, 0.88);
-  font: 800 0.5rem/1.25 ui-monospace, "Cascadia Mono", Consolas, monospace;
-  pointer-events: none;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 .live-plot > .live-portrait-grid {
   position: absolute;
   z-index: 7;
@@ -1329,8 +1307,8 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   min-width: 0;
   padding: 0.12rem;
   transform: translate(-50%, -50%);
-  background: rgba(255, 249, 232, 0.94);
-  box-shadow: 2px 2px 0 rgba(0, 0, 0, 0.3);
+  background: transparent;
+  box-shadow: none;
   pointer-events: auto;
 }
 .live-plot .live-thing-name {

--- a/test/window-viewer.test.ts
+++ b/test/window-viewer.test.ts
@@ -394,15 +394,6 @@ test('the live plate states its honest timing and drawing rules in shipped code'
   assert.match(WINDOW_CSS, /\.live-trail/u)
   assert.match(WINDOW_CSS, /\.live-footnote-mark/u)
   assert.match(WINDOW_CSS, /\.drawing-undrawn/u)
-  assert.match(
-    WINDOW_CSS,
-    /\.live-plot-terrain\s*>\s*\.drawing-grid\s+\.drawing-undrawn-label\s*\{[^}]*display:\s*(?:block|inline|inline-block)/u,
-  )
-  assert.match(
-    WINDOW_CSS,
-    /\.live-plot-owner\s*\{[^}]*pointer-events:\s*none/u,
-    'noninteractive plot chrome must not block the place opener',
-  )
   assert.doesNotMatch(WINDOW_JS, /cacheRevision/u)
   assert.match(WINDOW_JS, /function invalidateLiveCaches/u)
   assert.match(WINDOW_JS, /resident_edited[\s\S]{0,180}resident:/u)
@@ -423,6 +414,61 @@ test('the live plate states its honest timing and drawing rules in shipped code'
     WINDOW_CSS,
     /@media \(max-width: 54rem\)[\s\S]*?\.live-layout\s*\{[^}]*display:\s*block[^}]*\}[\s\S]*?\.live-viewport/u,
   )
+})
+
+test('Live sprites carry the drawing alone, with a neutral marker and a shadowed name in place of chips', () => {
+  // Step 2 ruling: no state chip, no provenance chip, no owner line, no
+  // hatched square, no card backing behind a sprite or its name.
+  assert.doesNotMatch(WINDOW_JS, /function appendLiveDrawingLabels/u)
+  assert.doesNotMatch(WINDOW_JS, /drawing-live-label/u)
+  assert.doesNotMatch(WINDOW_JS, /drawing-undrawn-label/u)
+  assert.doesNotMatch(WINDOW_JS, /live-plot-owner/u)
+  assert.doesNotMatch(WINDOW_CSS, /\.drawing-undrawn-label/u)
+  assert.doesNotMatch(WINDOW_CSS, /\.drawing-blank/u)
+  assert.doesNotMatch(WINDOW_CSS, /\.live-plot-owner/u)
+
+  // Every resident/thing sprite on the ground is the drawing alone, or a
+  // small neutral marker when there is none -- never nothing, never a chip.
+  assert.match(WINDOW_JS, /function liveSpriteNode\(type, id, label, hasDrawing\)/u)
+  assert.match(WINDOW_JS, /live-neutral-marker/u)
+  assert.match(WINDOW_JS, /liveSpriteNode\(\s*'resident'/u)
+  assert.match(WINDOW_JS, /liveSpriteNode\(\s*'thing'/u)
+
+  // Genuinely transparent pixels show the floor through: no CSS paints an
+  // opaque backing behind a sprite or the ground it fetches from.
+  assert.match(
+    WINDOW_CSS,
+    /\.live-portrait\s*\{[^}]*background:\s*transparent;[^}]*border:\s*0;/u,
+  )
+  assert.match(
+    WINDOW_CSS,
+    /\.live-thing-specimen\s*\{[^}]*background:\s*transparent;[^}]*border:\s*0;/u,
+  )
+  assert.match(
+    WINDOW_CSS,
+    /\.live-plot \.live-thing-specimen\s*\{[^}]*background:\s*transparent;/u,
+  )
+  assert.doesNotMatch(
+    WINDOW_CSS,
+    /\.live-resident-tag\s*\{[^}]*background:\s*var\(--paper-light\)/u,
+  )
+
+  // Names sit under the sprite with one shared, tunable text shadow --
+  // never a box -- so the owner can judge and adjust legibility from one
+  // CSS variable on the preview.
+  assert.match(WINDOW_CSS, /--live-name-shadow-strength:\s*[\d.]+px;/u)
+  assert.match(
+    WINDOW_CSS,
+    /\.live-item-name\s*\{[^}]*text-shadow:[^}]*var\(--live-name-shadow-strength\)/u,
+  )
+  assert.match(WINDOW_JS, /'live-resident-tag live-item-name'/u)
+  assert.match(WINDOW_JS, /'live-thing-name live-item-name'/u)
+
+  // State and provenance stay a public fact -- reachable via the accessible
+  // name / title and the unchanged drawing-detail click-through -- they are
+  // only no longer painted as a visible chip on the plate.
+  assert.match(WINDOW_JS, /drawingAccessibleLabel\(label, entry\)/u)
+  assert.match(WINDOW_JS, /function openDrawingDetailButton/u)
 })
 
 test('drawing presentation and details expose the complete authored contract without eager history', () => {


### PR DESCRIPTION
## What changed

This is step 2 of the live-view blueprint (step 1, quiet opening, shipped in #185). It removes every chip painted over a sprite on the Live plate and fixes the presentation so genuinely transparent pixels show the floor through.

- **New liveSpriteNode(type, id, label, hasDrawing)** is now the single way resident and thing sprites render on the plate: the existing alpha-correct thumb.png thumbnail when the resident/thing has a drawing, or a small neutral marker when it does not. Before this change an undrawn resident or thing rendered nothing at all -- no marker, no name, just empty ground.
- **No more chips.** drawingNode (used for place-terrain tiling) no longer appends visible COMPLETE / IN PROGRESS / "Own drawing" state labels or provenance labels over the art. State and source stay as data attributes and in the accessible name (role="img" + aria-label/title), so a screen reader or the existing drawing-detail click-through still gets the same information -- it just isn't painted as a box any more.
- **No more owner line.** The "kept by owner" / "undrawn - kept by owner" text under a place plot is gone. The owner remains reachable through that plot's existing "Current drawing" button (unchanged), which opens the full place detail.
- **No more card backing.** Thing specimens (.live-thing-specimen, both at the world root and inside a plot) lost their paper-colored background and border -- the sprite and its name now sit directly on the ground, same as residents already did.
- **Names use a text shadow, not a box.** Resident name tags lost their paper background/border entirely; both resident tags and thing names share one new .live-item-name rule with a text-shadow, tuned by one CSS variable -- --live-name-shadow-strength -- so it's a single dial to adjust on the preview once you've looked at it.
- **The "no drawing" glyph changed.** .drawing-undrawn's loud diagonal hatch is now a small transparent diamond marker (.drawing-undrawn::before), matching the "small neutral marker" language in the ruling. .drawing-blank (which forced a cream background behind an all-transparent Complete/"Blank" drawing) is deleted outright -- that's what was actually painting the "moonlit white" you saw; the drawing pipeline itself (src/drawings.ts thumb route) was already alpha-correct and needed no server change.
- **Proof scene extended.** The Vercel-preview-only proof scene now has, side by side: proof-alex with a genuinely transparent portrait (real transparent cells, not just a fully-opaque pattern) standing on the workshop's own strongly patterned floor; proof-cato, a new Blank (all-transparent Complete) portrait; and proof-bea/dara/eli/fia/gus, who stay undrawn and exercise the new marker path.

## The rulings this implements

Verbatim from the task: every resident/thing/place sprite on the Live plate is the drawing alone, on the ground, with genuinely transparent pixels showing the floor through; no state chip, no provenance chip, no owner line, no "UN..." box, no hatched square, no card backing behind a sprite or its name; an undrawn resident/thing is a small neutral marker plus its name; names use a text shadow (one CSS variable controls the strength) instead of a box; the drawing pipeline already serves alpha thumbnails so this is a CSS/markup fix, not a pipeline fix; the alpha chip on the tab stays (untouched); the existing detail/click path (title attributes, the drawing-detail button) stays reachable so nothing the chips carried becomes unreachable.

**What step 4 will move:** step 4 (per the blueprint) ports a single hover/focus popover carrying state, maker, current owner, exact size, and last action, and wires it into bindLiveActivation. When that lands, it should absorb the title attributes and become the primary way to reach this information; the plot's "Current drawing" detail button and drawing-record readback stay as the underlying source of truth either way.

## Proof scene / preview evidence

WINDOW_JS byte size: **550,202 -> 550,841 bytes (+639)**. liveSpriteNode and the removed label code roughly offset each other; the net growth is mostly the new proof-scene resident and a bit of documentation comments.

The full three-way comparison the task asked for (transparent-on-patterned-floor, Blank, undrawn) is in the shipped proof scene, reachable from any Vercel preview via the Live tab's "Run preview proof scene" button -- click "Retry proof room" then "Show 3 more residents" to see all seven. It is also pinned as a DOM-state e2e test, `proof: sprites on the ground, no chips`, since this suite disables Playwright's own screenshot/trace/video capture project-wide for credential safety (see playwright.config.ts) -- that test is the DOM-state equivalent of the screenshot the task asked for.

## What's left to later steps

- **Step 3** (not this PR): place floors tiled from the residents' own art at reduced opacity, with plain paper ground for an undrawn place. This PR only removed the chip/hatch from .drawing-undrawn's glyph and the .drawing-blank white paint; it deliberately does not touch .live-plot-terrain's own background-color or add floor tiling/opacity -- that's step 3's job.
- **Step 4** (not this PR): the single hover/focus popover. Until it lands, title attributes and the existing "Current drawing" detail button remain the reachable path for state/provenance/owner, as the task instructed.

## Tests

- `npm run typecheck` -- clean.
- `npm run door:check` -- clean (this step is presentation-only; no contract-visible/server changes, confirmed by no diff after regeneration).
- `npm test` -- **1893/1897 pass**; the 4 failures are the known Windows-only identity-client local-credentials-file failures tracked in issue #183, unrelated to this change.
- `npx playwright test e2e/public-window-live.spec.ts` -- **78/78 pass**, including:
  - extended `Live stage portraits stay unboxed on the ground and when focused` (now also checks .live-thing-specimen and .live-plot-owner absence)
  - new `an undrawn resident renders exactly a neutral marker plus a shadowed name, no chip`
  - new `proof: sprites on the ground, no chips`
  - updated `the Live tab draws stored world ground and keeps surveyed plots fixed through new places` (its old assertion on the now-removed owner-line text is replaced with a check that the owner stays reachable through the drawing-detail button)
- Also ran e2e/public-window.spec.ts, e2e/public-window-interactions.spec.ts, e2e/window-locations.spec.ts, e2e/quiet-room-leak-scan.spec.ts (102 tests) for regressions -- all green on a clean run. Two unrelated tests (`resident focus persists locally...`, `THINGS stays bounded by choice and transparent...`) showed pre-existing sub-pixel/timing flakiness under full-suite load but pass reliably in isolation; neither touches Live sprite rendering.
- Unit: test/window-viewer.test.ts gained a dedicated test pinning the removed selectors (appendLiveDrawingLabels, .drawing-live-label, .drawing-undrawn-label, .live-plot-owner, .drawing-blank) and the new contract (liveSpriteNode, --live-name-shadow-strength, .live-item-name).

Not merging -- the owner reviews the Vercel preview and says ship, per the standing demo gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
