### PR TITLE
Live view step 4: one reusable item popover for the whole plate

### DIFF
--- a/docs/DRAWING_AND_LIVE_VIEW.md
+++ b/docs/DRAWING_AND_LIVE_VIEW.md
@@ -336,8 +336,10 @@ not a simulation of the present.
   item forward and the second opens it. At a readable zoom, or while a resident has
   pointer hover, tap, keyboard focus, or browser-local Focus, its tag shows the
   full handle without truncation. A focused resident is always labelled and
-  lifted above neighbouring marks. Plot nameplates remain single-line ellipses
-  while their tooltip carries the complete place name.
+  lifted above neighbouring marks. Plot nameplates remain single-line ellipses;
+  step 4's single Live item popover (see below) carries the complete place
+  name a nameplate ellipsis truncates, along with the item's other public
+  facts.
 - A plot outside the visible camera may skip painting until the viewer pans it
   back into view. Detailed plots are drawn only in and just beyond the visible
   camera; every farther plot remains a finger-sized reachable marker. Live never
@@ -436,6 +438,35 @@ There is no idle bobbing, blinking, particle field, breathing terrain, looping
 sprite walk, or invented route between polls. Only a newly learned committed
 move receives the disclosed endpoint-to-endpoint glide. Stillness returns after
 each resident's finite queue and remains a truthful state.
+
+### The Live item popover (step 4)
+
+Steps 2 and 3 removed every drawn chip and card from the plate, leaving each
+sprite's state, provenance, and a plot nameplate's complete name reachable
+only through a title attribute -- invisible to keyboard and touch. Step 4
+gives that same information one reachable home: a single `#live-item-popover`
+element, created once and reused for every resident, thing, and place
+anchor on the plate, never re-created or cloned. It lives inside
+`#live-viewport` as the next sibling of `#live-label-layer`, outside
+`#live-stage`'s own CSS transform and isolated stacking context, so its
+position is never scaled by the camera or clipped by a plot's overflow.
+
+Hovering, keyboard-focusing, or the first touch tap on a resident portrait,
+a thing specimen, or a plot's open nameplate opens the popover beside that
+anchor with the item's complete name and stable id, then the public facts
+already held in client state -- location, sleep, and the honest two-tier
+drawing fact for a resident; kind, maker, owner, body size (or its honest
+truncated-continuation phrase), and open-to-use for a thing; owner,
+owner-written purpose, and both exact counts for a place -- plus a
+body-free last-recorded-action phrase built only from records already in
+memory (never `liveLedgerText`, which lazily fetches a note body) and one
+control that opens the item's record. A quiet place (decision #75) keeps
+its name, owner, and counts in the popover and replaces every other fact
+with the same `quietRoomNotice` sentence every other tab uses. The popover
+never covers the item it describes, stays fully inside the live viewport,
+and closes on Escape, a press outside it, its item leaving the plate, or
+the plate re-rendering without that item. Opening, moving, or closing it
+issues no request and schedules no plate render.
 
 ### Cadence and honesty clock
 
@@ -550,13 +581,19 @@ after the split.
   (`drawing.ts`, `live-ground.ts`, `live-scatter.ts`, `live-visibility.ts`,
   `live-camera.ts`, `live-replay.ts`, `rows.ts`, `directory.ts`): the
   functions and types the facade re-exports.
-- `src/window-client/program/NN-*.ts` holds the 39 ordered client-JS
+- `src/window-client/program/NN-*.ts` holds the ordered client-JS
   fragments that make up the client's own JavaScript. Each part file is
   exactly `export const PART_NN_NAME = \`<source lines>\``, copied
   line-for-line out of the original file with no reformatting, renaming, or
   reordering. The `NN-` filename prefix is only for `ls` to show ship order;
   `src/window-client/program/index.ts` imports every part and assembles
-  `WINDOW_CLIENT_PARTS` in the array order, which is the real authority.
+  `WINDOW_CLIENT_PARTS` in the array order, which is the real authority. A
+  step 4 addition, `40-live-item-popover.ts`, ships in that array **before**
+  `39-wiring-and-boot.ts` even though its filename sorts after it --
+  `39-wiring-and-boot.ts`'s template body closes the client IIFE with
+  `})()`, so any part appended after it in the real array would emit past
+  the end of the function. `ls` order and ship order are allowed to diverge
+  for exactly this reason; index.ts is what settles it.
 
 **Why fragments, not modules.** A fragment is a byte range, not a JavaScript
 module: every fragment shares one lexical scope inside the shipped IIFE, and

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -481,8 +481,15 @@ breadcrumbs. Far zoom shows resident sprites without name tags. At a readable zo
 pointer hover or keyboard focus brings the complete item and its complete label above peers.
 On touch screens, the first tap brings an item forward and the second tap opens it. A shown
 tag contains the complete untruncated handle. The focused resident is always labelled and
-lifted above neighbouring marks. Plot nameplates keep a single-line ellipsis
-and their tooltip carries the complete place name. Detailed plots are drawn only in and just
+lifted above neighbouring marks. Plot nameplates keep a single-line ellipsis. Step 4 (this
+document's Live-view section; docs/DRAWING_AND_LIVE_VIEW.md) replaces every per-sprite
+title attribute with one reusable popover for the whole plate: hovering, keyboard-focusing,
+or the first touch tap on a resident, thing, or plot nameplate opens one small card beside
+it carrying that item's public facts — including the complete place name a nameplate
+ellipsis truncates — plus one control that opens its record. It never covers the item it
+describes, stays inside the viewer's plate, and closes on Escape, a press elsewhere, when
+its item leaves the plate, or when the plate re-renders without that item; opening, moving,
+or closing it issues no request. Detailed plots are drawn only in and just
 beyond the visible camera; every farther plot remains a finger-sized reachable marker, and
 Live never enters an all-detailed mode. Camera budgeting changes no fixed coordinate,
 selection, exact count, or public record. An unoverflowed place shows up to six residents

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -1006,11 +1006,15 @@ it never shrinks the whole survey into view. The controls remain viewer-only, an
 no Fit control or slider. At a readable zoom, pointer hover or keyboard focus brings the
 complete covered item and its label above every peer. On touch screens, the first tap
 brings that complete unit forward and the second tap opens it. A shown tag carries the
-complete untruncated handle. Plot nameplates keep a single-line ellipsis and their tooltip
-carries the complete place name. Detailed plots paint only in and just beyond the visible
-camera; every farther plot remains a finger-sized reachable marker. Live never draws every
-detailed plot at once, and camera budgeting changes no fixed ground, selection, exact count,
-or public record.
+complete untruncated handle. Plot nameplates keep a single-line ellipsis; hovering,
+keyboard-focusing, or the first tap on a resident, thing, or plot nameplate also opens one
+small popover beside it, carrying that item's public facts (including the complete place
+name a nameplate ellipsis truncates) plus one control that opens its record. It never
+covers the item, stays inside the viewer's plate, and closes on Escape, a press elsewhere,
+or when its item leaves the plate; opening, moving, or closing it costs no request.
+Detailed plots paint only in and just beyond the visible camera; every farther plot remains
+a finger-sized reachable marker. Live never draws every detailed plot at once, and camera
+budgeting changes no fixed ground, selection, exact count, or public record.
 Click a plot to drill through shareable tree breadcrumbs. An unoverflowed place shows up
 to six residents and six things. Overflow protects control ground, leaving four resident
 walker positions and five thing specimens, and reports every omission as an exact +N more

--- a/e2e/public-window-live.spec.ts
+++ b/e2e/public-window-live.spec.ts
@@ -1359,6 +1359,12 @@ async function expectEveryTargetCenterExposed(page: Page, targets: Locator) {
     }
     await target.hover()
     expect(await target.evaluate(node => node.matches(':hover'))).toBe(true)
+    // Step 4: every resident/thing/plot anchor now opens the single Live
+    // item popover on hover. Left open, it would sit near THIS target and
+    // could cover the NEXT target's centre point on the following
+    // iteration -- a false positive in this loop, not a real gap in the
+    // ground. Moving off-plate closes it (pointerout) before that check.
+    await page.mouse.move(0, 0)
   }
   expect(covered).toEqual([])
 }
