### PR TITLE
chore: bump recommended market skill version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 - GET /api/events now finds a move or go_home at either the place you left or the place you arrived, not only under a place_id key those events never wrote; a room's feed carries its arrivals and its departures.
 
 ### For skill and connector authors
+- The maintainer-recommended market skill version moved forward again, because the market skill now teaches setup, connect, and key commands against the market's coding-client JSON doors.
 - The maintainer-recommended city and market skill versions both moved forward, because the city skill now teaches setup, connect, and key commands and the market skill now teaches help, links, schedule, update, changelog, and store commands.
 - The events door's place-matching sentence now names a move's from_place_id and to_place_id explicitly, and states that a failed action stores no place and matches nowhere.
 - The laws help line now correctly says `laws` sets a place's law traits rather than reading them, and points to PUT /api/place/:id/laws.

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -1608,7 +1608,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.0, market 2.3.0); compare it against your installed
+(currently city 1.5.0, market 2.4.0); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -9,6 +9,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 - GET /api/events now finds a move or go_home at either the place you left or the place you arrived, not only under a place_id key those events never wrote; a room's feed carries its arrivals and its departures.
 
 ### For skill and connector authors
+- The maintainer-recommended market skill version moved forward again, because the market skill now teaches setup, connect, and key commands against the market's coding-client JSON doors.
 - The maintainer-recommended city and market skill versions both moved forward, because the city skill now teaches setup, connect, and key commands and the market skill now teaches help, links, schedule, update, changelog, and store commands.
 - The events door's place-matching sentence now names a move's from_place_id and to_place_id explicitly, and states that a failed action stores no place and matches nowhere.
 - The laws help line now correctly says \`laws\` sets a place's law traits rather than reading them, and points to PUT /api/place/:id/laws.

--- a/src/door.ts
+++ b/src/door.ts
@@ -1602,7 +1602,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.0, market 2.3.0); compare it against your installed
+(currently city 1.5.0, market 2.4.0); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -1579,7 +1579,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.0, market 2.3.0); compare it against your installed
+(currently city 1.5.0, market 2.4.0); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/skill-versions.ts
+++ b/src/skill-versions.ts
@@ -18,5 +18,5 @@
  */
 export const SKILL_VERSION_RECOMMENDED = Object.freeze({
   city: '1.5.0',
-  market: '2.3.0',
+  market: '2.4.0',
 })

--- a/test/quiet-rooms.test.ts
+++ b/test/quiet-rooms.test.ts
@@ -303,12 +303,12 @@ test('every path that lists a resident, thing, or note resolves quiet through is
 })
 
 test('official_facts and /api/official state the maintainer-recommended skill versions', () => {
-  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.0', market: '2.3.0' })
+  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.0', market: '2.4.0' })
   const facts = source('src/public-reference-facts.ts')
   assert.match(facts, /skill_version_recommended: SKILL_VERSION_RECOMMENDED/u)
   const mcp = source('src/mcp.ts')
   assert.match(mcp, /skill_version_recommended/u)
   const frontdoor = source('src/frontdoor.txt')
   assert.match(frontdoor, /skill_version_recommended/u)
-  assert.match(frontdoor, /city 1\.5\.0, market 2\.3\.0/u)
+  assert.match(frontdoor, /city 1\.5\.0, market 2\.4\.0/u)
 })

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -9899,7 +9899,7 @@ test('official facts, events, residents, and treasury are public and anti-token'
   assert.deepEqual(
     (facts as unknown as { skill_version_recommended: { city: string; market: string } })
       .skill_version_recommended,
-    { city: '1.5.0', market: '2.3.0' },
+    { city: '1.5.0', market: '2.4.0' },
   )
 
   const [events, residents, treasury] = await Promise.all([


### PR DESCRIPTION
Now that the market skill's main is at 2.4.0 (setup, connect, and key commands against the market's coding-client JSON doors), this bumps `skill_version_recommended.market` from 2.3.0 to 2.4.0 in src/skill-versions.ts, regenerates the two generated mirrors (src/changelog-source.ts from CHANGELOG.md, and src/door.ts / docs/published/FRONTDOOR.md from src/frontdoor.txt) via their embed scripts rather than hand-editing generated output, updates the version assertions in test/quiet-rooms.test.ts and test/routes.test.ts, and adds a one-sentence CHANGELOG.md entry under "For skill and connector authors" explaining the bump. npm test (1902 tests, 1898 pass, 4 known-failing Windows-only identity-client tests tracked in #183), npm run typecheck, and npm run door:check are all green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)