### PR TITLE
test: pin the Gazette page limit under the byte ceiling

### DIFF
--- a/src/public-pagination.ts
+++ b/src/public-pagination.ts
@@ -4,6 +4,7 @@ import { PUBLIC_EVENT_THING_DRAWING_JOIN_SQL } from './public-drawing-presence.t
 
 export const PUBLIC_EVENT_WITHIN_MAX_SECONDS = 1_800
 const PUBLIC_PLACE_RECORD_TEXT_MAX_BYTES = 65_536
+// Coupled to GAZETTE_ENTRY_PAGE_LIMIT; guarded in test/gazette-window-client-budget-shape.test.ts.
 export const PUBLIC_PLACE_COLLECTION_TEXT_MAX_BYTES =
   PUBLIC_PAGE_DEFAULT * PUBLIC_PLACE_RECORD_TEXT_MAX_BYTES
 const POSTGRES_INTEGER_MAX = 2_147_483_647

--- a/test/gazette-window-client-budget-shape.test.ts
+++ b/test/gazette-window-client-budget-shape.test.ts
@@ -19,8 +19,28 @@
 // design. This test reproduces the exact shape directly against the shipped
 // normalizer, independent of that arithmetic coincidence.
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import { WINDOW_JS } from '../src/window-client.ts'
+import { PUBLIC_PLACE_COLLECTION_TEXT_MAX_BYTES } from '../src/public-pagination.ts'
+
+test('GAZETTE_ENTRY_PAGE_LIMIT stays below PUBLIC_PLACE_COLLECTION_TEXT_MAX_BYTES at the largest note size', () => {
+  const pageLimitMatch = /const GAZETTE_ENTRY_PAGE_LIMIT = ([\d_]+)/u.exec(WINDOW_JS)
+  assert.ok(pageLimitMatch, 'GAZETTE_ENTRY_PAGE_LIMIT must be present in the shipped window client')
+
+  const societySource = readFileSync(new URL('../src/society.ts', import.meta.url), 'utf8')
+  const noteCharactersMatch = /const NOTE_CHARACTERS = ([\d_]+)/u.exec(societySource)
+  assert.ok(noteCharactersMatch, 'NOTE_CHARACTERS must be present in the note route source')
+
+  const gazetteEntryPageLimit = Number(pageLimitMatch[1]?.replaceAll('_', ''))
+  const noteCharacters = Number(noteCharactersMatch[1]?.replaceAll('_', ''))
+  const largestEntryBytes = noteCharacters * 4
+
+  assert.ok(
+    gazetteEntryPageLimit * largestEntryBytes < PUBLIC_PLACE_COLLECTION_TEXT_MAX_BYTES,
+    `GAZETTE_ENTRY_PAGE_LIMIT (${gazetteEntryPageLimit}) times the largest note (${largestEntryBytes} bytes) must stay below PUBLIC_PLACE_COLLECTION_TEXT_MAX_BYTES (${PUBLIC_PLACE_COLLECTION_TEXT_MAX_BYTES})`,
+  )
+})
 
 function extract(pattern: RegExp, label: string): string {
   const match = pattern.exec(WINDOW_JS)


### PR DESCRIPTION
Closes #202. One unit test pins the coupling that keeps the Gazette read's empty-budgeted-page shape unreachable: GAZETTE_ENTRY_PAGE_LIMIT x NOTE_CHARACTERS x 4 must stay under PUBLIC_PLACE_COLLECTION_TEXT_MAX_BYTES (today 400,000 < 655,360). If either constant moves out of step the test fails naming both. A pointer comment sits beside the server constant in src/public-pagination.ts. No behaviour change.

Proven: typecheck clean; the Gazette test file 10 pass; the lane's full run 1,952 tests with only the four known Windows identity-client failures (#183) plus its sandbox's git-ownership failure in the embed-door test, which does not occur outside the sandbox.

Built by a Codex lane on sol; committed by Claude. The lane's one-line comment inside the split window client was dropped so this PR stays off src/window-client while the live steps land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)