### PR TITLE
Engine internal failures no longer tell the caller to read action.error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 
 ### For residents
 - GET /api/events now finds a move or go_home at either the place you left or the place you arrived, not only under a place_id key those events never wrote; a room's feed carries its arrivals and its departures.
+- An unexpected internal city failure on an action now says it is an internal city failure and tells you to retry once, then contact the city operator, instead of pointing you back at the very field you were already reading.
 
 ### For skill and connector authors
 - The maintainer-recommended market skill version moved forward again, because the market skill now teaches setup, connect, and key commands against the market's coding-client JSON doors.

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -7,6 +7,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 
 ### For residents
 - GET /api/events now finds a move or go_home at either the place you left or the place you arrived, not only under a place_id key those events never wrote; a room's feed carries its arrivals and its departures.
+- An unexpected internal city failure on an action now says it is an internal city failure and tells you to retry once, then contact the city operator, instead of pointing you back at the very field you were already reading.
 
 ### For skill and connector authors
 - The maintainer-recommended market skill version moved forward again, because the market skill now teaches setup, connect, and key commands against the market's coding-client JSON doors.

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -900,7 +900,7 @@ function failureFromError(error: unknown, actionId: number): EngineError {
   logUnrecognizedExecutionFailure('action', actionId, error)
   return new EngineError(
     500,
-    'the city hit an internal failure running this action; that failure is not something you did, so retry once, then contact the city operator if it keeps failing',
+    'the city could not complete the action because of an internal failure; retry once, then contact the city operator if it keeps failing',
   )
 }
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -898,7 +898,10 @@ function failureFromError(error: unknown, actionId: number): EngineError {
   if (gazetteRoomError) return new EngineError(409, gazetteRoomError)
   if (isRetryableCollision(error)) return new EngineError(409, COLLISION_CONFLICT_MESSAGE)
   logUnrecognizedExecutionFailure('action', actionId, error)
-  return new EngineError(500, 'the city could not complete this action because its primitive failed; correct the primitive refusal shown in action.error before retrying')
+  return new EngineError(
+    500,
+    'the city hit an internal failure running this action; that failure is not something you did, so retry once, then contact the city operator if it keeps failing',
+  )
 }
 
 async function recordFailedExecution(

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2308,7 +2308,7 @@ test('a recognized internal engine failure is generic in the public record', asy
 
   assert.equal(result.status, 'failed')
   assert.equal(result.httpStatus, 500)
-  const expectedError = 'the city hit an internal failure running this action; that failure is not something you did, so retry once, then contact the city operator if it keeps failing'
+  const expectedError = 'the city could not complete the action because of an internal failure; retry once, then contact the city operator if it keeps failing'
   assert.equal(result.error, expectedError)
   assert.equal(logged.length, 1)
   assert.deepEqual(logged[0]?.[1], {
@@ -2362,7 +2362,7 @@ test('an unknown action failure is generic in the public record but useful in se
 
   assert.equal(result.status, 'failed')
   assert.equal(result.httpStatus, 500)
-  const expectedError = 'the city hit an internal failure running this action; that failure is not something you did, so retry once, then contact the city operator if it keeps failing'
+  const expectedError = 'the city could not complete the action because of an internal failure; retry once, then contact the city operator if it keeps failing'
   assert.equal(result.error, expectedError)
   assert.equal(logged.length, 1)
   assert.equal(logged[0]?.[0], 'unrecognized action execution failure')

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2308,7 +2308,7 @@ test('a recognized internal engine failure is generic in the public record', asy
 
   assert.equal(result.status, 'failed')
   assert.equal(result.httpStatus, 500)
-  const expectedError = 'the city could not complete this action because its primitive failed; correct the primitive refusal shown in action.error before retrying'
+  const expectedError = 'the city hit an internal failure running this action; that failure is not something you did, so retry once, then contact the city operator if it keeps failing'
   assert.equal(result.error, expectedError)
   assert.equal(logged.length, 1)
   assert.deepEqual(logged[0]?.[1], {
@@ -2362,7 +2362,7 @@ test('an unknown action failure is generic in the public record but useful in se
 
   assert.equal(result.status, 'failed')
   assert.equal(result.httpStatus, 500)
-  const expectedError = 'the city could not complete this action because its primitive failed; correct the primitive refusal shown in action.error before retrying'
+  const expectedError = 'the city hit an internal failure running this action; that failure is not something you did, so retry once, then contact the city operator if it keeps failing'
   assert.equal(result.error, expectedError)
   assert.equal(logged.length, 1)
   assert.equal(logged[0]?.[0], 'unrecognized action execution failure')

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -2387,6 +2387,44 @@ test('an unknown action failure is generic in the public record but useful in se
   )
 })
 
+test('an internal engine failure does not tell the caller to read action.error', async t => {
+  const logged: unknown[][] = []
+  t.mock.method(console, 'error', (...values: unknown[]) => {
+    logged.push(values)
+  })
+  const { db } = fakeSql(({ text }) => {
+    if (/FROM resident_presence/.test(text)) {
+      return [{ resident_id: 7, current_place_id: 2, home_place_id: 3, updated_at: 'now' }]
+    }
+    if (/INSERT INTO action_runs/.test(text)) return [{ id: 118 }]
+    if (/FROM active_blocks/.test(text)) return [{ blocked: false }]
+    if (/INSERT INTO action_resolutions/.test(text)) return [{ id: 218 }]
+    return []
+  })
+
+  const result = await runAction({
+    actorId: 7,
+    actorHandle: 'tiny-lantern',
+    action: 'make',
+    placeId: 2,
+    primitiveHandledByCaller: true,
+    performPrimitive: async () => {
+      throw new EngineError(500, 'database returned an invalid private result')
+    },
+  }, db)
+
+  assert.equal(result.status, 'failed')
+  assert.equal(result.httpStatus, 500)
+  assert.ok(result.error)
+  // The recorded action.error must not send the caller back to the very
+  // field it is reading, and must not repeat the old circular sentence.
+  assert.doesNotMatch(result.error ?? '', /action\.error/u)
+  assert.notEqual(
+    result.error,
+    'the city could not complete this action because its primitive failed; correct the primitive refusal shown in action.error before retrying',
+  )
+})
+
 test('extra caller JSON cannot inject a forged law program', async () => {
   const { db, calls } = fakeSql(({ text }) => {
     if (/FROM resident_presence/.test(text)) {


### PR DESCRIPTION
## What was wrong

When an action's primitive failed inside the engine, `failureFromError` (`src/engine.ts`, around line 901) shaped a generic 500 whose text told the caller to "correct the primitive refusal shown in action.error before retrying." `recordFailedExecution` then stored that same sentence as `action.error`. The caller read a self-referential instruction pointing back at the field it was already reading, and never learned the actual cause -- that only ever reached the server log via `logUnrecognizedExecutionFailure`.

This is what left residents scree (#95) and ephemeris (#135) stuck seeing `effects_applied: 0` on the destroy brick for two weeks with no way to say why (root cause was a 42702 error visible only in logs, fixed in #186). Found during the #186 review; #177 is a related but distinct raw-constraint-error case.

## What changed (round 1, 0fa2858)

`failureFromError` is the one place engine-level 500s are shaped, so the fix lives there (`src/engine.ts`). Its generic branch stopped naming `action.error`, added a retry-or-report instruction, and `test/engine.test.ts` had two existing tests pinned to the old sentence updated to match, plus a new regression test proving `action.error` never matches `/action\.error/` and is never the old circular sentence.

## What changed (round 2, this update)

An Opus review of round 1 (`fix_first` verdict) found the round-1 wording, while no longer circular, diverged from the front-door contract and made an unbacked fault claim, and flagged a caller-visible pair of same-file 500s the round-1 sweep missed. Addressed:

- **Message wording** (`src/engine.ts`): `failureFromError`'s generic branch now reads exactly:
  > "the city could not complete the action because of an internal failure; retry once, then contact the city operator if it keeps failing"

  This literally reuses "the city could not complete the action" from `src/frontdoor.txt:1119` ("An unexpected city failure says that the city could not complete the action..."), so the front-door description and the actual message agree word for word without editing `frontdoor.txt` or regenerating its mirrors (`npm run door:check` confirms no mirror diff). It also drops the round-1 claim "that failure is not something you did" -- an affirmative fault disclaimer the generic branch cannot always back, since it also catches unmapped raw Postgres constraint errors triggered by caller input (the #177 shape), where retrying the same input will not help. The two `test/engine.test.ts` cases pinned to the round-1 text are updated to the new wording.
- **CHANGELOG** (`CHANGELOG.md` / `src/changelog-source.ts`): added a "For residents" entry under 2026-09-03 recording the wording change, regenerated the embedded source with `scripts/embed-changelog.mjs`. `test/changelog.test.ts` passes (its one-sentence-per-item rule required rephrasing around the literal `action.error` token, since a stray internal `.` reads as a second sentence).

### Reported, not fixed here

The review also found that `src/engine.ts`'s local `rowId` (line 268) and `queryRows` (line 291) throw caller-visible 500s (`database returned an invalid ${field}` / `database returned an invalid result`) that lack the `; retry once, then contact the city operator` suffix every other copy of these identical helpers carries (`src/engine-effects.ts:109/129`, `src/engine-target-scope.ts:5/12`, `src/engine-timer-store.ts:27/34`). This is a real gap in the same honest-status class #188 was an instance of, but it is **not fixed in this PR**: `docs/audits/2026-09-refusal-census.md` records the exact current literal text of both messages as census entries, and `test/refusal-census-audit.test.ts` enforces exact-set equality between that manifest and every EngineError literal discovered by source scan. Changing the message text without regenerating the census manifest (and its `test/refusal-honesty-a-m.test.ts` coverage) is a separate, larger change than the wording fix here, so per AGENTS.md ("adjacent problems are reported, not silently fixed") it is filed as **#198** instead, with the exact fix and file:line detail.

## How it's proven

- `test/engine.test.ts`: "an internal engine failure does not tell the caller to read action.error" (added round 1, still passing) asserts `action.error` never matches `/action\.error/` and is never the old circular sentence. The two existing generic-500 tests are updated to the round-2 wording; both pass.
- `npm run typecheck` -- clean.
- `npm test` -- 1906 tests, 1902 pass, 4 fail. The 4 failures are the pre-existing Windows-only `identity-client.test.ts` local-credentials-file failures tracked in #183, unrelated to this change (present on `main` before this branch).
- `npm run door:check` -- passes; `src/door.ts` / `docs/published/FRONTDOOR.md` regenerate with no diff, confirming the message now agrees with the existing front-door text without needing a `frontdoor.txt` edit.
- `test/changelog.test.ts`, `test/refusal-census-audit.test.ts`, and both `test/refusal-honesty-*.test.ts` files all pass, confirming the message-text change did not disturb the refusal census (`failureFromError`'s `EngineError` is returned, not thrown, so it is not a census-scanned producer -- only the two `rowId`/`queryRows` sites reported above are).

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Live verification evidence (round-2 review, before merge)

Deployment for head ef12191 found via `gh api repos/onetapstudiogames/1f3d9/deployments -f sha=ef1219...` -> id 6256295569, environment Preview, created 2026-09-04T01:49:35Z; its statuses endpoint reports state "success", environment_url https://1f3d9-2t5u06j37-onetapstudiogames-projects.vercel.app. Three probes, all read-only or refusal-only. (1) GET / -> HTTP 200, content-type text/plain; charset=UTF-8, body opens "1F3D9 — THE CITY / ================ / U+1F3D9, CITYSCAPE. https://1f3d9-hosted-chat-preview.vercel.app" — the head build serves. (2) GET /changelog -> HTTP 200 text/html; charset=UTF-8, line 63 contains "<li>An unexpected internal city failure on an action now says it is an internal city failure and tells you to retry once, then contact the city operator, instead of pointing you back at the very field you were already reading.</li>"; GET /changelog.txt -> HTTP 200 text/plain; charset=UTF-8, line 9 is the same sentence as a "- " bullet. This is live proof that round-2's CHANGELOG fix reached both published changelog surfaces named at src/frontdoor.txt:1607 and src/llms.txt:360, not merely the repo file. (3) POST /api/action with Content-Type: application/json, body {"action":"go_home"}, no Authorization -> HTTP 401 and exactly {"error":"resident sign-in failed because Authorization: Bearer is missing or does not contain a current city key; send your saved current key as Authorization: Bearer <key>"} — the /api/action refusal shape and wording are unchanged by this PR. The changed branch itself (an unexpected internal engine failure inside runAction) cannot be induced from outside with a read-only or refusal-only request, so the new 500 body was not observed live; see unverified.

The changed 500 branch itself cannot be induced from outside with a read-only or refusal-only request; it is proven by unit test only (test/engine.test.ts).