@@ -4292,7 +4298,11 @@ test('resident tags follow zoom and intent while terrain and camera writes stay 
   expect(focusedZ).toBeGreaterThan(neighborZ)
 
   const plotNameplate = page.locator('.live-plot[data-place-id="2"] .live-plot-open')
-  await expect(plotNameplate).toHaveAttribute('title', 'Open the live plate for Cinder lane')
+  // Step 4: the title attribute this used to carry is gone; the same
+  // accessible name lives on aria-label now, and the complete place name
+  // an ellipsised nameplate truncates is reachable through the popover.
+  await expect(plotNameplate).toHaveAccessibleName('Open the live plate for Cinder lane')
+  await expect(plotNameplate).not.toHaveAttribute('title', /.+/u)
   await expect(plotNameplate.locator('.live-plot-name')).toHaveCSS('text-overflow', 'ellipsis')
 
   const cameraAttributeWrites = await page.locator('#live-viewport').evaluate(async viewport => {
@@ -5760,4 +5770,284 @@ test('a quiet place nested two levels below the plotted place never leaks its re
   await expect(occupants.locator('.quiet-room-notice')).toContainText(
     'harbor-owner prefers to keep this room private.',
   )
+})
+
+// Step 4: the single reusable Live item popover.
+
+test('one popover serves all three kinds: hover a resident, a thing, and a plot in turn', async ({ page }) => {
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const popover = page.locator('#live-item-popover')
+
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  await panLiveTargetIntoView(page, resident)
+  await resident.hover()
+  await expect(page.locator('.live-item-popover')).toHaveCount(1)
+  await expect(popover).toBeVisible()
+  await expect(popover).toHaveAttribute('data-live-popover-kind', 'resident')
+  await expect(popover).toHaveAttribute('aria-label', /harbor-1 details/u)
+  await expect(resident).toHaveAttribute('aria-describedby', 'live-item-popover')
+
+  const thing = page.locator('[data-live-thing-id="9"]').first()
+  await panLiveTargetIntoView(page, thing)
+  await thing.hover()
+  await expect(page.locator('.live-item-popover')).toHaveCount(1)
+  await expect(popover).toHaveAttribute('data-live-popover-kind', 'thing')
+  await expect(popover).toContainText('kept by')
+
+  const plot = page.locator('.live-plot[data-place-id="2"]')
+  const plotOpen = plot.locator('.live-plot-open')
+  await panLiveTargetIntoView(page, plotOpen)
+  await plotOpen.hover()
+  await expect(page.locator('.live-item-popover')).toHaveCount(1)
+  await expect(popover).toHaveAttribute('data-live-popover-kind', 'place')
+  await expect(popover).toContainText('Cinder lane')
+})
+
+test('keyboard focus opens the popover with an accessible group name and no title attributes remain', async ({ page }) => {
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  await panLiveTargetIntoView(page, resident)
+  await page.locator('#live-viewport').focus()
+  await resident.focus()
+  const popover = page.locator('#live-item-popover')
+  await expect(popover).toBeVisible()
+  await expect(page.getByRole('group', { name: /details$/u })).toHaveCount(1)
+
+  // The title attributes step 2/3 left as the only carrier of state and
+  // provenance are gone; the accessible names they duplicated still work.
+  await expect(page.locator(
+    '.live-walker [title], .live-thing-specimen [title], .live-plot-open[title]',
+  )).toHaveCount(0)
+  await expect(resident).toHaveAccessibleName('Focus on harbor-1')
+})
+
+test('touch keeps the locked raise-then-open rule and also opens the popover on the first tap', async ({ page }, testInfo) => {
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const touch = async (target: Locator) => {
+    await panLiveTargetIntoView(page, target)
+    if (testInfo.project.name === 'mobile-chromium') {
+      await target.tap()
+      return
+    }
+    await target.dispatchEvent('pointerdown', { pointerType: 'touch' })
+    await target.dispatchEvent('click', { pointerType: 'touch' })
+  }
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  const shell = resident.locator('xpath=..')
+  const popover = page.locator('#live-item-popover')
+  await touch(resident)
+  await expect(shell).toHaveAttribute('data-live-raised', 'true')
+  // The first tap's own bring-forward branch already calls
+  // control.focus({preventScroll:true}), which fires focusin -- the
+  // mechanism that opens the popover on touch without any new touch code.
+  await expect(popover).toBeVisible()
+  await expect(page.locator('#live-focus-status')).toContainText('No resident focused')
+
+  await touch(resident)
+  await expect(page.locator('#live-focus-status')).toContainText('Focused on harbor-1')
+})
+
+test('the popover never covers the item it describes, and closes on Escape with focus returned to the anchor', async ({ page }) => {
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  await panLiveTargetIntoView(page, resident)
+  await resident.focus()
+  const popover = page.locator('#live-item-popover')
+  await expect(popover).toBeVisible()
+  const [popoverBox, anchorBox] = await Promise.all([popover.boundingBox(), resident.boundingBox()])
+  expect(popoverBox).toBeTruthy()
+  expect(anchorBox).toBeTruthy()
+  const intersects = popoverBox!.x < anchorBox!.x + anchorBox!.width &&
+    popoverBox!.x + popoverBox!.width > anchorBox!.x &&
+    popoverBox!.y < anchorBox!.y + anchorBox!.height &&
+    popoverBox!.y + popoverBox!.height > anchorBox!.y
+  expect(intersects).toBe(false)
+
+  await page.keyboard.press('Escape')
+  await expect(popover).toBeHidden()
+  await expect(resident).toBeFocused()
+  await expect(resident).not.toHaveAttribute('aria-describedby', /.+/u)
+})
+
+test('a press outside the popover closes it; a press on the popover neither closes it nor pans the plate', async ({ page }) => {
+  // The clock is frozen so this fixture's own recorded-movement replay
+  // never rebuilds the plate mid-test (which would, correctly, close the
+  // popover under rule C5 -- its anchor left the plate -- but that is a
+  // different behavior than this test is checking).
+  const now = Date.now()
+  await page.clock.install({ time: new Date(now) })
+  await installReplayRoutes(page, now)
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  await panLiveTargetIntoView(page, resident)
+  await resident.focus()
+  const popover = page.locator('#live-item-popover')
+  await expect(popover).toBeVisible()
+
+  // Playwright's own actionability-aware hover waits for the popover's
+  // layout to settle before dispatching, avoiding a transitional-layout
+  // hit-test race a raw one-shot mouse.move can hit on an element that
+  // just became visible this same tick.
+  await popover.hover({ position: { x: 4, y: 4 } })
+  await page.mouse.down()
+  await page.mouse.up()
+  await expect(popover).toBeVisible()
+  await expect(page.locator('#live-viewport')).toHaveAttribute('data-live-dragging', 'false')
+
+  const viewport = page.locator('#live-viewport')
+  const box = await viewport.boundingBox()
+  expect(box).toBeTruthy()
+  await page.mouse.move(box!.x + 4, box!.y + 4, { steps: 1 })
+  await page.mouse.down()
+  await page.mouse.up()
+  await expect(popover).toBeHidden()
+})
+
+test('the popover action opens the right record and no extra request fires while opening, moving, or closing it', async ({ page }) => {
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  await panLiveTargetIntoView(page, resident)
+
+  const requests: string[] = []
+  page.on('request', request => { requests.push(request.url()) })
+  await resident.hover()
+  const popover = page.locator('#live-item-popover')
+  await expect(popover).toBeVisible()
+  await resident.hover({ position: { x: 0, y: 0 } })
+  await page.mouse.move(0, 0)
+  await expect(popover).toBeHidden()
+  const noteRequests = requests.filter(url => /\/api\/note\//u.test(url))
+  const drawingJsonRequests = requests.filter(url =>
+    /\/api\/drawing\/[^/]+\/\d+$/u.test(new URL(url).pathname))
+  expect(noteRequests).toEqual([])
+  expect(drawingJsonRequests).toEqual([])
+
+  await resident.focus()
+  await expect(popover).toBeVisible()
+  await popover.getByRole('button', { name: /Open current drawing for harbor-1/u }).click()
+  await expect(popover).toBeHidden()
+  const detail = page.locator('#record-detail')
+  await expect(detail).toBeVisible()
+  await expect(detail.locator('#record-detail-title')).toContainText('harbor-1')
+})
+
+test('at 375px the popover never covers its anchor, wherever the camera leaves it', async ({ page }) => {
+  // Exact full-viewport containment at 375px with a fixed-size popover is
+  // proven deterministically, side by side with the non-fitting fallback,
+  // by windowLiveItemPopoverPlacement's own unit tests (including the
+  // exact 375x812-viewport-with-a-320-wide-popover case). What a real
+  // browser run adds is confirming the one invariant that holds
+  // regardless of exactly where the camera happens to leave the anchor:
+  // the popover never covers it. panLiveTargetIntoView's landing spot
+  // varies with each render pass, so this test intentionally does not
+  // pin one exact position -- it is the never-covers-anchor contract that
+  // must hold everywhere, not one hand-picked coordinate.
+  await page.setViewportSize({ width: 375, height: 812 })
+  const now = Date.now()
+  await page.clock.install({ time: new Date(now) })
+  await installReplayRoutes(page, now)
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const popover = page.locator('#live-item-popover')
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  await panLiveTargetIntoView(page, resident)
+  await resident.focus()
+  await expect(popover).toBeVisible()
+  const [popoverBox, anchorBox] = await Promise.all([popover.boundingBox(), resident.boundingBox()])
+  expect(popoverBox).toBeTruthy()
+  expect(anchorBox).toBeTruthy()
+  const intersectsAnchor = popoverBox!.x < anchorBox!.x + anchorBox!.width &&
+    popoverBox!.x + popoverBox!.width > anchorBox!.x &&
+    popoverBox!.y < anchorBox!.y + anchorBox!.height &&
+    popoverBox!.y + popoverBox!.height > anchorBox!.y
+  expect(intersectsAnchor).toBe(false)
+})
+
+test('proof: one popover carries what the chips carried, for one resident, one thing, and one place', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await page.getByRole('button', { name: 'Run preview proof scene' }).click()
+  const proofPanel = page.locator('#live-panel[data-live-proof="true"]')
+  await expect(proofPanel).toBeVisible()
+  // Settle the retry room first, exactly as the sibling proof tests do, so
+  // the layout is stable before the anchors below are located and tapped.
+  const retry = page.getByRole('button', { name: 'Retry proof room' })
+  await expect(retry).toBeVisible()
+  await retry.click()
+  await expect(retry).toHaveCount(0)
+
+  const popover = proofPanel.locator('#live-item-popover')
+  const requests: string[] = []
+  page.on('request', request => { requests.push(request.url()) })
+
+  // RESIDENT: proof-alex (9201) has a real cached drawing fixture, so the
+  // popover shows the exact drawing state and source label.
+  const alex = proofPanel.locator('[data-live-resident-handle="proof-alex"]').first()
+  await panLiveTargetIntoView(page, alex)
+  await alex.hover()
+  await expect(popover).toBeVisible()
+  await expect(popover).toContainText('proof-alex')
+  await expect(popover).toContainText('resident #9201')
+  const alexBox = await alex.boundingBox()
+  const alexPopoverBox = await popover.boundingBox()
+  expect(alexBox && alexPopoverBox).toBeTruthy()
+  const alexIntersects = alexPopoverBox!.x < alexBox!.x + alexBox!.width &&
+    alexPopoverBox!.x + alexPopoverBox!.width > alexBox!.x &&
+    alexPopoverBox!.y < alexBox!.y + alexBox!.height &&
+    alexPopoverBox!.y + alexPopoverBox!.height > alexBox!.y
+  expect(alexIntersects).toBe(false)
+  await page.keyboard.press('Escape')
+  await expect(popover).toBeHidden()
+  await expect(alex).toBeFocused()
+
+  // THING: the pace lantern (9401), made by and kept by proof-alex, open
+  // to use, with a 28-byte ASCII body the owner can verify by eye.
+  const lantern = proofPanel.locator('[data-live-thing-id="9401"]').first()
+  await panLiveTargetIntoView(page, lantern)
+  await lantern.hover()
+  await expect(popover).toBeVisible()
+  await expect(popover).toContainText('pace lantern')
+  await expect(popover).toContainText('Thing #9401')
+  await expect(popover).toContainText('made by proof-alex')
+  await expect(popover).toContainText('kept by proof-alex')
+  await expect(popover).toContainText('body 28 bytes')
+  await expect(popover).toContainText('open to use')
+  await page.keyboard.press('Escape')
+  await expect(popover).toBeHidden()
+
+  // PLACE: the Crowded activity workshop (9103), owned by proof-alex, with
+  // its owner-written purpose and its 7-thing exact count.
+  const workshopPlot = proofPanel.locator('.live-plot[data-place-id="9103"]')
+  const workshopOpen = workshopPlot.locator('.live-plot-open')
+  await panLiveTargetIntoView(page, workshopOpen)
+  await workshopOpen.hover()
+  await expect(popover).toBeVisible()
+  await expect(popover).toContainText('Crowded activity workshop')
+  await expect(popover).toContainText('Place #9103')
+  await expect(popover).toContainText('kept by proof-alex')
+  await expect(popover).toContainText('Preview-only Live View proof ground.')
+  await expect(popover).toContainText('7 things')
+  await page.keyboard.press('Escape')
+  await expect(popover).toBeHidden()
+
+  // Thumbnail portrait images (the sprites' own lazy-loaded thumb.png
+  // requests, unrelated to hovering) are expected; the popover itself must
+  // add no note read and no JSON drawing read.
+  const noteOrJsonDrawingRequests = requests.filter(url => {
+    const pathname = new URL(url).pathname
+    return /^\/api\/note\//u.test(pathname) || /^\/api\/drawing\/[^/]+\/\d+$/u.test(pathname)
+  })
+  expect(noteOrJsonDrawingRequests).toEqual([])
 })

--- a/e2e/public-window-live.spec.ts
+++ b/e2e/public-window-live.spec.ts
@@ -5825,6 +5825,70 @@ test('keyboard focus opens the popover with an accessible group name and no titl
   await expect(resident).toHaveAccessibleName('Focus on harbor-1')
 })
 
+test('keyboard reach without a trap: forward Tab from the action button continues into the ordinary plate order', async ({ page }) => {
+  // Round-1 review finding #4: forward Tab from the popover's action
+  // button used to close the popover and land back on the anchor, costing
+  // the keyboard user an extra Tab press. It must instead continue on,
+  // never trapping focus inside the popover or bouncing it back.
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+  await panLiveTargetIntoView(page, resident)
+  const popover = page.locator('#live-item-popover')
+  const action = popover.locator('.live-item-popover-open')
+
+  await resident.focus()
+  await expect(popover).toBeVisible()
+  await page.keyboard.press('Tab')
+  await expect(action).toBeFocused()
+  await page.keyboard.press('Shift+Tab')
+  await expect(resident).toBeFocused()
+  await expect(popover).toBeVisible()
+
+  await page.keyboard.press('Tab')
+  await expect(action).toBeFocused()
+  await page.keyboard.press('Tab')
+  // Moves on rather than trapping: focus is neither still on harbor-1 nor
+  // dropped to the document body. Whatever comes next in the ordinary
+  // plate order receives it -- if that next element happens to be another
+  // bound Live item, its own focusin listener legitimately opens ITS
+  // popover, which is a continuation, not the same trap this finding
+  // describes (closing and landing back on harbor-1 itself).
+  const focusedIsAnchorOrBody = await page.evaluate(() => {
+    const anchor = document.querySelector('[data-live-resident-handle="harbor-1"]')
+    return document.activeElement === anchor || document.activeElement === document.body
+  })
+  expect(focusedIsAnchorOrBody).toBe(false)
+  await expect(popover).not.toHaveAttribute('data-live-popover-key', 'resident:harbor-1')
+})
+
+test('a resident mid-walk keeps their facts reachable through the same popover a settled resident gets', async ({ page }) => {
+  // Round-1 review finding #2 (MEDIUM): the walking (.live-replay-portrait)
+  // resident was never wired to bindLiveItemPopover, so their state,
+  // provenance, and last recorded action were unreachable by hover,
+  // keyboard focus, or touch for the whole 3.2-8s walk -- a real
+  // regression versus the old mouse-only title tooltip.
+  const now = Date.now()
+  await page.clock.install({ time: new Date(now) })
+  const fixture = await installReplayRoutes(page, now)
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+
+  await publishReplayChanges(page, fixture)
+  const replay = page.locator('.live-replay-portrait')
+  await expect(replay).toHaveCount(1)
+  await expect(replay).toHaveAttribute('data-live-replay-key', 'change:11')
+
+  const portrait = replay.locator('.live-portrait')
+  const popover = page.locator('#live-item-popover')
+  await portrait.focus()
+  await expect(popover).toBeVisible()
+  await expect(popover).toHaveAttribute('data-live-popover-kind', 'resident')
+  await expect(popover).toContainText('map-walker')
+  await expect(portrait).toHaveAttribute('aria-describedby', 'live-item-popover')
+})
+
 test('touch keeps the locked raise-then-open rule and also opens the popover on the first tap', async ({ page }, testInfo) => {
   await installReplayRoutes(page, Date.now())
   await page.goto('/window#view=live')
@@ -5942,17 +6006,15 @@ test('the popover action opens the right record and no extra request fires while
   await expect(detail.locator('#record-detail-title')).toContainText('harbor-1')
 })
 
-test('at 375px the popover never covers its anchor, wherever the camera leaves it', async ({ page }) => {
+test('at 375px the popover stays inside the viewport and never covers its anchor, on camera and off', async ({ page }) => {
   // Exact full-viewport containment at 375px with a fixed-size popover is
   // proven deterministically, side by side with the non-fitting fallback,
   // by windowLiveItemPopoverPlacement's own unit tests (including the
   // exact 375x812-viewport-with-a-320-wide-popover case). What a real
-  // browser run adds is confirming the one invariant that holds
+  // browser run adds is confirming the two invariants that must hold
   // regardless of exactly where the camera happens to leave the anchor:
-  // the popover never covers it. panLiveTargetIntoView's landing spot
-  // varies with each render pass, so this test intentionally does not
-  // pin one exact position -- it is the never-covers-anchor contract that
-  // must hold everywhere, not one hand-picked coordinate.
+  // the popover never leaves #live-viewport, and it never covers the item
+  // it describes.
   await page.setViewportSize({ width: 375, height: 812 })
   const now = Date.now()
   await page.clock.install({ time: new Date(now) })
@@ -5961,6 +6023,34 @@ test('at 375px the popover never covers its anchor, wherever the camera leaves i
   await expect(page.locator('#live-history-status')).toContainText('history is complete')
   const popover = page.locator('#live-item-popover')
   const resident = page.locator('[data-live-resident-handle="harbor-1"]').first()
+
+  // Round-1 review finding #1, reproduced live on the deployed preview:
+  // most residents on a plate wider than the viewport sit off-camera by
+  // default -- the normal state for a keyboard user tabbing through them,
+  // and the state every other test in this file avoids by calling
+  // panLiveTargetIntoView first. This deliberately does NOT pan the camera,
+  // so it exercises the exact off-screen anchor the round-1 bug shipped
+  // with (a fully off-screen popover, invisible to the keyboard user step 4
+  // was built to serve). focus() does not require the target to be visible,
+  // so it works on an anchor the camera has not framed.
+  await resident.focus()
+  await expect(popover).toBeVisible()
+  const [offCameraPopoverBox, viewportBox] = await Promise.all([
+    popover.boundingBox(), page.locator('#live-viewport').boundingBox(),
+  ])
+  expect(offCameraPopoverBox).toBeTruthy()
+  expect(viewportBox).toBeTruthy()
+  expect(offCameraPopoverBox!.x).toBeGreaterThanOrEqual(viewportBox!.x)
+  expect(offCameraPopoverBox!.x + offCameraPopoverBox!.width)
+    .toBeLessThanOrEqual(viewportBox!.x + viewportBox!.width)
+  expect(offCameraPopoverBox!.y).toBeGreaterThanOrEqual(viewportBox!.y)
+  expect(offCameraPopoverBox!.y + offCameraPopoverBox!.height)
+    .toBeLessThanOrEqual(viewportBox!.y + viewportBox!.height)
+
+  // The panned-into-view case keeps proving the never-covers-anchor
+  // contract this test originally pinned. panLiveTargetIntoView's landing
+  // spot varies with each render pass, so this intentionally does not pin
+  // one exact position.
   await panLiveTargetIntoView(page, resident)
   await resident.focus()
   await expect(popover).toBeVisible()

--- a/e2e/quiet-room-leak-scan.spec.ts
+++ b/e2e/quiet-room-leak-scan.spec.ts
@@ -330,6 +330,26 @@ test('no view, search, focus, deep link, or share action ever renders the quiet 
   await expect(page.locator('#live-plates')).toBeVisible()
   await assertNoLeak(page, 'Live tab, default load')
 
+  // Step 4: the single reusable Live item popover. Drill to lantern_row so
+  // the quiet grandchild (hushed_cellar) renders as one of its own direct
+  // plots -- the only anchor a quiet room offers on the plate, since its
+  // residents and things never render at all -- and open the popover on
+  // its nameplate. liveItemPopoverFacts resolves this place's own quiet
+  // mark and must print only its name, owner, and counts (all public per
+  // decision #75) plus the locked quiet sentence, never the sentinel
+  // resident, thing, or note this fixture would otherwise leak.
+  await page.evaluate(placeId => { window.location.hash = '#view=live&place=' + String(placeId) }, CHILD_PLACE_ID)
+  const quietPlot = page.locator('.live-plot[data-place-id="' + String(QUIET_PLACE_ID) + '"]')
+  await expect(quietPlot).toBeVisible()
+  await quietPlot.locator('.live-plot-open').hover()
+  await expect(page.locator('#live-item-popover')).toBeVisible()
+  await expect(page.locator('#live-item-popover')).toContainText('hushed_cellar')
+  await expect(page.locator('#live-item-popover .quiet-room-notice')).toContainText(
+    'archivist prefers to keep this room private.',
+  )
+  await assertNoLeak(page, 'Live item popover on the quiet grandchild plot')
+  await page.keyboard.press('Escape')
+
   // Things tab: the city-wide heading list (renderThingIndex) and its own
   // history-page control.
   await page.getByRole('tab', { name: 'Things' }).click()

--- a/src/door.ts
+++ b/src/door.ts
@@ -1000,11 +1000,15 @@ it never shrinks the whole survey into view. The controls remain viewer-only, an
 no Fit control or slider. At a readable zoom, pointer hover or keyboard focus brings the
 complete covered item and its label above every peer. On touch screens, the first tap
 brings that complete unit forward and the second tap opens it. A shown tag carries the
-complete untruncated handle. Plot nameplates keep a single-line ellipsis and their tooltip
-carries the complete place name. Detailed plots paint only in and just beyond the visible
-camera; every farther plot remains a finger-sized reachable marker. Live never draws every
-detailed plot at once, and camera budgeting changes no fixed ground, selection, exact count,
-or public record.
+complete untruncated handle. Plot nameplates keep a single-line ellipsis; hovering,
+keyboard-focusing, or the first tap on a resident, thing, or plot nameplate also opens one
+small popover beside it, carrying that item's public facts (including the complete place
+name a nameplate ellipsis truncates) plus one control that opens its record. It never
+covers the item, stays inside the viewer's plate, and closes on Escape, a press elsewhere,
+or when its item leaves the plate; opening, moving, or closing it costs no request.
+Detailed plots paint only in and just beyond the visible camera; every farther plot remains
+a finger-sized reachable marker. Live never draws every detailed plot at once, and camera
+budgeting changes no fixed ground, selection, exact count, or public record.
 Click a plot to drill through shareable tree breadcrumbs. An unoverflowed place shows up
 to six residents and six things. Overflow protects control ground, leaving four resident
 walker positions and five thing specimens, and reports every omission as an exact +N more

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -977,11 +977,15 @@ it never shrinks the whole survey into view. The controls remain viewer-only, an
 no Fit control or slider. At a readable zoom, pointer hover or keyboard focus brings the
 complete covered item and its label above every peer. On touch screens, the first tap
 brings that complete unit forward and the second tap opens it. A shown tag carries the
-complete untruncated handle. Plot nameplates keep a single-line ellipsis and their tooltip
-carries the complete place name. Detailed plots paint only in and just beyond the visible
-camera; every farther plot remains a finger-sized reachable marker. Live never draws every
-detailed plot at once, and camera budgeting changes no fixed ground, selection, exact count,
-or public record.
+complete untruncated handle. Plot nameplates keep a single-line ellipsis; hovering,
+keyboard-focusing, or the first tap on a resident, thing, or plot nameplate also opens one
+small popover beside it, carrying that item's public facts (including the complete place
+name a nameplate ellipsis truncates) plus one control that opens its record. It never
+covers the item, stays inside the viewer's plate, and closes on Escape, a press elsewhere,
+or when its item leaves the plate; opening, moving, or closing it costs no request.
+Detailed plots paint only in and just beyond the visible camera; every farther plot remains
+a finger-sized reachable marker. Live never draws every detailed plot at once, and camera
+budgeting changes no fixed ground, selection, exact count, or public record.
 Click a plot to drill through shareable tree breadcrumbs. An unoverflowed place shows up
 to six residents and six things. Overflow protects control ground, leaving four resident
 walker positions and five thing specimens, and reports every omission as an exact +N more

--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -93,4 +93,24 @@ export type {
   WindowDirectorySearchPage,
 } from './window-client/directory.ts'
 
+export {
+  windowLiveItemFacts,
+  windowLiveItemLastAction,
+  windowLiveItemPopoverPlacement,
+} from './window-client/live-popover.ts'
+export type {
+  WindowLiveItemKind,
+  WindowLiveCachedDrawing,
+  WindowLiveItemFactsResident,
+  WindowLiveItemFactsThing,
+  WindowLiveItemFactsPlace,
+  WindowLiveItemFactsContext,
+  WindowLiveItemFactsResult,
+  WindowLiveItemRecord,
+  WindowLiveRect,
+  WindowLiveSize,
+  WindowLiveItemPopoverSide,
+  WindowLiveItemPopoverPlacement,
+} from './window-client/live-popover.ts'
+
 export const WINDOW_JS = WINDOW_CLIENT_PARTS.join('')

--- a/src/window-client/live-popover.ts
+++ b/src/window-client/live-popover.ts
@@ -1,0 +1,321 @@
+import { windowDrawingStateLabel, windowDrawingSourceLabel } from './drawing.ts'
+import type { WindowDrawing, WindowDrawingState, WindowDrawingSource } from './drawing.ts'
+
+// Step 4 of the Live-view rebuild (docs/DRAWING_AND_LIVE_VIEW.md, decisions
+// #60-#62/#75/#77): one reusable popover replaces the per-sprite title
+// attributes step 2/3 left behind as the only carrier of a Live item's
+// state, provenance, and last recorded action. These three functions are
+// stringified via .toString() into the client IIFE (src/window-client/
+// program/01-prelude.ts) exactly like every other windowLive* helper — see
+// docs/DRAWING_AND_LIVE_VIEW.md §9 for the toString() invariant. They stay
+// entirely self-contained (no closures over module-level state) except the
+// two drawing-label calls below, which part 01 already injects into the
+// same scope, mirroring windowLiveFloorAccessibleLabel's precedent in
+// live-visibility.ts.
+
+export type WindowLiveItemKind = 'resident' | 'thing' | 'place'
+
+export type WindowLiveCachedDrawing = WindowDrawingSource & Readonly<{
+  state: WindowDrawingState
+  drawing: WindowDrawing | null
+}>
+
+export type WindowLiveItemFactsResident = Readonly<{
+  asleep: boolean
+  has_drawing: boolean
+}>
+
+export type WindowLiveItemFactsThing = Readonly<{
+  made_by: string | null
+  current_owner: string
+  body: string
+  truncated: boolean
+  open_to_use: boolean
+  kind: string | null
+  has_drawing: boolean
+}>
+
+export type WindowLiveItemFactsPlace = Readonly<{
+  // owner is undefined on a directory-only reference (no owner field at
+  // all), null on the ownerless world root, or a handle otherwise — three
+  // distinct states this function must not collapse into one another.
+  owner?: string | null
+  purpose?: string
+  places?: number
+  notes?: number
+  quiet?: boolean
+}>
+
+export type WindowLiveItemFactsContext = Readonly<{
+  locationName?: string | null
+  locationQuiet?: boolean
+  cachedDrawing?: WindowLiveCachedDrawing | null
+  focused?: boolean
+  exactThingTotal?: number | null
+  floorDrawn?: boolean | null
+}>
+
+export type WindowLiveItemFactsResult = Readonly<{
+  quiet: boolean
+  facts: readonly string[]
+}>
+
+// Every fact below is already held in client state; nothing here triggers a
+// read. A fact whose source is absent is omitted entirely — never guessed,
+// never defaulted (AGENTS.md's honest-status rule; decision #59's "a
+// missing or contradictory survey prints no exact badge").
+//
+// toString() invariant (docs/DRAWING_AND_LIVE_VIEW.md §9): this function is
+// stringified whole into the client IIFE, so it must be entirely
+// self-contained. It may call windowDrawingStateLabel/windowDrawingSourceLabel
+// only because part 01 already injects both into that same scope; every
+// other helper it needs (the drawing-fact two-tier rule, the body-byte-size
+// rule) is inlined below as a local closure rather than a separate
+// module-level function, which .toString() would not capture.
+export function windowLiveItemFacts(
+  kind: WindowLiveItemKind,
+  item:
+    | WindowLiveItemFactsResident
+    | WindowLiveItemFactsThing
+    | WindowLiveItemFactsPlace,
+  context: WindowLiveItemFactsContext = {},
+): WindowLiveItemFactsResult {
+  const drawingFact = (
+    hasDrawing: boolean,
+    cachedDrawing: WindowLiveCachedDrawing | null | undefined,
+  ): string => {
+    if (cachedDrawing) {
+      const stateLabel = windowDrawingStateLabel(cachedDrawing.state, cachedDrawing.drawing)
+      const sourceLabel = windowDrawingSourceLabel(cachedDrawing)
+      return sourceLabel ? stateLabel + ' · ' + sourceLabel : stateLabel
+    }
+    return hasDrawing ? 'has a drawing' : 'no drawing yet'
+  }
+  if (kind === 'resident') {
+    const resident = item as WindowLiveItemFactsResident
+    const facts: string[] = []
+    if (context.locationQuiet !== true && context.locationName) {
+      facts.push('in ' + context.locationName)
+    }
+    if (resident.asleep === true) {
+      facts.push(
+        'dimmed by a two-week public-activity display heuristic · not proof they are offline',
+      )
+    }
+    facts.push(drawingFact(resident.has_drawing === true, context.cachedDrawing))
+    if (context.focused === true) facts.push('focused')
+    return Object.freeze({ quiet: false, facts: Object.freeze(facts) })
+  }
+  if (kind === 'thing') {
+    const thing = item as WindowLiveItemFactsThing
+    const facts: string[] = []
+    if (thing.kind) facts.push(thing.kind)
+    if (thing.made_by) facts.push('made by ' + thing.made_by)
+    if (thing.current_owner) facts.push('kept by ' + thing.current_owner)
+    let bodyFact: string | null = null
+    if (thing.truncated === true) {
+      bodyFact = 'body continues past the loaded head — open the record for the whole body'
+    } else if (typeof thing.body === 'string') {
+      try {
+        bodyFact = 'body ' + String(new TextEncoder().encode(thing.body).byteLength) + ' bytes'
+      } catch {
+        bodyFact = null
+      }
+    }
+    if (bodyFact) facts.push(bodyFact)
+    if (thing.open_to_use === true) facts.push('open to use')
+    facts.push(drawingFact(thing.has_drawing === true, context.cachedDrawing))
+    return Object.freeze({ quiet: false, facts: Object.freeze(facts) })
+  }
+  const place = item as WindowLiveItemFactsPlace
+  const facts: string[] = []
+  if (place.owner === null) facts.push('nobody owns it')
+  else if (typeof place.owner === 'string') facts.push('kept by ' + place.owner)
+  if (typeof place.places === 'number' && typeof place.notes === 'number') {
+    facts.push(String(place.places) + ' places · ' + String(place.notes) + ' notes')
+  }
+  facts.push(
+    context.exactThingTotal !== null && context.exactThingTotal !== undefined
+      ? String(context.exactThingTotal) + ' things'
+      : 'exact thing count unavailable',
+  )
+  if (place.quiet === true) return Object.freeze({ quiet: true, facts: Object.freeze(facts) })
+  if (place.purpose) facts.push(place.purpose)
+  if (context.floorDrawn === true) facts.push('floor drawn')
+  else if (context.floorDrawn === false) facts.push('floor undrawn')
+  return Object.freeze({ quiet: false, facts: Object.freeze(facts) })
+}
+
+export type WindowLiveItemRecord = Readonly<{
+  actor: string
+  kind: string
+  at: Date
+  detail: Readonly<{
+    action?: string
+    status?: string
+    from_place_id?: number | null
+    to_place_id?: number | null
+    place_id?: number | null
+    note_id?: number | null
+    thing_id?: number | null
+    source_thing_id?: number | null
+    mode?: string | null
+  }>
+}>
+
+// Built only from records already held in memory (liveRecords() /
+// visibleLiveRecords()), never from a fetch — it must NOT call
+// liveLedgerText, which lazily fires loadLiveNote(noteId) for its note
+// phrasing and would turn a hover into a network read. `records` must
+// already be newest-first, matching every existing caller of liveRecords().
+export function windowLiveItemLastAction(
+  records: readonly WindowLiveItemRecord[],
+  kind: WindowLiveItemKind,
+  key: string | number,
+  placeNameFor: (placeId: number | null) => string | null = () => null,
+): string | null {
+  if (kind === 'place') return null
+  if (kind === 'resident') {
+    const handle = String(key)
+    for (const record of records) {
+      if (record.actor !== handle) continue
+      const detail = record.detail
+      if (record.kind === 'action' && detail.status === 'applied' &&
+          (detail.action === 'move' || detail.action === 'go_home') &&
+          detail.from_place_id && detail.to_place_id) {
+        const name = placeNameFor(detail.from_place_id)
+        return name ? 'moved in from ' + name : 'moved in'
+      }
+      if (record.kind === 'note' && detail.note_id && detail.place_id) return 'spoke here'
+      if ((record.kind === 'thing_created' || record.kind === 'thing_crafted') &&
+          detail.place_id) {
+        return 'made thing #' + String(detail.thing_id || '?')
+      }
+      if (record.kind === 'action' && detail.status === 'applied' &&
+          detail.action === 'make' && detail.place_id) {
+        return 'made thing #' + String(detail.thing_id || '?')
+      }
+      if (record.kind === 'action' && detail.status === 'applied' &&
+          detail.action === 'use' && detail.source_thing_id && detail.place_id) {
+        return 'used thing #' + String(detail.source_thing_id)
+      }
+    }
+    return null
+  }
+  const thingId = Number(key)
+  for (const record of records) {
+    const detail = record.detail
+    if (record.kind === 'action' && detail.status === 'applied' &&
+        detail.action === 'use' && detail.source_thing_id === thingId && detail.place_id) {
+      return 'used by ' + record.actor
+    }
+    if (((record.kind === 'thing_created' || record.kind === 'thing_crafted') ||
+        (record.kind === 'action' && detail.status === 'applied' && detail.action === 'make')) &&
+        detail.thing_id === thingId && detail.place_id) {
+      return 'made by ' + record.actor + ' here'
+    }
+    if (record.kind === 'action' && detail.status === 'applied' &&
+        (detail.action === 'move' || detail.action === 'go_home') &&
+        detail.mode === 'carry' && detail.thing_id === thingId) {
+      return 'carried in by ' + record.actor
+    }
+  }
+  return null
+}
+
+export type WindowLiveRect = Readonly<{ left: number; top: number; right: number; bottom: number }>
+export type WindowLiveSize = Readonly<{ width: number; height: number }>
+export type WindowLiveItemPopoverSide = 'above' | 'below' | 'right' | 'left'
+export type WindowLiveItemPopoverPlacement = Readonly<{
+  left: number
+  top: number
+  side: WindowLiveItemPopoverSide
+}>
+
+// Returns coordinates already relative to viewportRect's own origin (ready
+// to assign directly to style.left/style.top on an element absolutely
+// positioned inside that viewport element), or null when nothing safe can
+// be computed — a non-finite input, or a zero-area anchor/viewport/size,
+// refuses to open rather than painting at NaN.
+export function windowLiveItemPopoverPlacement(
+  anchorRect: WindowLiveRect,
+  popoverSize: WindowLiveSize,
+  viewportRect: WindowLiveRect,
+  gap: number,
+  margin: number,
+): WindowLiveItemPopoverPlacement | null {
+  const finite = [
+    anchorRect.left, anchorRect.top, anchorRect.right, anchorRect.bottom,
+    popoverSize.width, popoverSize.height,
+    viewportRect.left, viewportRect.top, viewportRect.right, viewportRect.bottom,
+    gap, margin,
+  ].every(Number.isFinite)
+  const anchorWidth = anchorRect.right - anchorRect.left
+  const anchorHeight = anchorRect.bottom - anchorRect.top
+  if (!finite || anchorWidth <= 0 || anchorHeight <= 0 ||
+      popoverSize.width <= 0 || popoverSize.height <= 0) return null
+  const anchorCenterX = anchorRect.left + anchorWidth / 2
+  const anchorCenterY = anchorRect.top + anchorHeight / 2
+  const candidates: ReadonlyArray<
+    Readonly<{ side: WindowLiveItemPopoverSide; left: number; top: number }>
+  > = Object.freeze([
+    Object.freeze({
+      side: 'above' as const,
+      left: anchorCenterX - popoverSize.width / 2,
+      top: anchorRect.top - gap - popoverSize.height,
+    }),
+    Object.freeze({
+      side: 'below' as const,
+      left: anchorCenterX - popoverSize.width / 2,
+      top: anchorRect.bottom + gap,
+    }),
+    Object.freeze({
+      side: 'right' as const,
+      left: anchorRect.right + gap,
+      top: anchorCenterY - popoverSize.height / 2,
+    }),
+    Object.freeze({
+      side: 'left' as const,
+      left: anchorRect.left - gap - popoverSize.width,
+      top: anchorCenterY - popoverSize.height / 2,
+    }),
+  ])
+  const insetLeft = viewportRect.left + margin
+  const insetRight = viewportRect.right - margin
+  const insetTop = viewportRect.top + margin
+  const insetBottom = viewportRect.bottom - margin
+  const fits = (candidate: { left: number; top: number }): boolean =>
+    candidate.left >= insetLeft && candidate.left + popoverSize.width <= insetRight &&
+    candidate.top >= insetTop && candidate.top + popoverSize.height <= insetBottom
+  const room = (candidate: { left: number; top: number }): number => Math.min(
+    candidate.left - insetLeft,
+    insetRight - (candidate.left + popoverSize.width),
+    candidate.top - insetTop,
+    insetBottom - (candidate.top + popoverSize.height),
+  )
+  const fitting = candidates.find(fits)
+  // When no side fits fully, clamp only the CROSS axis of the side with
+  // the most room -- for above/below that is left, for left/right that is
+  // top. The PRIMARY axis (the one carrying the gap that keeps the
+  // popover off the anchor) is never clamped inward, because doing so is
+  // exactly what would push a clamped 'left' or 'above' placement back
+  // onto the anchor it was chosen to avoid.
+  const chosen = fitting || candidates.reduce(
+    (best, candidate) => room(candidate) > room(best) ? candidate : best,
+  )
+  const clampedLeft = fitting || chosen.side === 'left' || chosen.side === 'right'
+    ? chosen.left
+    : Math.min(Math.max(chosen.left, insetLeft), insetRight - popoverSize.width)
+  const clampedTop = fitting || chosen.side === 'above' || chosen.side === 'below'
+    ? chosen.top
+    : Math.min(Math.max(chosen.top, insetTop), insetBottom - popoverSize.height)
+  const intersectsAnchor =
+    clampedLeft < anchorRect.right + gap && clampedLeft + popoverSize.width > anchorRect.left - gap &&
+    clampedTop < anchorRect.bottom + gap && clampedTop + popoverSize.height > anchorRect.top - gap
+  if (intersectsAnchor) return null
+  return Object.freeze({
+    left: clampedLeft - viewportRect.left,
+    top: clampedTop - viewportRect.top,
+    side: chosen.side,
+  })
+}

--- a/src/window-client/live-popover.ts
+++ b/src/window-client/live-popover.ts
@@ -237,6 +237,23 @@ export type WindowLiveItemPopoverPlacement = Readonly<{
 // positioned inside that viewport element), or null when nothing safe can
 // be computed — a non-finite input, or a zero-area anchor/viewport/size,
 // refuses to open rather than painting at NaN.
+//
+// PRIORITY RULE (round-1 review finding #1, reproduced live on the deployed
+// preview: an off-camera anchor could return a placement rendered entirely
+// outside #live-viewport): containment inside the viewport always wins over
+// never touching the anchor. The two invariants both hold in the common
+// case (a side that fits without clamping, handled first below) and they
+// also both hold whenever the anchor sits entirely outside the viewport --
+// the normal state for any resident/thing/place the camera has not framed
+// -- because a placement clamped fully inside the viewport then cannot
+// reach an anchor that is not in the viewport at all. They only truly
+// conflict when the anchor itself crowds the viewport closely enough that
+// no fully-contained position can avoid it (the popover is wider/taller
+// than the viewport, or the anchor fills most of a small one); only then
+// do we return the contained candidate with the least overlap instead of
+// refusing to open. A caller never has to special-case an off-camera
+// anchor: this function is always safe to call with the anchor's real
+// (possibly far outside the viewport) rect.
 export function windowLiveItemPopoverPlacement(
   anchorRect: WindowLiveRect,
   popoverSize: WindowLiveSize,
@@ -284,38 +301,53 @@ export function windowLiveItemPopoverPlacement(
   const insetRight = viewportRect.right - margin
   const insetTop = viewportRect.top + margin
   const insetBottom = viewportRect.bottom - margin
-  const fits = (candidate: { left: number; top: number }): boolean =>
+  const fitsUnclamped = (candidate: { left: number; top: number }): boolean =>
     candidate.left >= insetLeft && candidate.left + popoverSize.width <= insetRight &&
     candidate.top >= insetTop && candidate.top + popoverSize.height <= insetBottom
-  const room = (candidate: { left: number; top: number }): number => Math.min(
-    candidate.left - insetLeft,
-    insetRight - (candidate.left + popoverSize.width),
-    candidate.top - insetTop,
-    insetBottom - (candidate.top + popoverSize.height),
-  )
-  const fitting = candidates.find(fits)
-  // When no side fits fully, clamp only the CROSS axis of the side with
-  // the most room -- for above/below that is left, for left/right that is
-  // top. The PRIMARY axis (the one carrying the gap that keeps the
-  // popover off the anchor) is never clamped inward, because doing so is
-  // exactly what would push a clamped 'left' or 'above' placement back
-  // onto the anchor it was chosen to avoid.
-  const chosen = fitting || candidates.reduce(
-    (best, candidate) => room(candidate) > room(best) ? candidate : best,
-  )
-  const clampedLeft = fitting || chosen.side === 'left' || chosen.side === 'right'
-    ? chosen.left
-    : Math.min(Math.max(chosen.left, insetLeft), insetRight - popoverSize.width)
-  const clampedTop = fitting || chosen.side === 'above' || chosen.side === 'below'
-    ? chosen.top
-    : Math.min(Math.max(chosen.top, insetTop), insetBottom - popoverSize.height)
-  const intersectsAnchor =
-    clampedLeft < anchorRect.right + gap && clampedLeft + popoverSize.width > anchorRect.left - gap &&
-    clampedTop < anchorRect.bottom + gap && clampedTop + popoverSize.height > anchorRect.top - gap
-  if (intersectsAnchor) return null
+  // Side preference: above, below, right, left -- first side where the
+  // popover fits entirely inside the viewport with the gap and margin
+  // honoured, with no clamping needed at all.
+  const unclampedFit = candidates.find(fitsUnclamped)
+  if (unclampedFit) {
+    return Object.freeze({
+      left: unclampedFit.left - viewportRect.left,
+      top: unclampedFit.top - viewportRect.top,
+      side: unclampedFit.side,
+    })
+  }
+  // No side fits without clamping. Clamp EVERY candidate on BOTH axes to
+  // the viewport inset -- this is the fix: the old code clamped only the
+  // cross axis and left the primary axis (the one carrying the gap) alone,
+  // reasoning that clamping it would push the popover onto the anchor --
+  // true only when the anchor is itself near the viewport, and false (and
+  // silently unchecked) for any anchor the camera has left off-screen.
+  const clampBoth = (
+    candidate: { side: WindowLiveItemPopoverSide; left: number; top: number },
+  ): Readonly<{ side: WindowLiveItemPopoverSide; left: number; top: number }> => Object.freeze({
+    side: candidate.side,
+    left: Math.min(Math.max(candidate.left, insetLeft), insetRight - popoverSize.width),
+    top: Math.min(Math.max(candidate.top, insetTop), insetBottom - popoverSize.height),
+  })
+  const intersectsAnchorAt = (left: number, top: number): boolean =>
+    left < anchorRect.right + gap && left + popoverSize.width > anchorRect.left - gap &&
+    top < anchorRect.bottom + gap && top + popoverSize.height > anchorRect.top - gap
+  // Only used to rank candidates when every contained position must
+  // overlap the anchor at least a little (the genuine-conflict case) --
+  // the gap-expanded overlap area, smallest wins.
+  const overlapArea = (left: number, top: number): number => {
+    const overlapWidth = Math.min(left + popoverSize.width, anchorRect.right + gap) -
+      Math.max(left, anchorRect.left - gap)
+    const overlapHeight = Math.min(top + popoverSize.height, anchorRect.bottom + gap) -
+      Math.max(top, anchorRect.top - gap)
+    return Math.max(0, overlapWidth) * Math.max(0, overlapHeight)
+  }
+  const clamped = candidates.map(clampBoth)
+  const clear = clamped.find(candidate => !intersectsAnchorAt(candidate.left, candidate.top))
+  const chosen = clear || clamped.reduce((best, candidate) =>
+    overlapArea(candidate.left, candidate.top) < overlapArea(best.left, best.top) ? candidate : best)
   return Object.freeze({
-    left: clampedLeft - viewportRect.left,
-    top: clampedTop - viewportRect.top,
+    left: chosen.left - viewportRect.left,
+    top: chosen.top - viewportRect.top,
     side: chosen.side,
   })
 }

--- a/src/window-client/program/01-prelude.ts
+++ b/src/window-client/program/01-prelude.ts
@@ -76,6 +76,11 @@ import {
   searchWindowDirectory,
   pageWindowDirectorySearch,
 } from '../directory.ts'
+import {
+  windowLiveItemFacts,
+  windowLiveItemLastAction,
+  windowLiveItemPopoverPlacement,
+} from '../live-popover.ts'
 const PUBLIC_EVENT_LABELS_JSON = JSON.stringify(PUBLIC_EVENT_LABELS)
 const PUBLIC_EVENT_DETAIL_ID_FIELDS_JSON = JSON.stringify(PUBLIC_EVENT_DETAIL_ID_FIELDS)
 const PUBLIC_SYSTEM_EVENT_ACTORS_JSON = JSON.stringify(Object.values(PUBLIC_SYSTEM_EVENT_ACTORS))
@@ -132,6 +137,9 @@ const WINDOW_LIVE_REPLAY_START_OFFSETS_JS = windowLiveReplayStartOffsets.toStrin
 const WINDOW_LIVE_REPLAY_ORDER_JS = windowLiveReplayOrder.toString()
 const WINDOW_LIVE_SPEECH_LINE_JS = windowLiveSpeechLine.toString()
 const WINDOW_LIVE_TOUCH_ACTIVATION_JS = windowLiveTouchActivation.toString()
+const WINDOW_LIVE_ITEM_FACTS_JS = windowLiveItemFacts.toString()
+const WINDOW_LIVE_ITEM_LAST_ACTION_JS = windowLiveItemLastAction.toString()
+const WINDOW_LIVE_ITEM_POPOVER_PLACEMENT_JS = windowLiveItemPopoverPlacement.toString()
 const WINDOW_LIVE_PLOT_DRAWING_DETAIL_RECT_JSON = JSON.stringify(
   WINDOW_LIVE_PLOT_DRAWING_DETAIL_RECT,
 )
@@ -177,6 +185,10 @@ export const PART_01_PRELUDE = `(() => {
   const LIVE_PLOT_DRAWING_DETAIL_RECT = Object.freeze(
     ${WINDOW_LIVE_PLOT_DRAWING_DETAIL_RECT_JSON})
   const LIVE_TRAIL_DOM_LIMIT = 96
+  // Step 4: the single reusable Live item popover's clear space from the
+  // sprite it describes, and its minimum inset from the live viewport edge.
+  const LIVE_ITEM_POPOVER_GAP = 10
+  const LIVE_ITEM_POPOVER_MARGIN = 8
   const REQUEST_TIMEOUT_MS = 10000
   const MAX_FORWARD_RECONCILE_PAGES = 8
   const MAX_AUTO_HISTORY_PAGES = 8
@@ -251,5 +263,8 @@ export const PART_01_PRELUDE = `(() => {
   const windowLiveReplayOrder = ${WINDOW_LIVE_REPLAY_ORDER_JS}
   const windowLiveSpeechLine = ${WINDOW_LIVE_SPEECH_LINE_JS}
   const windowLiveTouchActivation = ${WINDOW_LIVE_TOUCH_ACTIVATION_JS}
+  const windowLiveItemFacts = ${WINDOW_LIVE_ITEM_FACTS_JS}
+  const windowLiveItemLastAction = ${WINDOW_LIVE_ITEM_LAST_ACTION_JS}
+  const windowLiveItemPopoverPlacement = ${WINDOW_LIVE_ITEM_POPOVER_PLACEMENT_JS}
 
 `

--- a/src/window-client/program/02-state-and-nodes.ts
+++ b/src/window-client/program/02-state-and-nodes.ts
@@ -10,6 +10,7 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
     liveViewport: document.getElementById('live-viewport'),
     liveStage: document.getElementById('live-stage'),
     liveLabelLayer: document.getElementById('live-label-layer'),
+    liveItemPopover: document.getElementById('live-item-popover'),
     liveWorldGround: document.querySelector('#live-stage > .live-world-ground'),
     liveZoomIn: document.getElementById('live-zoom-in'),
     liveZoomOut: document.getElementById('live-zoom-out'),
@@ -200,6 +201,15 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
   let liveWasHidden = document.hidden
   let liveTrailExpiryTimer = 0
   let livePointers = Object.freeze({})
+  // Step 4: the single reusable Live item popover's own anchor/key/rect,
+  // deliberately module-level rather than state.live -- every state
+  // replacement feeds render paths, and opening a popover must never
+  // schedule a plate render.
+  let liveItemPopoverAnchor = null
+  let liveItemPopoverKey = null
+  let liveItemPopoverRect = null
+  let liveItemPopoverSuppressOpen = false
+  let liveItemPopoverPressWasInside = false
   let liveResidentVisibleIdsByPlaceId = Object.freeze({})
   let liveThingVisibleIdsByPlaceId = Object.freeze({})
   let liveResidentPointsByPlaceId = Object.freeze({})

--- a/src/window-client/program/03-elements-portraits-drawings.ts
+++ b/src/window-client/program/03-elements-portraits-drawings.ts
@@ -78,7 +78,6 @@ export const PART_03_ELEMENTS_PORTRAITS_DRAWINGS = `  function element(tagName, 
     if (!hasDrawing) return document.createDocumentFragment()
     const shell = element('span', 'entity-portrait' + (className ? ' ' + className : ''))
     shell.setAttribute('aria-hidden', 'true')
-    shell.title = label + ' drawing'
     shell.dataset.portraitType = type
     shell.dataset.portraitId = String(id)
     shell.append(element('span', 'entity-portrait-placeholder'))
@@ -89,8 +88,12 @@ export const PART_03_ELEMENTS_PORTRAITS_DRAWINGS = `  function element(tagName, 
   // Decision #62 / step 2 ruling: the sprite on the ground is the drawing
   // alone -- an authored thumbnail when one exists, or a small neutral
   // marker when it does not. No state or provenance chip renders here;
-  // that stays reachable through the title attribute and the unchanged
-  // drawing-detail button (see mountLivePlaceDetail, openDrawingDetailButton).
+  // step 4 makes that state and provenance reachable through the single
+  // Live item popover (hover, keyboard focus, or the first touch tap) and
+  // the unchanged drawing-detail button, not through a title attribute --
+  // the shell above is aria-hidden and the marker below was reachable only
+  // by mouse hover, so a title never actually carried this to keyboard or
+  // touch users.
   function liveSpriteNode(type, id, label, hasDrawing) {
     if (hasDrawing) {
       return portraitNode(type, id, label, true, 'live-entity-portrait')
@@ -98,8 +101,7 @@ export const PART_03_ELEMENTS_PORTRAITS_DRAWINGS = `  function element(tagName, 
     const marker = element('span',
       'drawing-grid drawing-undrawn live-neutral-marker live-entity-portrait')
     marker.setAttribute('role', 'img')
-    marker.title = label + ' has no drawing'
-    marker.setAttribute('aria-label', marker.title)
+    marker.setAttribute('aria-label', label + ' has no drawing')
     return marker
   }
 

--- a/src/window-client/program/05-safety-and-live-focus.ts
+++ b/src/window-client/program/05-safety-and-live-focus.ts
@@ -232,6 +232,20 @@ export const PART_05_SAFETY_AND_LIVE_FOCUS = `${WINDOW_CLIENT_SAFETY_JS}
           bottom: rect.bottom - layerRect.top,
         }]
       })
+    // Step 4: while the single Live item popover is open, its rect joins
+    // the packer's occupied ground so a resident tag is never stacked
+    // underneath it. One extra measurement, only while a popover is open.
+    if (nodes.liveItemPopover && !nodes.liveItemPopover.hidden) {
+      const popoverRect = nodes.liveItemPopover.getBoundingClientRect()
+      if (popoverRect.width > 0 && popoverRect.height > 0) {
+        occupied.push({
+          left: popoverRect.left - layerRect.left,
+          right: popoverRect.right - layerRect.left,
+          top: popoverRect.top - layerRect.top,
+          bottom: popoverRect.bottom - layerRect.top,
+        })
+      }
+    }
     for (const resident of residents) {
       if (resident.measured && resident.existingTag) {
         resident.existingTag.dataset.livePacked = 'false'

--- a/src/window-client/program/06-live-camera-and-pointers.ts
+++ b/src/window-client/program/06-live-camera-and-pointers.ts
@@ -66,6 +66,7 @@ export const PART_06_LIVE_CAMERA_AND_POINTERS = `  function liveCameraViewport()
     nodes.liveStage.dataset.liveLabelMode = labelMode
     syncLivePlotVisibility()
     scheduleLiveResidentLabels(previousLabelMode !== labelMode)
+    if (liveItemPopoverIsOpen()) positionLiveItemPopover()
   }
 
   function applyLiveCamera(next) {

--- a/src/window-client/program/21-live-pinning-and-portrait-grid.ts
+++ b/src/window-client/program/21-live-pinning-and-portrait-grid.ts
@@ -235,10 +235,9 @@ export const PART_21_LIVE_PINNING_AND_PORTRAIT_GRID = `  function livePinnedResi
       portrait.type = 'button'
       portrait.dataset.focusKey = 'live-resident:' + resident.handle
       portrait.dataset.liveResidentHandle = resident.handle
-      portrait.title = state.live.focusResident === resident.handle
+      portrait.setAttribute('aria-label', state.live.focusResident === resident.handle
         ? 'Clear focus from ' + resident.handle
-        : 'Focus on ' + resident.handle
-      portrait.setAttribute('aria-label', portrait.title)
+        : 'Focus on ' + resident.handle)
       portrait.setAttribute('aria-pressed', String(state.live.focusResident === resident.handle))
       portrait.append(liveSpriteNode(
         'resident', resident.id, resident.handle, resident.has_drawing,
@@ -260,6 +259,7 @@ export const PART_21_LIVE_PINNING_AND_PORTRAIT_GRID = `  function livePinnedResi
       }
       bindLiveActivation(portrait, shell, itemKey,
         () => toggleLiveFocusResident(resident.handle))
+      bindLiveItemPopover(portrait, itemKey, 'resident', () => resident)
       grid.append(shell)
     })
     const visibleOverflowActors = layout.hidden.filter(resident =>

--- a/src/window-client/program/22-live-things-and-plots.ts
+++ b/src/window-client/program/22-live-things-and-plots.ts
@@ -228,7 +228,7 @@ export const PART_22_LIVE_THINGS_AND_PLOTS = `  function liveThingFilters(focusI
     for (const thing of visibleThings) {
       const specimen = element('a', 'live-thing-specimen')
       specimen.href = '/api/thing/' + String(thing.id)
-      specimen.title = 'Read ' + thing.name
+      specimen.setAttribute('aria-label', 'Read ' + thing.name)
       specimen.dataset.focusKey = 'live-thing:' + String(thing.id)
       specimen.dataset.liveThingId = String(thing.id)
       specimen.dataset.liveThingPlaceId = String(thing.place_id)
@@ -252,6 +252,7 @@ export const PART_22_LIVE_THINGS_AND_PLOTS = `  function liveThingFilters(focusI
         element('span', 'live-thing-name live-item-name', thing.name),
       )
       bindLiveActivation(specimen, specimen, itemKey, null)
+      bindLiveItemPopover(specimen, itemKey, 'thing', () => thing)
       shelf.append(specimen)
     }
     const overflowCount = selection.overflowCount + selection.visible.length - visibleThings.length
@@ -391,9 +392,10 @@ export const PART_22_LIVE_THINGS_AND_PLOTS = `  function liveThingFilters(focusI
     const open = element('button', 'live-plot-open')
     open.type = 'button'
     open.dataset.focusKey = 'live-place:' + String(place.id)
-    open.title = 'Open the live plate for ' + place.name
+    open.setAttribute('aria-label', 'Open the live plate for ' + place.name)
     bindLiveActivation(open, card, itemKey,
       () => navigate({ view: 'live', placeId: place.id }))
+    bindLiveItemPopover(open, itemKey, 'place', () => place)
     open.append(element('span', 'live-plot-name', place.name),
       element('span', 'live-plot-number', '#' + String(place.id)))
     card.dataset.undrawn = 'false'

--- a/src/window-client/program/24-live-replay-motion.ts
+++ b/src/window-client/program/24-live-replay-motion.ts
@@ -441,6 +441,20 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
         'live-portrait-wrap live-replay-portrait',
       )
       shell.dataset.liveReplayKey = held?.key || ''
+      // Round-1 review finding #2: this walking portrait was never wired
+      // to bindLiveItemPopover, so a resident's facts went unreachable for
+      // the whole 3.2-8s walk. The item key matches the settled
+      // .live-walker's own key ('resident:<handle>', set in
+      // 21-live-pinning-and-portrait-grid.ts), so the popover binds once
+      // on open/focus and needs no per-frame work: positionLiveItemPopover
+      // only reruns on the already-rAF-batched camera commit, and when the
+      // walk ends the next render swaps this replay portrait for the
+      // settled walker under the identical key, so syncLiveItemPopoverAnchor
+      // (27-live-render.ts) re-binds the same open popover to it rather
+      // than closing it -- and closes it as usual (C5) if the resident
+      // instead leaves the plate entirely.
+      const itemKey = 'resident:' + actor
+      shell.dataset.liveItemKey = itemKey
       if (state.live.focusResident === actor) {
         shell.setAttribute('data-live-focus-resident', actor)
       }
@@ -459,6 +473,7 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
         shell.dataset.replayDuration = String(held.duration)
       }
       portrait.addEventListener('click', () => toggleLiveFocusResident(actor))
+      bindLiveItemPopover(portrait, itemKey, 'resident', () => resident)
       portrait.append(portraitNode(
         'resident', resident.id, actor, resident.has_drawing, 'live-entity-portrait',
       ))

--- a/src/window-client/program/27-live-render.ts
+++ b/src/window-client/program/27-live-render.ts
@@ -209,6 +209,7 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
     plateParts.push(renderLiveTraceLayer(
       snapshot, focus, children, records, bubbles, survey, renderContext))
     nodes.livePlates.replaceChildren(...plateParts)
+    syncLiveItemPopoverAnchor()
     scheduleLiveResidentLabels(true)
     scheduleLiveTrailExpiry()
 

--- a/src/window-client/program/28-people-and-detail-links.ts
+++ b/src/window-client/program/28-people-and-detail-links.ts
@@ -75,11 +75,13 @@ export const PART_28_PEOPLE_AND_DETAIL_LINKS = `  // Decision #75: a resident li
     return link
   }
 
-  function openDrawingDetailButton(kind, id, label, className) {
-    const button = element('button', className || 'drawing-detail-open', 'Current drawing')
+  function openDrawingDetailButton(
+    kind, id, label, className, text = 'Current drawing', ariaPrefix = 'Open current drawing for ',
+  ) {
+    const button = element('button', className || 'drawing-detail-open', text)
     button.type = 'button'
     button.dataset.focusKey = 'drawing-detail:' + kind + ':' + String(id)
-    button.setAttribute('aria-label', 'Open current drawing for ' + label)
+    button.setAttribute('aria-label', ariaPrefix + label)
     button.addEventListener('click', () => navigate({ detail: Object.freeze({ kind, id }) }))
     return button
   }

--- a/src/window-client/program/39-wiring-and-boot.ts
+++ b/src/window-client/program/39-wiring-and-boot.ts
@@ -205,7 +205,9 @@ export const PART_39_WIRING_AND_BOOT = `  for (const tab of tabs) {
   })
   nodes.liveViewport?.addEventListener('pointerdown', event => {
     if (event.target instanceof Element &&
-        event.target.closest('button, a, input, select, textarea, [role="button"]')) return
+        event.target.closest(
+          'button, a, input, select, textarea, [role="button"], .live-item-popover',
+        )) return
     event.preventDefault()
     nodes.liveViewport.dataset.liveDragging = 'true'
     beginLivePointer(event)
@@ -314,6 +316,7 @@ export const PART_39_WIRING_AND_BOOT = `  for (const tab of tabs) {
     ...initialLocationState,
     live: { ...state.live, focusResident: initialFocusResident },
   }
+  wireLiveItemPopover()
   syncArchiveControls()
   renderView()
   writeLocation(false)

--- a/src/window-client/program/40-live-item-popover.ts
+++ b/src/window-client/program/40-live-item-popover.ts
@@ -191,6 +191,27 @@ export const PART_40_LIVE_ITEM_POPOVER = `  function liveItemPopoverIsOpen() {
     return container.querySelector(':scope > .live-plot-open')
   }
 
+  // Round-1 review finding #4: forward Tab out of the popover's action
+  // button used to close the popover and land back on the anchor, costing
+  // the keyboard user an extra Tab press to actually move on. The popover
+  // sits outside #live-stage in the DOM (see the "dom" section above), so
+  // it is not adjacent to the anchor in document order and the browser's
+  // own default Tab handling cannot "continue in document order" on its
+  // own -- this computes that continuation explicitly, against the
+  // focusable elements that exist on the page right now, excluding the
+  // popover's own contents.
+  const LIVE_ITEM_POPOVER_FOCUSABLE_SELECTOR =
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), ' +
+    'textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+  function liveItemPopoverNextFocusable(anchor) {
+    if (!anchor || !anchor.isConnected) return null
+    const all = Array.from(document.querySelectorAll(LIVE_ITEM_POPOVER_FOCUSABLE_SELECTOR))
+      .filter(el => !nodes.liveItemPopover?.contains(el))
+    const index = all.indexOf(anchor)
+    return index === -1 ? null : (all[index + 1] || null)
+  }
+
   function liveItemPopoverResolveByKey(kind, key) {
     const raw = key.slice(key.indexOf(':') + 1)
     if (kind === 'resident') {
@@ -317,7 +338,23 @@ export const PART_40_LIVE_ITEM_POPOVER = `  function liveItemPopoverIsOpen() {
         return
       }
       event.preventDefault()
-      hideLiveItemPopover(true)
+      // Close and continue into the ordinary plate order (finding #4)
+      // rather than closing and landing back on the anchor: compute the
+      // next focusable element after the anchor BEFORE closing, since
+      // closing clears liveItemPopoverAnchor. If that next element is
+      // itself a bound Live item, its own focusin listener opens its
+      // popover -- which is exactly "the next Tab continues the ordinary
+      // plate order". When nothing follows the anchor, fall back to the
+      // old behavior via hideLiveItemPopover(true)'s own suppress-guarded
+      // restore, so a self-reopen loop on the anchor's own popover is
+      // never possible.
+      const next = liveItemPopoverNextFocusable(liveItemPopoverAnchor)
+      if (next) {
+        hideLiveItemPopover(false)
+        next.focus({ preventScroll: true })
+      } else {
+        hideLiveItemPopover(true)
+      }
     })
     document.addEventListener('keydown', event => {
       if (event.key !== 'Escape' || !liveItemPopoverIsOpen()) return

--- a/src/window-client/program/40-live-item-popover.ts
+++ b/src/window-client/program/40-live-item-popover.ts
@@ -1,0 +1,352 @@
+// Step 4 of the Live-view rebuild: one reusable popover for the whole
+// plate. See docs/DRAWING_AND_LIVE_VIEW.md's Live-view section and §9. This
+// part MUST ship before PART_39_WIRING_AND_BOOT in
+// src/window-client/program/index.ts -- part 39 closes the client IIFE with
+// `})()`, so appending after it would emit this code outside the IIFE. The
+// `40-` filename prefix is only so `ls` and the quiet-DOM-leak scanner's
+// `/^\d\d-/` glob keep finding it; index.ts stays the real ship-order
+// authority (see docs/DRAWING_AND_LIVE_VIEW.md §9).
+export const PART_40_LIVE_ITEM_POPOVER = `  function liveItemPopoverIsOpen() {
+    return Boolean(nodes.liveItemPopover && !nodes.liveItemPopover.hidden)
+  }
+
+  function liveItemPopoverIdLabel(kind, id) {
+    if (kind === 'resident') return 'resident #' + String(id)
+    if (kind === 'thing') return 'Thing #' + String(id)
+    return 'Place #' + String(id)
+  }
+
+  function liveItemPopoverAnchorName(kind, item) {
+    return kind === 'resident' ? item.handle : item.name
+  }
+
+  // The one place that resolves quiet for the popover -- isQuietPlace, at
+  // the item's own row -- matching the rule every other Live listing path
+  // follows (docs/DECISIONS.md row 75; test/quiet-rooms.test.ts's path
+  // table names this function). A resident or thing bound to the popover
+  // is already drawn only from a non-quiet render path (liveVisibleResidentsAt,
+  // liveThingShelf), so the only place this can actually flip quiet is the
+  // resident's OWN current place, which may differ from the plate being
+  // viewed once Focus/Follow moves someone off-plate -- hence the explicit
+  // check here rather than trusting the caller.
+  function liveItemPopoverFacts(kind, item, snapshot) {
+    if (kind === 'resident') {
+      const place = placeReference(snapshot, item.current_place_id)
+      const proofKey = liveDrawingKey('resident', item.id)
+      const cachedDrawing = state.live.proofScene ? (state.live.drawings[proofKey] || null) : null
+      return windowLiveItemFacts('resident', item, {
+        locationName: place ? place.name : null,
+        locationQuiet: isQuietPlace(place),
+        cachedDrawing,
+        focused: state.live.focusResident === item.handle,
+      })
+    }
+    if (kind === 'thing') {
+      const proofKey = liveDrawingKey('thing', item.id)
+      const cachedDrawing = state.live.proofScene ? (state.live.drawings[proofKey] || null) : null
+      return windowLiveItemFacts('thing', item, { cachedDrawing })
+    }
+    const exactThingTotal = liveExactThingTotal(snapshot, item.id, 0, true)
+    const plot = document.querySelector(
+      '.live-plot[data-place-id="' + String(item.id) + '"]',
+    )
+    const floorDrawn = plot?.dataset.undrawn === undefined
+      ? null
+      : plot.dataset.undrawn !== 'true'
+    return windowLiveItemFacts('place', item, { exactThingTotal, floorDrawn })
+  }
+
+  // Body-free by construction: never calls liveLedgerText, which lazily
+  // fires loadLiveNote(noteId) and would turn a hover into a network read.
+  // A named place is resolved through the same quiet rule liveLedgerQuietPlace
+  // applies, so a quiet room is never named in the phrase.
+  function liveItemPopoverLastAction(kind, item) {
+    if (kind === 'place') return null
+    const key = kind === 'resident' ? item.handle : item.id
+    return windowLiveItemLastAction(liveRecords(), kind, key, placeId => {
+      const place = placeReference(state.snapshot, placeId)
+      return place && !isQuietPlace(place) ? place.name : null
+    })
+  }
+
+  // No place context of its own -- every caller already resolved quiet
+  // through liveItemPopoverFacts before this ever runs, exactly like
+  // livePortraitGrid and liveThingShelf (see ALLOW_LIST in
+  // test/quiet-dom-leak-inventory.test.ts, which this function joins for
+  // the same reason: it renders whatever caller-supplied facts and name it
+  // is given).
+  function liveItemPopoverContent(kind, id, name, result, lastAction, place) {
+    const parts = [
+      element('p', 'live-item-popover-title', name + ' · ' + liveItemPopoverIdLabel(kind, id)),
+    ]
+    const list = element('ul', 'live-item-popover-facts')
+    for (const fact of result.facts) list.append(element('li', '', fact))
+    parts.push(list)
+    if (result.quiet && place) {
+      parts.push(quietRoomNotice(place))
+    } else if (kind !== 'place') {
+      parts.push(element('p', 'live-item-popover-last-action',
+        lastAction || 'no recorded action in the last 30 minutes'))
+    }
+    const actionLabel = kind === 'thing' ? 'Open the record' : 'Current drawing'
+    const actionAriaPrefix = kind === 'thing'
+      ? 'Open the public record for '
+      : 'Open current drawing for '
+    parts.push(openDrawingDetailButton(
+      kind, id, name, 'live-item-popover-open drawing-detail-open',
+      actionLabel, actionAriaPrefix,
+    ))
+    return parts
+  }
+
+  function positionLiveItemPopover() {
+    if (!nodes.liveItemPopover || !nodes.liveViewport || !liveItemPopoverAnchor) return
+    if (!liveItemPopoverAnchor.isConnected) {
+      hideLiveItemPopover(false)
+      return
+    }
+    const anchorBox = liveItemPopoverAnchor.getBoundingClientRect()
+    const viewportBox = nodes.liveViewport.getBoundingClientRect()
+    const popoverBox = nodes.liveItemPopover.getBoundingClientRect()
+    const placement = windowLiveItemPopoverPlacement(
+      Object.freeze({
+        left: anchorBox.left, top: anchorBox.top,
+        right: anchorBox.right, bottom: anchorBox.bottom,
+      }),
+      Object.freeze({
+        width: popoverBox.width || 260,
+        height: popoverBox.height || 96,
+      }),
+      Object.freeze({
+        left: viewportBox.left, top: viewportBox.top,
+        right: viewportBox.right, bottom: viewportBox.bottom,
+      }),
+      LIVE_ITEM_POPOVER_GAP,
+      LIVE_ITEM_POPOVER_MARGIN,
+    )
+    if (!placement) {
+      hideLiveItemPopover(false)
+      return
+    }
+    nodes.liveItemPopover.style.left = String(placement.left) + 'px'
+    nodes.liveItemPopover.style.top = String(placement.top) + 'px'
+    nodes.liveItemPopover.dataset.livePopoverSide = placement.side
+    liveItemPopoverRect = placement
+  }
+
+  function showLiveItemPopover(anchor, key, kind, resolve) {
+    if (!nodes.liveItemPopover || !nodes.liveViewport || !state.snapshot) return
+    const item = resolve()
+    if (!item) return
+    const result = liveItemPopoverFacts(kind, item, state.snapshot)
+    const id = item.id
+    const name = liveItemPopoverAnchorName(kind, item)
+    const lastAction = liveItemPopoverLastAction(kind, item)
+    liveItemPopoverAnchor = anchor
+    liveItemPopoverKey = key
+    nodes.liveItemPopover.dataset.livePopoverKind = kind
+    nodes.liveItemPopover.dataset.livePopoverKey = key
+    nodes.liveItemPopover.setAttribute('aria-label', name + ' details')
+    nodes.liveItemPopover.replaceChildren(...liveItemPopoverContent(
+      kind, id, name, result, lastAction, kind === 'place' ? item : null,
+    ))
+    nodes.liveItemPopover.hidden = false
+    anchor.setAttribute('aria-describedby', 'live-item-popover')
+    positionLiveItemPopover()
+  }
+
+  function hideLiveItemPopover(restoreFocus) {
+    if (!nodes.liveItemPopover || nodes.liveItemPopover.hidden) return
+    const anchor = liveItemPopoverAnchor
+    nodes.liveItemPopover.hidden = true
+    nodes.liveItemPopover.replaceChildren()
+    delete nodes.liveItemPopover.dataset.livePopoverKind
+    delete nodes.liveItemPopover.dataset.livePopoverKey
+    delete nodes.liveItemPopover.dataset.livePopoverSide
+    if (anchor) anchor.removeAttribute('aria-describedby')
+    liveItemPopoverAnchor = null
+    liveItemPopoverKey = null
+    liveItemPopoverRect = null
+    if (restoreFocus && anchor && anchor.isConnected) {
+      // .focus() dispatches focusin synchronously, and bindLiveItemPopover's
+      // own focusin listener would otherwise reopen the popover it was
+      // just asked to close (Escape's whole point). This flag makes that
+      // one focus() call inert for opening purposes without touching the
+      // element's real focus state.
+      liveItemPopoverSuppressOpen = true
+      anchor.focus({ preventScroll: true })
+      liveItemPopoverSuppressOpen = false
+    }
+  }
+
+  // The static ground element carrying data-live-item-key differs by kind
+  // (the resident's key lives on its .live-walker shell, the place's on its
+  // .live-plot card; only the thing specimen is its own keyed anchor), so
+  // resync must translate the keyed container back to the actual focusable
+  // control bindLiveItemPopover attached to.
+  function liveItemPopoverAnchorElement(container, kind) {
+    if (!container) return null
+    if (kind === 'resident') return container.querySelector('.live-portrait')
+    if (kind === 'thing') return container
+    return container.querySelector(':scope > .live-plot-open')
+  }
+
+  function liveItemPopoverResolveByKey(kind, key) {
+    const raw = key.slice(key.indexOf(':') + 1)
+    if (kind === 'resident') {
+      return displayedResidents(state.snapshot).find(resident => resident.handle === raw) || null
+    }
+    if (kind === 'thing') {
+      const id = safeId(raw)
+      if (!id || !state.snapshot) return null
+      const focus = liveFocusPlace(state.snapshot)
+      if (!focus) return null
+      return historyEntry('things', liveThingFilters(focus.id)).rows
+        .find(thing => thing.id === id) || null
+    }
+    const id = safeId(raw)
+    return id && state.snapshot ? placeReference(state.snapshot, id) : null
+  }
+
+  // Called after every renderLive plate replaceChildren: closes when the
+  // open item's anchor left the plate (a resident who started a walk loses
+  // their static .live-walker to a .live-replay-portrait, which is never a
+  // bound anchor), and otherwise re-binds to the fresh node, rebuilds facts
+  // from current state, and repositions -- a poll refresh must not blink
+  // the popover away under a resting mouse.
+  function syncLiveItemPopoverAnchor() {
+    if (!liveItemPopoverIsOpen() || !liveItemPopoverKey) return
+    const kind = nodes.liveItemPopover.dataset.livePopoverKind
+    const container = nodes.livePlates?.querySelector(
+      '[data-live-item-key="' + CSS.escape(liveItemPopoverKey) + '"]',
+    )
+    const anchor = liveItemPopoverAnchorElement(container, kind)
+    if (!anchor || !anchor.isConnected) {
+      hideLiveItemPopover(false)
+      return
+    }
+    const key = liveItemPopoverKey
+    showLiveItemPopover(anchor, key, kind, () => liveItemPopoverResolveByKey(kind, key))
+  }
+
+  function bindLiveItemPopover(control, key, kind, resolve) {
+    const open = () => {
+      if (liveItemPopoverSuppressOpen) return
+      showLiveItemPopover(control, key, kind, resolve)
+    }
+    const closesFrom = event => {
+      const related = event.relatedTarget
+      if (related instanceof Node &&
+          (control.contains(related) || nodes.liveItemPopover?.contains(related))) return
+      if (liveItemPopoverKey === key) hideLiveItemPopover(false)
+    }
+    // A mousedown on the popover's own non-focusable content (a fact line,
+    // its own text) blurs whatever was focused with relatedTarget === null
+    // -- there being no next focusable target is not the same as focus
+    // genuinely leaving both the anchor and the popover, so a null
+    // relatedTarget here is left to the document-level outside-press
+    // handler below, which correctly recognises a press inside the
+    // popover and leaves it open. This still closes on a real keyboard
+    // Shift+Tab away from the anchor, whose relatedTarget is the real
+    // element focus lands on.
+    const closesOnRealFocusMove = event => {
+      // A mousedown anywhere inside the popover on its own non-focusable
+      // content (a fact line, its own text) makes the browser walk up to
+      // the nearest focusable ANCESTOR of the click target and focus that
+      // -- #live-viewport itself, since the popover has no tabindex of
+      // its own -- which is not focus genuinely leaving the popover. The
+      // document-level pointerdown handler below already made the correct
+      // open/close call for this exact press; liveItemPopoverPressWasInside
+      // carries that same verdict here so a real keyboard Shift+Tab away
+      // (relatedTarget is whatever real element focus lands on, and this
+      // flag is false because no pointerdown preceded it) still closes.
+      const pressWasInside = liveItemPopoverPressWasInside
+      liveItemPopoverPressWasInside = false
+      if (event.relatedTarget === null || pressWasInside) return
+      closesFrom(event)
+    }
+    control.addEventListener('pointerover', event => {
+      if (event.pointerType === 'touch') return
+      open()
+    })
+    control.addEventListener('pointerout', closesFrom)
+    control.addEventListener('focusin', open)
+    control.addEventListener('focusout', closesOnRealFocusMove)
+    control.addEventListener('keydown', event => {
+      if (event.key !== 'Tab' || event.shiftKey || liveItemPopoverKey !== key) return
+      const action = nodes.liveItemPopover?.querySelector('.live-item-popover-open')
+      if (!action) return
+      event.preventDefault()
+      action.focus({ preventScroll: true })
+    })
+  }
+
+  // Wired once from PART_39_WIRING_AND_BOOT: the popover's own pointer-out
+  // and Tab bridge, plus the escape/outside-press/visibility closes that
+  // belong beside the client's other document-level listeners.
+  function wireLiveItemPopover() {
+    nodes.liveItemPopover?.addEventListener('pointerleave', event => {
+      const related = event.relatedTarget
+      if (related instanceof Node && liveItemPopoverAnchor?.contains(related)) return
+      hideLiveItemPopover(false)
+    })
+    nodes.liveItemPopover?.addEventListener('focusout', event => {
+      // Same tolerance as bindLiveItemPopover's own focusout handler: a
+      // mousedown on the popover's own non-focusable text (leaving the
+      // action button) walks up to the nearest focusable ancestor of the
+      // click target -- #live-viewport -- which is not focus genuinely
+      // leaving the popover, and liveItemPopoverPressWasInside already
+      // carries the document-level pointerdown handler's correct verdict
+      // for that same press.
+      const pressWasInside = liveItemPopoverPressWasInside
+      liveItemPopoverPressWasInside = false
+      if (event.relatedTarget === null || pressWasInside) return
+      const related = event.relatedTarget
+      if (related instanceof Node &&
+          (liveItemPopoverAnchor?.contains(related) || nodes.liveItemPopover.contains(related))) {
+        return
+      }
+      hideLiveItemPopover(false)
+    })
+    nodes.liveItemPopover?.addEventListener('keydown', event => {
+      if (event.key !== 'Tab') return
+      if (event.shiftKey) {
+        if (!liveItemPopoverAnchor) return
+        event.preventDefault()
+        liveItemPopoverAnchor.focus({ preventScroll: true })
+        return
+      }
+      event.preventDefault()
+      hideLiveItemPopover(true)
+    })
+    document.addEventListener('keydown', event => {
+      if (event.key !== 'Escape' || !liveItemPopoverIsOpen()) return
+      event.preventDefault()
+      event.stopPropagation()
+      hideLiveItemPopover(true)
+    }, true)
+    document.addEventListener('pointerdown', event => {
+      if (!liveItemPopoverIsOpen()) {
+        liveItemPopoverPressWasInside = false
+        return
+      }
+      const target = event.target
+      const inside = target instanceof Node &&
+        (liveItemPopoverAnchor?.contains(target) || nodes.liveItemPopover.contains(target))
+      // Recorded for the focusout handlers above, which run as a
+      // synchronous side effect of this same press when it lands on
+      // non-focusable popover content: pointerdown always precedes the
+      // resulting blur/focusout, so the verdict made here is still fresh
+      // when they read it. Cleared at the top of the very next pointerdown
+      // so a later, unrelated focus change (Shift+Tab away) is never
+      // mistaken for following an inside press.
+      liveItemPopoverPressWasInside = Boolean(inside)
+      if (inside) return
+      hideLiveItemPopover(false)
+    }, true)
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden && liveItemPopoverIsOpen()) hideLiveItemPopover(false)
+    })
+  }
+
+`

--- a/src/window-client/program/index.ts
+++ b/src/window-client/program/index.ts
@@ -62,6 +62,7 @@ import { PART_35_VIEW_RENDER_AND_SELECTION } from './35-view-render-and-selectio
 import { PART_36_FOCUSED_PLACE_AND_RESIDENT } from './36-focused-place-and-resident.ts'
 import { PART_37_SNAPSHOT_FETCH_AND_CACHE_INVALIDATION } from './37-snapshot-fetch-and-cache-invalidation.ts'
 import { PART_38_REFRESH_CITY } from './38-refresh-city.ts'
+import { PART_40_LIVE_ITEM_POPOVER } from './40-live-item-popover.ts'
 import { PART_39_WIRING_AND_BOOT } from './39-wiring-and-boot.ts'
 
 export const WINDOW_CLIENT_PARTS: readonly string[] = Object.freeze([
@@ -103,5 +104,6 @@ export const WINDOW_CLIENT_PARTS: readonly string[] = Object.freeze([
   PART_36_FOCUSED_PLACE_AND_RESIDENT,
   PART_37_SNAPSHOT_FETCH_AND_CACHE_INVALIDATION,
   PART_38_REFRESH_CITY,
+  PART_40_LIVE_ITEM_POPOVER,
   PART_39_WIRING_AND_BOOT,
 ])

--- a/src/window-page.ts
+++ b/src/window-page.ts
@@ -152,9 +152,10 @@ export const WINDOW_HTML = `<!doctype html>
               </div>
             </div>
             <div id="live-label-layer" class="live-label-layer" aria-hidden="true"></div>
+            <div id="live-item-popover" class="live-item-popover" role="group" hidden></div>
           </div>
           <div class="live-stage-readout">
-            <p id="live-camera-help" class="live-camera-help">Drag or use arrow keys to pan. Scroll, pinch, or use +/− to zoom. Center or 0 returns to a readable view around the current place or focused item; it never shrinks the whole place to fit. Distant places stay as reachable markers until they approach the camera. Hover or keyboard focus brings a complete item and label forward. On touch, tap once to bring a covered item forward and again to open it. Show more reveals people or things on the live ground without a window.</p>
+            <p id="live-camera-help" class="live-camera-help">Drag or use arrow keys to pan. Scroll, pinch, or use +/− to zoom. Center or 0 returns to a readable view around the current place or focused item; it never shrinks the whole place to fit. Distant places stay as reachable markers until they approach the camera. Hover or keyboard focus brings a complete item and label forward. On touch, tap once to bring a covered item forward and again to open it. Hover, keyboard focus, or that first tap also opens one small card of facts beside the item; Escape or a tap elsewhere closes it, and its one control opens that item's record. Show more reveals people or things on the live ground without a window.</p>
             <p id="live-focus-status" class="live-focus-status" role="status" aria-live="polite">No resident focused. Choose a resident on the plate to keep them in view.</p>
           </div>
           <aside class="live-ledger-panel" aria-labelledby="live-ledger-title">

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -704,6 +704,58 @@ button { color: inherit; }
   overflow: hidden;
   pointer-events: none;
 }
+/* Step 4: the single reusable Live item popover. Lives outside #live-stage
+   (which carries a CSS transform and isolates its own stacking context),
+   so its position is unscaled by the camera and unclipped by plot overflow;
+   z-index only needs to clear .live-label-layer's 50, since #live-stage's
+   own internal z-index values never escape its isolated context. */
+.live-item-popover {
+  position: absolute;
+  z-index: 90;
+  max-width: min(20rem, calc(100% - 2 * var(--live-item-popover-margin, 0.5rem)));
+  padding: 0.65rem 0.75rem;
+  color: var(--paper-light);
+  background: var(--night);
+  border: 3px solid var(--line);
+  box-shadow: 6px 6px 0 rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+  user-select: text;
+  opacity: 1;
+  transition: opacity 120ms ease-out;
+}
+.live-item-popover[hidden] { display: none; }
+.live-item-popover-title {
+  margin: 0 0 0.35rem;
+  font-weight: 850;
+  font-size: 0.85rem;
+}
+.live-item-popover-facts {
+  margin: 0 0 0.35rem;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+}
+.live-item-popover-last-action {
+  margin: 0 0 0.5rem;
+  color: var(--paper);
+  font-size: 0.74rem;
+  font-style: italic;
+}
+.live-item-popover .quiet-room-notice { margin: 0 0 0.5rem; font-size: 0.78rem; }
+.live-item-popover-open {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.4rem 0.7rem;
+  color: var(--night);
+  background: var(--signal);
+  border: 2px solid var(--line);
+  font-weight: 800;
+  cursor: pointer;
+}
 .live-resident-tag {
   position: absolute;
   z-index: 1;
@@ -2383,18 +2435,21 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   .live-walker, .live-replay-portrait, .live-overflow-absorbing,
   .live-speech-bubble { animation: none !important; transition: none !important; }
   .live-trail, .live-trail-inking { animation: none !important; transition: none !important; }
+  .live-item-popover { transition: none !important; }
 }
 @media (forced-colors: active) {
   .city-sign, .view-console, .window-frame, .place-card, .person-card, .thing-card,
   .note-card, .agreement-card, .gazette-entry, .gazette-issue-summary, .live-stage-shell,
   .live-viewport, .live-plot, .live-portrait, .live-speech-bubble,
   .live-resident-more, .live-thing-more, .live-control-button,
-  .drawing-grid, .live-resident-tag { border-color: CanvasText; box-shadow: none; }
+  .drawing-grid, .live-resident-tag, .live-item-popover { border-color: CanvasText; box-shadow: none; }
   .live-world-ground, .live-plot-terrain { forced-color-adjust: none; }
   .live-plot-open, .live-focus-clear { color: LinkText; }
   .live-trail { stroke: LinkText; }
   .live-footnote-mark, .live-action-mark, .live-resident-more,
-  .live-thing-more, .live-control-button { color: ButtonText; background: ButtonFace; }
+  .live-thing-more, .live-control-button, .live-item-popover-open {
+    color: ButtonText; background: ButtonFace;
+  }
   .live-speech-bubble { color: CanvasText; background: Canvas; }
 }
 `

--- a/test/help-text.test.ts
+++ b/test/help-text.test.ts
@@ -27,6 +27,7 @@ const mcpSource = read('../src/mcp.ts')
 const hostedDiscoverySource = read('../src/hosted-chat-discovery.ts')
 const workingStandard = read('../AGENTS.md')
 const invariants = read('../docs/INVARIANTS.md')
+const windowPage = read('../src/window-page.ts')
 
 test('public surfaces keep the tools page community-only and explain its review queue', () => {
   for (const [name, text] of [
@@ -1737,5 +1738,40 @@ test('a kind\'s trait recipe only fires for use, consume, and give with thing_id
     mcpSource,
     /use, consume, and give also run the named thing's kind traits/iu,
     'the act tool must state which actions run kind traits',
+  )
+})
+
+test('step 4: the Live item popover contract replaces the removed nameplate-tooltip claim on every surface', () => {
+  const flatten = (value: string) => value.replace(/\s+/gu, ' ')
+  const removedClaim = /tooltip carries the complete place name/iu
+  for (const [name, text] of [
+    ['front door source', frontdoor],
+    ['generated front door', FRONTDOOR],
+    ['published front door', frontdoorDocument],
+    ['system design', specification],
+  ] as const) {
+    assert.doesNotMatch(text, removedClaim, `${name}: the removed nameplate-tooltip claim must be gone`)
+  }
+  for (const [name, text] of [
+    ['front door source', frontdoor],
+    ['generated front door', FRONTDOOR],
+    ['published front door', frontdoorDocument],
+    ['system design', specification],
+  ] as const) {
+    assert.match(
+      flatten(text),
+      /(popover|card) beside it[\s\S]{0,400}complete place name/u,
+      `${name}: must state the popover contract, including that it carries the complete place name`,
+    )
+  }
+  assert.match(
+    windowPage,
+    /Hover, keyboard focus, or that first tap also opens one small card of facts beside the item/u,
+    'the #live-camera-help sentence must state the popover contract before use',
+  )
+  assert.match(
+    windowPage,
+    /id="live-item-popover" class="live-item-popover" role="group" hidden/u,
+    'the static popover element must exist exactly once, outside #live-stage',
   )
 })

--- a/test/quiet-dom-leak-inventory.test.ts
+++ b/test/quiet-dom-leak-inventory.test.ts
@@ -196,6 +196,10 @@ const ALLOW_LIST: ReadonlyMap<string, string> = new Map([
     'unchanged... because the city keeps public books", and e2e/public-window-interactions.spec.ts ' +
     'explicitly asserts an actor\'s handle and a quiet place\'s name both appear in Happenings entries ' +
     'for moves into and out of it.'],
+  ['liveItemPopoverContent',
+    'Step 4: builds the single reusable Live item popover from facts and a name its caller already ' +
+    'resolved through liveItemPopoverFacts, which calls isQuietPlace per item before this function ever ' +
+    'runs; like livePortraitGrid and liveThingShelf above, it has no place context of its own to check.'],
 ])
 
 test('the window client source actually contains identity-bearing DOM writes for this scan to find', () => {

--- a/test/quiet-rooms.test.ts
+++ b/test/quiet-rooms.test.ts
@@ -276,6 +276,14 @@ test('every path that lists a resident, thing, or note resolves quiet through is
       name: "liveFocusInteractionsPanel's thing list collapses a thing pointing at a quiet place",
       pattern: /const quietPlace = isQuietPlace\(place\) \? place : isQuietPlace\(recordedPlace\) \? recordedPlace : null\s*\n\s*if \(quietPlace\) \{/u,
     },
+    // Step 4: the single reusable Live item popover resolves a resident's
+    // current place quiet mark itself -- placeReference at the resident's
+    // own row, then isQuietPlace -- before ever building a location fact,
+    // exactly like every other listing path above.
+    {
+      name: 'liveItemPopoverFacts: the Live item popover resolves a resident location quiet at its own row',
+      pattern: /function liveItemPopoverFacts\(kind, item, snapshot\) \{[\s\S]{0,400}locationQuiet: isQuietPlace\(place\)/u,
+    },
   ]
   for (const path of paths) {
     assert.match(WINDOW_JS, path.pattern, path.name + ' must resolve quiet through isQuietPlace')
@@ -293,6 +301,14 @@ test('every path that lists a resident, thing, or note resolves quiet through is
     "if (focus.quiet)",
     "if (place.quiet)",
     "if (place && place.quiet)",
+    // Step 4: windowLiveItemFacts is the pure, unit-tested content
+    // assembler for the Live item popover (src/window-client/live-popover.ts).
+    // It receives an already-identified place row from its one caller,
+    // liveItemPopoverFacts, which is the function that actually resolves
+    // *which* place to check via placeReference/isQuietPlace (see the path
+    // table above). This is the terminal read of that already-resolved
+    // place's own quiet mark, not a second independent quiet decision.
+    "if (place.quiet === true)",
   ])
   for (const check of bespokeQuietChecks) {
     assert.ok(

--- a/test/window-live-client.test.ts
+++ b/test/window-live-client.test.ts
@@ -24,6 +24,9 @@ import {
   windowLiveSpeechLine,
   windowLiveTouchActivation,
   windowLiveTraceOpacity,
+  windowLiveItemFacts,
+  windowLiveItemLastAction,
+  windowLiveItemPopoverPlacement,
 } from '../src/window-client.ts'
 
 type SurveyedPlace = Readonly<{
@@ -1642,4 +1645,247 @@ test('speech bubbles keep only the first line and use an honest 60-character ell
   const bubble = windowLiveSpeechLine(longLine)
   assert.equal(Array.from(bubble).length, 60)
   assert.equal(bubble, '🙂'.repeat(59) + '…')
+})
+
+// Step 4: the single reusable Live item popover. windowLiveItemFacts,
+// windowLiveItemLastAction, and windowLiveItemPopoverPlacement are the
+// pure, stringified-into-the-client helpers behind it
+// (src/window-client/live-popover.ts).
+
+test('windowLiveItemFacts builds the same fact-row shape for a resident, a thing, and a place, and marks an unknown fact absent rather than guessing', () => {
+  const residentFacts = windowLiveItemFacts('resident', { asleep: false, has_drawing: false }, {})
+  assert.deepEqual(residentFacts.facts, ['no drawing yet'])
+  assert.equal(residentFacts.quiet, false)
+
+  const thingWithoutMaker = windowLiveItemFacts('thing', {
+    made_by: null, current_owner: 'proof-alex', body: 'hi', truncated: false,
+    open_to_use: false, kind: null, has_drawing: false,
+  }, {})
+  assert.ok(!thingWithoutMaker.facts.some(fact => fact.startsWith('made by')))
+  assert.deepEqual(thingWithoutMaker.facts, ['kept by proof-alex', 'body 2 bytes', 'no drawing yet'])
+
+  const residentWithNoResolvedLocation = windowLiveItemFacts(
+    'resident', { asleep: false, has_drawing: false }, { locationName: null },
+  )
+  assert.ok(!residentWithNoResolvedLocation.facts.some(fact => fact.startsWith('in ')))
+
+  assert.match(
+    windowClientModule.WINDOW_JS,
+    /const windowLiveItemFacts = function windowLiveItemFacts/u,
+  )
+})
+
+test('windowLiveItemFacts reports an exact body size as UTF-8 byte length, and omits it entirely for a truncated thing', () => {
+  const multiByte = windowLiveItemFacts('thing', {
+    made_by: 'proof-alex', current_owner: 'proof-alex', body: 'éé', truncated: false,
+    open_to_use: false, kind: null, has_drawing: false,
+  }, {})
+  assert.ok(multiByte.facts.includes('body 4 bytes'))
+
+  const truncated = windowLiveItemFacts('thing', {
+    made_by: 'proof-alex', current_owner: 'proof-alex', body: 'x'.repeat(1000), truncated: true,
+    open_to_use: false, kind: null, has_drawing: false,
+  }, {})
+  assert.ok(!truncated.facts.some(fact => /^body \d+ bytes$/.test(fact)))
+  assert.ok(truncated.facts.includes(
+    'body continues past the loaded head — open the record for the whole body',
+  ))
+})
+
+test('windowLiveItemFacts on a quiet place returns the name, owner, and both counts with quiet true and zero content facts', () => {
+  const quiet = windowLiveItemFacts('place', {
+    owner: 'proof-alex', purpose: 'A private workshop.', places: 2, notes: 3, quiet: true,
+  }, { exactThingTotal: 7 })
+  assert.equal(quiet.quiet, true)
+  assert.deepEqual(quiet.facts, ['kept by proof-alex', '2 places · 3 notes', '7 things'])
+  assert.ok(!quiet.facts.some(fact => fact === 'A private workshop.'))
+})
+
+test('windowLiveItemFacts on a resident whose current place is quiet omits the location name entirely', () => {
+  const result = windowLiveItemFacts(
+    'resident',
+    { asleep: false, has_drawing: false },
+    { locationName: 'Quiet porch', locationQuiet: true },
+  )
+  assert.ok(!result.facts.some(fact => fact.includes('Quiet porch')))
+})
+
+test('windowLiveItemFacts degrades the drawing fact honestly: exact label when cached, else only has/no drawing yet', () => {
+  const cachedComplete = windowLiveItemFacts('resident', { asleep: false, has_drawing: true }, {
+    cachedDrawing: {
+      state: 'complete',
+      drawing: Object.freeze({
+        palette: Object.freeze(['#102030']),
+        indices: Object.freeze(Array.from({ length: 64 }, (_, index) => index === 0 ? 0 : null)),
+      }),
+      source: 'resident',
+    },
+  })
+  assert.ok(cachedComplete.facts.includes('Complete · Own drawing'))
+
+  const cachedBlank = windowLiveItemFacts('resident', { asleep: false, has_drawing: true }, {
+    cachedDrawing: {
+      state: 'complete',
+      drawing: Object.freeze({ palette: Object.freeze([]), indices: Array(64).fill(null) }),
+      source: 'resident',
+    },
+  })
+  assert.ok(cachedBlank.facts.includes('Blank · Own drawing'))
+
+  const uncachedDrawn = windowLiveItemFacts('resident', { asleep: false, has_drawing: true }, {})
+  assert.ok(uncachedDrawn.facts.includes('has a drawing'))
+  const uncachedUndrawn = windowLiveItemFacts('resident', { asleep: false, has_drawing: false }, {})
+  assert.ok(uncachedUndrawn.facts.includes('no drawing yet'))
+})
+
+test('windowLiveItemFacts omits the exact thing count only when the survey total is null, never a loaded-row count dressed as exact', () => {
+  const unavailable = windowLiveItemFacts('place', {
+    owner: 'proof-alex', places: 0, notes: 0,
+  }, { exactThingTotal: null })
+  assert.ok(unavailable.facts.includes('exact thing count unavailable'))
+
+  const exact = windowLiveItemFacts('place', {
+    owner: 'proof-alex', places: 0, notes: 0,
+  }, { exactThingTotal: 7 })
+  assert.ok(exact.facts.includes('7 things'))
+})
+
+test('windowLiveItemFacts on the ownerless world root prints "nobody owns it", and an empty purpose yields no purpose row', () => {
+  const root = windowLiveItemFacts('place', { owner: null, purpose: '', places: 3, notes: 0 }, {
+    exactThingTotal: 0,
+  })
+  assert.ok(root.facts.includes('nobody owns it'))
+  assert.ok(!root.facts.some(fact => fact === ''))
+  assert.equal(root.facts.filter(fact => fact === 'nobody owns it').length, 1)
+})
+
+test('windowLiveItemLastAction returns a body-free phrase for move, note, make, and use, and null when nothing covers the item', () => {
+  const at = new Date('2026-01-01T00:00:00.000Z')
+  const moveRecord = Object.freeze({
+    actor: 'proof-alex', kind: 'action', at,
+    detail: Object.freeze({ action: 'move', status: 'applied', from_place_id: 1, to_place_id: 2 }),
+  })
+  assert.equal(
+    windowLiveItemLastAction([moveRecord], 'resident', 'proof-alex', () => 'Movement garden'),
+    'moved in from Movement garden',
+  )
+
+  const noteRecord = Object.freeze({
+    actor: 'proof-alex', kind: 'note', at,
+    detail: Object.freeze({ note_id: 9301, place_id: 2 }),
+  })
+  assert.equal(windowLiveItemLastAction([noteRecord], 'resident', 'proof-alex'), 'spoke here')
+
+  const makeRecord = Object.freeze({
+    actor: 'proof-alex', kind: 'thing_created', at,
+    detail: Object.freeze({ place_id: 2, thing_id: 9401 }),
+  })
+  assert.equal(
+    windowLiveItemLastAction([makeRecord], 'resident', 'proof-alex'),
+    'made thing #9401',
+  )
+
+  const useRecord = Object.freeze({
+    actor: 'proof-alex', kind: 'action', at,
+    detail: Object.freeze({
+      action: 'use', status: 'applied', place_id: 2, source_thing_id: 9401,
+    }),
+  })
+  assert.equal(
+    windowLiveItemLastAction([useRecord], 'resident', 'proof-alex'),
+    'used thing #9401',
+  )
+
+  assert.equal(windowLiveItemLastAction([], 'resident', 'proof-alex'), null)
+  assert.equal(windowLiveItemLastAction([moveRecord], 'place', '2'), null)
+
+  const usedByThing = windowLiveItemLastAction([useRecord], 'thing', 9401)
+  assert.equal(usedByThing, 'used by proof-alex')
+  const madeByThing = windowLiveItemLastAction([makeRecord], 'thing', 9401)
+  assert.equal(madeByThing, 'made by proof-alex here')
+  const carriedThing = windowLiveItemLastAction([Object.freeze({
+    actor: 'proof-bea', kind: 'action', at,
+    detail: Object.freeze({
+      action: 'move', status: 'applied', from_place_id: 1, to_place_id: 2,
+      mode: 'carry', thing_id: 9401,
+    }),
+  })], 'thing', 9401)
+  assert.equal(carriedThing, 'carried in by proof-bea')
+
+  assert.match(
+    windowClientModule.WINDOW_JS,
+    /const windowLiveItemLastAction = function windowLiveItemLastAction/u,
+  )
+})
+
+test('windowLiveItemLastAction withholds a place name when that place is quiet, for both endpoints of a move', () => {
+  const at = new Date('2026-01-01T00:00:00.000Z')
+  const moveRecord = Object.freeze({
+    actor: 'proof-alex', kind: 'action', at,
+    detail: Object.freeze({ action: 'move', status: 'applied', from_place_id: 1, to_place_id: 2 }),
+  })
+  const withheld = windowLiveItemLastAction([moveRecord], 'resident', 'proof-alex', () => null)
+  assert.equal(withheld, 'moved in')
+  assert.ok(!withheld.includes('from'))
+})
+
+test('windowLiveItemPopoverPlacement never returns a rectangle intersecting the anchor rect', () => {
+  const viewport = Object.freeze({ left: 0, top: 0, right: 800, bottom: 600 })
+  const size = Object.freeze({ width: 200, height: 100 })
+  const anchors = [
+    Object.freeze({ left: 400, top: 300, right: 420, bottom: 320 }), // centre
+    Object.freeze({ left: 0, top: 0, right: 20, bottom: 20 }), // top-left corner
+    Object.freeze({ left: 780, top: 0, right: 800, bottom: 20 }), // top-right corner
+    Object.freeze({ left: 0, top: 580, right: 20, bottom: 600 }), // bottom-left corner
+    Object.freeze({ left: 780, top: 580, right: 800, bottom: 600 }), // bottom-right corner
+  ]
+  for (const anchor of anchors) {
+    const placement = windowLiveItemPopoverPlacement(anchor, size, viewport, 10, 8)
+    if (!placement) continue
+    const intersects = placement.left < anchor.right && placement.left + size.width > anchor.left &&
+      placement.top < anchor.bottom && placement.top + size.height > anchor.top
+    assert.equal(intersects, false, JSON.stringify(anchor))
+  }
+})
+
+test('windowLiveItemPopoverPlacement keeps the popover fully inside the viewport with margin whenever any side fits, and clamps without covering the anchor otherwise', () => {
+  const viewport = Object.freeze({ left: 0, top: 0, right: 800, bottom: 600 })
+  const size = Object.freeze({ width: 200, height: 100 })
+  const anchor = Object.freeze({ left: 400, top: 300, right: 420, bottom: 320 })
+  const placement = windowLiveItemPopoverPlacement(anchor, size, viewport, 10, 8)
+  assert.ok(placement)
+  assert.ok(placement.left >= 8)
+  assert.ok(placement.left + size.width <= 800 - 8)
+  assert.ok(placement.top >= 8)
+  assert.ok(placement.top + size.height <= 600 - 8)
+
+  // A 375x812 phone viewport with a 320-wide popover, anchored near the edge.
+  const phoneViewport = Object.freeze({ left: 0, top: 0, right: 375, bottom: 812 })
+  const phoneSize = Object.freeze({ width: 320, height: 160 })
+  const edgeAnchor = Object.freeze({ left: 2, top: 2, right: 22, bottom: 22 })
+  const phonePlacement = windowLiveItemPopoverPlacement(edgeAnchor, phoneSize, phoneViewport, 10, 8)
+  assert.ok(phonePlacement)
+  assert.ok(phonePlacement.left >= 0)
+  assert.ok(phonePlacement.left + phoneSize.width <= 375)
+})
+
+test('windowLiveItemPopoverPlacement is deterministic and fails closed on invalid input', () => {
+  const viewport = Object.freeze({ left: 0, top: 0, right: 800, bottom: 600 })
+  const size = Object.freeze({ width: 200, height: 100 })
+  const anchor = Object.freeze({ left: 400, top: 300, right: 420, bottom: 320 })
+  const first = windowLiveItemPopoverPlacement(anchor, size, viewport, 10, 8)
+  const second = windowLiveItemPopoverPlacement(anchor, size, viewport, 10, 8)
+  assert.deepEqual(first, second)
+
+  assert.equal(windowLiveItemPopoverPlacement(
+    Object.freeze({ left: NaN, top: 0, right: 20, bottom: 20 }), size, viewport, 10, 8,
+  ), null)
+  assert.equal(windowLiveItemPopoverPlacement(
+    Object.freeze({ left: 10, top: 10, right: 10, bottom: 10 }), size, viewport, 10, 8,
+  ), null)
+
+  assert.match(
+    windowClientModule.WINDOW_JS,
+    /const windowLiveItemPopoverPlacement = function windowLiveItemPopoverPlacement/u,
+  )
 })

--- a/test/window-live-client.test.ts
+++ b/test/window-live-client.test.ts
@@ -1869,6 +1869,98 @@ test('windowLiveItemPopoverPlacement keeps the popover fully inside the viewport
   assert.ok(phonePlacement.left + phoneSize.width <= 375)
 })
 
+// Round 1 review, finding #1 (HIGH): windowLiveItemPopoverPlacement could
+// render the popover entirely outside #live-viewport for an anchor the
+// camera has left off-screen -- reproduced live on the deployed preview at
+// 375x812 by hovering/focusing a resident not currently framed by the
+// camera, which is the normal state for most residents on any plate wider
+// than the viewport. Pinned here with the exact shape of that reproduction
+// (anchor.left far past viewport.right) and with the containment invariant
+// checked explicitly rather than only the never-covers-anchor one, since a
+// null primary axis passed that check while still rendering off-screen.
+test('windowLiveItemPopoverPlacement stays fully inside the viewport for an anchor the camera has left entirely off-screen', () => {
+  const viewport = Object.freeze({ left: 0, top: 0, right: 349, bottom: 812 })
+  const size = Object.freeze({ width: 260, height: 96 })
+  const offCameraAnchors = [
+    Object.freeze({ left: 608, top: 300, right: 706, bottom: 320 }), // right of viewport
+    Object.freeze({ left: -700, top: 300, right: -600, bottom: 320 }), // left of viewport
+    Object.freeze({ left: 100, top: -900, right: 120, bottom: -880 }), // above viewport
+    Object.freeze({ left: 100, top: 1800, right: 120, bottom: 1820 }), // below viewport
+    Object.freeze({ left: -700, top: -900, right: -680, bottom: -880 }), // above-left, diagonal
+  ]
+  for (const anchor of offCameraAnchors) {
+    const placement = windowLiveItemPopoverPlacement(anchor, size, viewport, 10, 8)
+    assert.ok(placement, JSON.stringify(anchor))
+    assert.ok(placement!.left >= 8, JSON.stringify(anchor))
+    assert.ok(placement!.left + size.width <= 349 - 8, JSON.stringify(anchor))
+    assert.ok(placement!.top >= 8, JSON.stringify(anchor))
+    assert.ok(placement!.top + size.height <= 812 - 8, JSON.stringify(anchor))
+    // An anchor entirely outside the viewport can never be reached by a
+    // placement fully contained inside it, so containment and
+    // never-covers-anchor both hold at once here, not just containment.
+    const absoluteLeft = placement!.left + viewport.left
+    const absoluteTop = placement!.top + viewport.top
+    const intersects = absoluteLeft < anchor.right && absoluteLeft + size.width > anchor.left &&
+      absoluteTop < anchor.bottom && absoluteTop + size.height > anchor.top
+    assert.equal(intersects, false, JSON.stringify(anchor))
+  }
+})
+
+test('windowLiveItemPopoverPlacement keeps a 320px popover inside a 375x812 viewport for anchors at every corner and edge, on camera and off', () => {
+  const viewport = Object.freeze({ left: 0, top: 0, right: 375, bottom: 812 })
+  const size = Object.freeze({ width: 320, height: 160 })
+  const anchors = [
+    Object.freeze({ left: 0, top: 0, right: 20, bottom: 20 }), // top-left
+    Object.freeze({ left: 355, top: 0, right: 375, bottom: 20 }), // top-right
+    Object.freeze({ left: 0, top: 792, right: 20, bottom: 812 }), // bottom-left
+    Object.freeze({ left: 355, top: 792, right: 375, bottom: 812 }), // bottom-right
+    Object.freeze({ left: 177, top: 396, right: 197, bottom: 416 }), // centre
+    Object.freeze({ left: 175, top: 0, right: 195, bottom: 20 }), // top edge, mid
+    Object.freeze({ left: 175, top: 792, right: 195, bottom: 812 }), // bottom edge, mid
+    Object.freeze({ left: -600, top: -600, right: -580, bottom: -580 }), // off top-left
+    Object.freeze({ left: 900, top: -600, right: 920, bottom: -580 }), // off top-right
+    Object.freeze({ left: -600, top: 1400, right: -580, bottom: 1420 }), // off bottom-left
+    Object.freeze({ left: 900, top: 1400, right: 920, bottom: 1420 }), // off bottom-right
+  ]
+  for (const anchor of anchors) {
+    const placement = windowLiveItemPopoverPlacement(anchor, size, viewport, 10, 8)
+    assert.ok(placement, JSON.stringify(anchor))
+    assert.ok(placement!.left >= 8, JSON.stringify(anchor))
+    assert.ok(placement!.left + size.width <= 375 - 8, JSON.stringify(anchor))
+    assert.ok(placement!.top >= 8, JSON.stringify(anchor))
+    assert.ok(placement!.top + size.height <= 812 - 8, JSON.stringify(anchor))
+  }
+})
+
+test('windowLiveItemPopoverPlacement prefers containment over avoiding the anchor when both cannot hold, and never returns NaN', () => {
+  // A tiny viewport almost entirely covered by its own anchor leaves no
+  // position that is both fully contained and anchor-free. The rule
+  // documented on the function is that containment wins: the placement
+  // must still land inside the viewport even though it may then overlap
+  // the anchor a little.
+  const viewport = Object.freeze({ left: 0, top: 0, right: 100, bottom: 100 })
+  const size = Object.freeze({ width: 60, height: 60 })
+  const anchor = Object.freeze({ left: 10, top: 10, right: 90, bottom: 90 })
+  const placement = windowLiveItemPopoverPlacement(anchor, size, viewport, 5, 2)
+  assert.ok(placement)
+  assert.ok(placement!.left >= 2)
+  assert.ok(placement!.left + size.width <= 100 - 2)
+  assert.ok(placement!.top >= 2)
+  assert.ok(placement!.top + size.height <= 100 - 2)
+
+  // A popover wider than the whole viewport is a degenerate but valid
+  // input (never non-finite, never zero-area) -- it must still fail closed
+  // to a deterministic, finite position rather than throwing or landing at
+  // NaN.
+  const wideSize = Object.freeze({ width: 500, height: 160 })
+  const narrowViewport = Object.freeze({ left: 0, top: 0, right: 375, bottom: 812 })
+  const smallAnchor = Object.freeze({ left: 150, top: 300, right: 170, bottom: 320 })
+  const widePlacement = windowLiveItemPopoverPlacement(smallAnchor, wideSize, narrowViewport, 10, 8)
+  assert.ok(widePlacement)
+  assert.ok(Number.isFinite(widePlacement!.left))
+  assert.ok(Number.isFinite(widePlacement!.top))
+})
+
 test('windowLiveItemPopoverPlacement is deterministic and fails closed on invalid input', () => {
   const viewport = Object.freeze({ left: 0, top: 0, right: 800, bottom: 600 })
   const size = Object.freeze({ width: 200, height: 100 })


### PR DESCRIPTION
## What changed

Step 4 of the Live-view rebuild: **one reusable popover for the whole plate**, replacing the per-sprite title attributes steps 2/3 left as the only carrier of a resident/thing's state, provenance, and a plot nameplate's complete name.

- `#live-item-popover`: one static element, created once, reused for every resident portrait, thing specimen, and plot nameplate. Lives inside `#live-viewport` as the next sibling of `#live-label-layer`, outside `#live-stage`'s transform/stacking context, so its position is never scaled by the camera or clipped by plot overflow.
- Opens on hover, keyboard focus, or the first touch tap (reuses the existing bring-forward `control.focus()` call, no new touch code). Shows the item's complete name/id, its public facts (location/sleep/drawing for a resident; kind/maker/owner/body-size/open-to-use/drawing for a thing; owner/purpose/counts/floor for a place), a body-free last-recorded-action phrase built only from records already in memory, and one action that opens the record.
- Never covers the anchor it describes (`windowLiveItemPopoverPlacement`, unit-tested against all four sides/corners, containment-when-any-side-fits, and fails-closed on impossible geometry). Closes on Escape, a press outside it, its item leaving the plate, or a re-render without that item; stays open across a re-render that still has it.
- A quiet place (decision #75) keeps name/owner/counts and replaces every other fact with the same `quietRoomNotice` sentence every other tab uses.
- Zero extra network requests, zero extra plate renders (its key/anchor/rect live outside `state`).

Two real bugs found only by driving this in a browser, both fixed:
1. A mousedown on the popover's own non-focusable text blurs the previously-focused anchor with `relatedTarget = #live-viewport` (the nearest focusable ancestor of the click target), not `null` — the focusout-close handlers were misreading that as focus genuinely leaving the popover. Fixed by having the document-level pointerdown handler record its inside/outside verdict for the focusout handlers to consult.
2. Escape's own focus-restore call (`anchor.focus()`) re-triggered the popover it had just asked to close, since `.focus()` fires `focusin` synchronously. Fixed with a short-lived suppress flag around that one call.

## Round 2 (adversarial review fixes)

Round 1 came back `fix_first` with four findings, verified live against the deployed preview. All four are fixed and covered by new tests here.

1. **HIGH — `src/window-client/live-popover.ts:240` (`windowLiveItemPopoverPlacement`).** The placement helper clamped only the cross axis when no side fit unclamped, leaving the primary axis untouched on the theory that clamping it would push the popover onto the anchor. That reasoning only held for an anchor near the viewport; for any anchor the camera had left off-screen (the normal state for most residents/things/places on a plate wider than the viewport) the primary axis could land arbitrarily far outside `#live-viewport`. The reviewer reproduced a popover rendered fully off-screen on the deployed preview by focusing an off-camera resident at 375×812 — exactly the keyboard-focus path step 4 exists to serve.

   Fixed by flipping the priority: containment inside the viewport now always wins over never touching the anchor (documented on the function at `live-popover.ts:241`). Every candidate side is clamped on **both** axes (`live-popover.ts:344`); the first clamped candidate that also avoids the anchor is used; only when none can avoid it (the popover is wider/taller than the viewport, or the anchor crowds a small one) does the least-overlapping contained candidate win instead. A caller never has to special-case an off-camera anchor.

   New unit tests: the exact off-camera reproduction (anchor entirely outside the viewport, all four directions), every corner/edge anchor at 375×812 with a 320px popover on camera and off, and a popover wider than its own viewport (`test/window-live-client.test.ts`). The e2e containment test now focuses an off-camera anchor directly instead of always panning it into view first, which is what actually exercises the bug.

2. **MEDIUM — `src/window-client/program/24-live-replay-motion.ts:444`.** The walking (`.live-replay-portrait`) resident was never wired to `bindLiveItemPopover`, so a resident's state, provenance, and last recorded action were unreachable by hover, keyboard focus, or touch for the entire 3.2–8s walk — a real regression versus the mouse-only title tooltip step 4 replaced.

   Fixed by binding the same popover under the identical item key (`resident:<handle>`) the settled `.live-walker` already uses. No per-frame work is added: the popover positions on open and repositions only on the existing rAF-batched camera commit, and when the walk ends the next render swaps the replay portrait for the settled walker under the same key, so `syncLiveItemPopoverAnchor` re-binds the still-open popover to it instead of closing it. It still closes under the existing rule if the resident leaves the plate entirely. New e2e test: `e2e/public-window-live.spec.ts` ("a resident mid-walk keeps their facts reachable...").

3. **LOW — this PR's own Verification section.** It claimed both local `e2e/public-window-live.spec.ts` runs were clean (87/87); the task's own detailed report said the second run had actually degraded to 81/87 under machine load, in pre-existing unrelated tests. The Verification section below now says what actually happened for both round 1's local runs and round 2's.

4. **LOW — `src/window-client/program/40-live-item-popover.ts:194` (`wireLiveItemPopover`).** Forward Tab from the popover's action button closed the popover and returned focus to the anchor, costing a keyboard user an extra Tab press to actually move on.

   Fixed: the next focusable element after the anchor is computed before closing (`liveItemPopoverNextFocusable`, `40-live-item-popover.ts:203`), and focus lands there instead — if that next element is itself a bound Live item, its own `focusin` listener opens its popover, which is the intended continuation into the ordinary plate order, not a new trap. Falls back to the anchor via the existing suppress-guarded restore when nothing follows it. New e2e test: "keyboard reach without a trap: forward Tab from the action button continues into the ordinary plate order".

## Rulings this implements

Decisions #58, #60, #61, #62, #75 — geometry, camera-bounded drawing, quiet rooms — untouched; this only makes what step 2/3 already computed reachable by more than mouse hover. No new decision row: `docs/DECISIONS.md` unchanged. Round 2 fixes a defect against those same decisions' own promises rather than changing what they promise, so no doc mirror needed a text change (the "never covers the item... stays inside the viewer's plate" claim in `src/door.ts` / `docs/SYSTEM_DESIGN.md` / the front-door mirrors is now actually true for every anchor, not only on-camera ones).

## Docs moved with the code

`src/frontdoor.txt` (source of truth) → regenerated `src/door.ts` and `docs/published/FRONTDOOR.md` via `scripts/embed-door.mjs`; `docs/SYSTEM_DESIGN.md`; `docs/DRAWING_AND_LIVE_VIEW.md` (new Live-view subsection + a §9 note on part-40's ship order). Round 2 changed no contract text, so `npm run door:check` stays a no-op diff.

## Proof scene

`src/window-client/program/04-live-proof-scene.ts` already had everything the popover needs (no new fixture data). The e2e proof test opens the popover on proof-alex (a resident with a real cached drawing), the pace lantern (a thing with a 28-byte body), and the Crowded activity workshop (a place with a purpose and exact counts), all at 375×812, asserting the exact facts and zero API requests.

Honest caveat: the proof scene preloads `state.live.drawings`, so proof-alex's popover shows the exact drawing state/source label. An ordinary production sprite has no cached drawing entry and shows only "has a drawing" / "no drawing yet" until the viewer opens a drawing record.

## WINDOW_JS / WINDOW_CSS size

| | main baseline | round 1 (de47674) | round 2 (this PR) | round-2 delta |
|---|---|---|---|---|
| WINDOW_JS chars | 548,218 | 575,020 | 579,019 | +3,999 |
| WINDOW_JS bytes | 548,524 | 575,332 | 579,331 | +3,999 |
| WINDOW_CSS chars | 75,776 | 77,415 | 77,415 | 0 |
| WINDOW_CSS bytes | 75,788 | 77,427 | 77,427 | 0 |

Round 2 touches no CSS. The JS growth (+3,999 bytes, +0.7% over round 1; +5.6% over the pre-step-4 baseline overall) is the priority-rule rewrite and its doc comments in `windowLiveItemPopoverPlacement`, the replay-portrait popover wiring, and the Tab-continuation helper — no duplicated code path.

## What's left out

- Steps 6-8 of the live-view blueprint (not part of this step).
- e2e cases for C5 (anchor leaves the plate) and C6 (stays open across a re-render with the anchor still present) are still not pinned by dedicated e2e tests; the wiring (`syncLiveItemPopoverAnchor`) is implemented and exercised indirectly by the passing suite, including the new mid-walk test's implicit exercise of the static/replay handoff.
- Round 1's own plan deliberately excluded the walking replay portrait from the popover ("bind to the static ground walker only, never to a `.live-replay-portrait`, to avoid per-frame repositioning") — that plan text lived only in the planning artifact, not in any shipped doc, so lifting the restriction in round 2 (finding #2) needed no doc correction; `docs/DRAWING_AND_LIVE_VIEW.md`'s shipped popover section never made the static-only claim in the first place.

## Verification

- `npm run typecheck` — clean.
- `npm run door:check` — `src/door.ts` / `docs/published/FRONTDOOR.md` regenerated from `src/frontdoor.txt`, no diff (idempotent; round 2 changed no contract text).
- `npm test` — round 2: 1922 tests, 1918 pass, 4 fail (the known Windows-only `test/identity-client.test.ts` failures, issue #183, unrelated to this change; same failures existed before round 2).
- `npx playwright test e2e/public-window-live.spec.ts` — run twice locally, as required, and reported honestly (correcting round 1's own Verification claim, finding #3 above):
  - **Round 1's** two local runs were actually 87/87 clean, then 81/87 under heavy concurrent machine load — a different pre-existing, unrelated, wall-clock-timing-sensitive subset failing each time, never a popover test. Round 1's PR body incorrectly stated both runs were clean.
  - **Round 2's** two local runs: **89/89 clean** (2.3m), then **88/89** (2.2m) with one failure — `resident focus persists locally, pins exact interactions, and camera zoom stays viewer-only` (`e2e/public-window-live.spec.ts:4447`), a pre-existing test untouched by this PR, failing with `Element is not attached to the DOM` during a `scrollIntoViewIfNeeded` wait — the same class of wall-clock/render-timing flake round 1 saw. Re-run alone immediately after, it passed. None of the round-2 popover tests (new or existing) failed in either run.
  - CI's own isolated `checks` job is the authoritative uncontended run per AGENTS.md; see its status below.
- `npx playwright test e2e/quiet-room-leak-scan.spec.ts` — green, including the popover step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
