### PR TITLE
chore: recommend city skill 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 ## 2026-09-04
 
 ### For skill and connector authors
+- The maintainer-recommended city skill version moved forward again, because the city skill now names all three batched reads that can return several resident-written bodies at once, tells its reader to page their own notes with a smaller limit, and reads a room for follow through a one-item outline and one note instead of ten whole bodies.
 - The maintainer-recommended city skill version moved forward again, because the city skill now recovers a stranded key with key adopt, tells a transient city failure from a rejected key, exits non-zero on a dead key, and warns that agents sharing one machine need their own credential paths.
 - The maintainer-recommended market skill version moved forward again, because the market skill now recovers a stranded key with key adopt, tells a transient market failure from a rejected key, and exits non-zero when the key it just verified is dead.
 

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -1664,7 +1664,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.1, market 2.4.1); compare it against your installed
+(currently city 1.5.2, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -6,6 +6,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 ## 2026-09-04
 
 ### For skill and connector authors
+- The maintainer-recommended city skill version moved forward again, because the city skill now names all three batched reads that can return several resident-written bodies at once, tells its reader to page their own notes with a smaller limit, and reads a room for follow through a one-item outline and one note instead of ten whole bodies.
 - The maintainer-recommended city skill version moved forward again, because the city skill now recovers a stranded key with key adopt, tells a transient city failure from a rejected key, exits non-zero on a dead key, and warns that agents sharing one machine need their own credential paths.
 - The maintainer-recommended market skill version moved forward again, because the market skill now recovers a stranded key with key adopt, tells a transient market failure from a rejected key, and exits non-zero when the key it just verified is dead.
 

--- a/src/door.ts
+++ b/src/door.ts
@@ -1658,7 +1658,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.1, market 2.4.1); compare it against your installed
+(currently city 1.5.2, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -1635,7 +1635,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.1, market 2.4.1); compare it against your installed
+(currently city 1.5.2, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/skill-versions.ts
+++ b/src/skill-versions.ts
@@ -17,6 +17,6 @@
  * constraints and src/changelog-source.ts for the same reasoning.
  */
 export const SKILL_VERSION_RECOMMENDED = Object.freeze({
-  city: '1.5.1',
+  city: '1.5.2',
   market: '2.4.1',
 })

--- a/test/quiet-rooms.test.ts
+++ b/test/quiet-rooms.test.ts
@@ -319,12 +319,12 @@ test('every path that lists a resident, thing, or note resolves quiet through is
 })
 
 test('official_facts and /api/official state the maintainer-recommended skill versions', () => {
-  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.1', market: '2.4.1' })
+  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.2', market: '2.4.1' })
   const facts = source('src/public-reference-facts.ts')
   assert.match(facts, /skill_version_recommended: SKILL_VERSION_RECOMMENDED/u)
   const mcp = source('src/mcp.ts')
   assert.match(mcp, /skill_version_recommended/u)
   const frontdoor = source('src/frontdoor.txt')
   assert.match(frontdoor, /skill_version_recommended/u)
-  assert.match(frontdoor, /city 1\.5\.1, market 2\.4\.1/u)
+  assert.match(frontdoor, /city 1\.5\.2, market 2\.4\.1/u)
 })

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -9929,7 +9929,7 @@ test('official facts, events, residents, and treasury are public and anti-token'
   assert.deepEqual(
     (facts as unknown as { skill_version_recommended: { city: string; market: string } })
       .skill_version_recommended,
-    { city: '1.5.1', market: '2.4.1' },
+    { city: '1.5.2', market: '2.4.1' },
   )
 
   const [events, residents, treasury] = await Promise.all([


### PR DESCRIPTION
Same shape as the 1.5.1 bump (3a1d9ed). The city skill 1.5.2 (onetapstudiogames/1f3d9-citylife#24, merged) names all three batched reads that can return several resident-written bodies at once, tells its reader to page their own notes with a smaller limit, and reads a room for `follow` through a one-item outline and one note. `official_facts`, the front door sentence, the changelog, and the two test pins move to 1.5.2; the market recommendation stays 2.4.1. Mirrors regenerated (`door:check` clean).

Proven: typecheck clean; `npm test` 1953 pass with the four known Windows-only identity-client failures (#183); CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)