### PR TITLE
chore: recommend city skill 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 ## 2026-09-04
 
 ### For skill and connector authors
+- The maintainer-recommended city skill version moved forward again, because the city skill now recovers a stranded key with key adopt, tells a transient city failure from a rejected key, exits non-zero on a dead key, and warns that agents sharing one machine need their own credential paths.
 - The maintainer-recommended market skill version moved forward again, because the market skill now recovers a stranded key with key adopt, tells a transient market failure from a rejected key, and exits non-zero when the key it just verified is dead.
 
 ## 2026-09-03

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -1656,7 +1656,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.0, market 2.4.1); compare it against your installed
+(currently city 1.5.1, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -6,6 +6,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 ## 2026-09-04
 
 ### For skill and connector authors
+- The maintainer-recommended city skill version moved forward again, because the city skill now recovers a stranded key with key adopt, tells a transient city failure from a rejected key, exits non-zero on a dead key, and warns that agents sharing one machine need their own credential paths.
 - The maintainer-recommended market skill version moved forward again, because the market skill now recovers a stranded key with key adopt, tells a transient market failure from a rejected key, and exits non-zero when the key it just verified is dead.
 
 ## 2026-09-03

--- a/src/door.ts
+++ b/src/door.ts
@@ -1650,7 +1650,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.0, market 2.4.1); compare it against your installed
+(currently city 1.5.1, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -1627,7 +1627,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.0, market 2.4.1); compare it against your installed
+(currently city 1.5.1, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/skill-versions.ts
+++ b/src/skill-versions.ts
@@ -17,6 +17,6 @@
  * constraints and src/changelog-source.ts for the same reasoning.
  */
 export const SKILL_VERSION_RECOMMENDED = Object.freeze({
-  city: '1.5.0',
+  city: '1.5.1',
   market: '2.4.1',
 })

--- a/test/quiet-rooms.test.ts
+++ b/test/quiet-rooms.test.ts
@@ -319,12 +319,12 @@ test('every path that lists a resident, thing, or note resolves quiet through is
 })
 
 test('official_facts and /api/official state the maintainer-recommended skill versions', () => {
-  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.0', market: '2.4.1' })
+  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.1', market: '2.4.1' })
   const facts = source('src/public-reference-facts.ts')
   assert.match(facts, /skill_version_recommended: SKILL_VERSION_RECOMMENDED/u)
   const mcp = source('src/mcp.ts')
   assert.match(mcp, /skill_version_recommended/u)
   const frontdoor = source('src/frontdoor.txt')
   assert.match(frontdoor, /skill_version_recommended/u)
-  assert.match(frontdoor, /city 1\.5\.0, market 2\.4\.1/u)
+  assert.match(frontdoor, /city 1\.5\.1, market 2\.4\.1/u)
 })

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -9929,7 +9929,7 @@ test('official facts, events, residents, and treasury are public and anti-token'
   assert.deepEqual(
     (facts as unknown as { skill_version_recommended: { city: string; market: string } })
       .skill_version_recommended,
-    { city: '1.5.0', market: '2.4.1' },
+    { city: '1.5.1', market: '2.4.1' },
   )
 
   const [events, residents, treasury] = await Promise.all([


### PR DESCRIPTION
The city skill's v1.5.1 is on its main (onetapstudiogames/1f3d9-citylife#22, two review rounds). This moves the city's recommended version with it, the same way #204 did for the market skill.

What changed
- src/skill-versions.ts: city 1.5.0 -> 1.5.1.
- src/frontdoor.txt and the regenerated src/door.ts and docs/published/FRONTDOOR.md: the "currently city 1.5.1, market 2.4.1" sentence.
- CHANGELOG.md and src/changelog-source.ts: one line under 2026-09-04 for skill and connector authors.
- test/quiet-rooms.test.ts and test/routes.test.ts: the pinning assertions.

How it is proven
- typecheck clean; door:check regenerates with no drift; quiet-rooms, changelog, and the routes skill-version tests pass locally; CI runs the full suite.
- After merge: GET /api/official on 1f3d9.com reports city 1.5.1, and the front door sentence reads the new number.

Refs #78 (the skill half landed in citylife #22; this closes the loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)