### PR TITLE
feat: one-command buyer client for the market's world aisle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,17 @@
         "@types/node": "^24",
         "@types/pg": "^8.21.0",
         "c8": "^12.0.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "viem": "2.55.11"
       },
       "engines": {
         "node": "24.x"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
@@ -94,6 +100,24 @@
         "node": ">=19.0.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
@@ -108,6 +132,30 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -137,6 +185,23 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -294,6 +359,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -418,6 +488,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -523,6 +601,29 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {
@@ -880,6 +981,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -908,6 +1010,29 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.55.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.33",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {
@@ -960,6 +1085,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "@types/node": "^24",
     "@types/pg": "^8.21.0",
     "c8": "^12.0.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "viem": "2.55.11"
   }
 }

--- a/scripts/world-buy.d.mts
+++ b/scripts/world-buy.d.mts
@@ -1,0 +1,26 @@
+import type { PaymentRequirements } from '../src/pay.ts'
+
+export declare function buildX402PaymentHeader(options: Readonly<{
+  accepted: PaymentRequirements
+  privateKey: `0x${string}`
+  wallet: `0x${string}`
+  nonce: `0x${string}`
+  nowSeconds: number
+}>): Promise<string>
+
+export declare function runWorldBuy(options: Readonly<{
+  listingId: number
+  offerId: number
+  wallet: string
+  cityKey: string
+  marketKey: string
+  privateKey: string
+  cityOrigin?: string
+  marketOrigin?: string
+  stateDirectory?: string
+  syncDelayMs?: number
+  stdout?: (message: string) => void
+  stderr?: (message: string) => void
+}>): Promise<number>
+
+export function freshWallet(makeKey?: () => `0x${string}`): { address: `0x${string}`; privateKey: `0x${string}` }

--- a/scripts/world-buy.d.mts
+++ b/scripts/world-buy.d.mts
@@ -19,6 +19,9 @@ export declare function runWorldBuy(options: Readonly<{
   marketOrigin?: string
   stateDirectory?: string
   syncDelayMs?: number
+  paidClaimTimeoutMs?: number
+  reconcileRetryDelayMs?: number
+  reconcileAttempts?: number
   stdout?: (message: string) => void
   stderr?: (message: string) => void
 }>): Promise<number>

--- a/scripts/world-buy.mjs
+++ b/scripts/world-buy.mjs
@@ -1,0 +1,549 @@
+#!/usr/bin/env node
+// Buy one city thing through 1F3EA's world aisle and safely resume a pending payment.
+//
+// Usage:
+//   BUYER_WALLET_PRIVATE_KEY=0x... AGENT_1F3D9_SECRET=... AGENT_1F3EA_SECRET=... \
+//     node scripts/world-buy.mjs --listing 23 --offer 2 --wallet 0x...
+//
+// Instead of the two agent-key environment variables, pass --city-key-file and/or
+// --market-key-file. The wallet private key is accepted only from
+// BUYER_WALLET_PRIVATE_KEY. A pending payment exits with code 2; run the same command
+// again so the client reconciles and syncs without signing or paying again.
+
+import { randomBytes } from 'node:crypto'
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+
+const CITY_ORIGIN = 'https://1f3d9.com'
+const MARKET_ORIGIN = 'https://1f3ea.com'
+const BASE_CHAIN_ID = 8453
+const DEFAULT_SYNC_DELAY_MS = 60_000
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/u
+const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/u
+const NONCE_RE = /^0x[0-9a-fA-F]{64}$/u
+const TX_HASH_RE = /^0x[0-9a-fA-F]{64}$/u
+const INTEGER_RE = /^(?:0|[1-9][0-9]*)$/u
+const TERMINAL_WORLD_STATES = new Set([
+  'sold',
+  'payment_invalid',
+  'payment_expired',
+  'founder_review',
+  'needs_review',
+  'canceled',
+  'withdrawn',
+])
+const PENDING_WORLD_STATES = new Set([
+  'claimed',
+  'finality_pending',
+  'payment_pending',
+  'sync_pending',
+])
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+}
+
+class WorldBuyError extends Error {
+  constructor(step, message) {
+    super(message)
+    this.step = step
+  }
+}
+
+function record(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value) ? value : null
+}
+
+function positiveInteger(value, name) {
+  if (typeof value !== 'string' || !/^[1-9][0-9]*$/u.test(value)) {
+    throw new WorldBuyError(0, `--${name} must be a positive integer.`)
+  }
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) throw new WorldBuyError(0, `--${name} is too large.`)
+  return parsed
+}
+
+function parseArguments(argv) {
+  const values = {}
+  const allowed = new Set(['listing', 'offer', 'wallet', 'city-key-file', 'market-key-file'])
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    if (!token.startsWith('--')) throw new WorldBuyError(0, `Unexpected argument ${token}.`)
+    const name = token.slice(2)
+    if (!allowed.has(name)) throw new WorldBuyError(0, `Unknown option --${name}.`)
+    const value = argv[index + 1]
+    if (value == null || value.startsWith('--')) {
+      throw new WorldBuyError(0, `--${name} needs a value.`)
+    }
+    if (name in values) throw new WorldBuyError(0, `--${name} may be given only once.`)
+    values[name] = value
+    index += 1
+  }
+  for (const name of ['listing', 'offer', 'wallet']) {
+    if (!(name in values)) throw new WorldBuyError(0, `--${name} is required.`)
+  }
+  return values
+}
+
+async function secretFromFileOrEnvironment(flags, fileFlag, environmentName) {
+  if (flags[fileFlag]) {
+    try {
+      const value = (await readFile(flags[fileFlag], 'utf8')).trim()
+      if (!value) throw new Error('empty')
+      return value
+    } catch {
+      throw new WorldBuyError(0, `Could not read a value from --${fileFlag}. Check that file and try again.`)
+    }
+  }
+  const value = process.env[environmentName]
+  if (!value) {
+    throw new WorldBuyError(
+      0,
+      `Set ${environmentName} or pass --${fileFlag} before running this command.`,
+    )
+  }
+  return value
+}
+
+function redact(message, secrets) {
+  return secrets.reduce(
+    (safe, secret) => secret ? safe.split(secret).join('[redacted]') : safe,
+    String(message),
+  )
+}
+
+function serverMessage(body, fallback) {
+  const value = record(body)
+  for (const field of ['error', 'message', 'retry']) {
+    if (typeof value?.[field] === 'string' && value[field].trim()) return value[field].trim()
+  }
+  return fallback
+}
+
+async function requestJson({
+  step,
+  url,
+  method = 'GET',
+  key,
+  body,
+  headers = {},
+  secrets,
+  acceptPaymentRequired = false,
+}) {
+  let response
+  try {
+    response = await fetch(url, {
+      method,
+      redirect: 'error',
+      headers: {
+        accept: 'application/json',
+        ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+        ...(key ? { authorization: `Bearer ${key}` } : {}),
+        ...headers,
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: AbortSignal.timeout(15_000),
+    })
+  } catch {
+    throw new WorldBuyError(step, `Could not reach ${new URL(url).origin}. Check the connection and retry this same command.`)
+  }
+
+  let text
+  try {
+    text = await response.text()
+  } catch {
+    throw new WorldBuyError(step, `${new URL(url).origin} returned an unreadable response. Retry this same command.`)
+  }
+  let parsed = {}
+  if (text) {
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      throw new WorldBuyError(step, `${new URL(url).origin} returned unreadable JSON. Retry this same command.`)
+    }
+  }
+  if (!record(parsed)) {
+    throw new WorldBuyError(step, `${new URL(url).origin} returned an invalid response. Retry this same command.`)
+  }
+  if (!response.ok && !(acceptPaymentRequired && response.status === 402)) {
+    const message = serverMessage(parsed, `${new URL(url).origin} returned HTTP ${response.status}.`)
+    throw new WorldBuyError(step, redact(message, secrets))
+  }
+  return { status: response.status, body: parsed, retryAfter: response.headers.get('retry-after') }
+}
+
+function validateRequirement(accepted, expectedResource) {
+  const requirement = record(accepted)
+  const extra = record(requirement?.extra)
+  if (
+    requirement?.scheme !== 'exact' || requirement.network !== 'base' ||
+    requirement.resource !== expectedResource || !ADDRESS_RE.test(requirement.payTo) ||
+    !ADDRESS_RE.test(requirement.asset) ||
+    typeof requirement.maxAmountRequired !== 'string' ||
+    !INTEGER_RE.test(requirement.maxAmountRequired) || BigInt(requirement.maxAmountRequired) <= 0n ||
+    !Number.isSafeInteger(requirement.maxTimeoutSeconds) || requirement.maxTimeoutSeconds <= 0 ||
+    typeof extra?.name !== 'string' || !extra.name ||
+    typeof extra.version !== 'string' || !extra.version
+  ) {
+    throw new WorldBuyError(3, 'The city returned payment terms this client cannot safely sign. Re-read the offer and retry without paying.')
+  }
+  return requirement
+}
+
+export async function buildX402PaymentHeader({ accepted, privateKey, wallet, nonce, nowSeconds }) {
+  if (!PRIVATE_KEY_RE.test(privateKey)) throw new Error('BUYER_WALLET_PRIVATE_KEY must be a 32-byte 0x private key')
+  if (!ADDRESS_RE.test(wallet)) throw new Error('wallet must be a Base address')
+  if (!NONCE_RE.test(nonce)) throw new Error('nonce must be 32 bytes')
+  const account = privateKeyToAccount(privateKey)
+  if (account.address.toLowerCase() !== wallet.toLowerCase()) {
+    throw new Error('BUYER_WALLET_PRIVATE_KEY does not belong to --wallet')
+  }
+  const validAfter = BigInt(nowSeconds - 60)
+  const validBefore = BigInt(nowSeconds + accepted.maxTimeoutSeconds)
+  const authorization = {
+    from: account.address,
+    to: accepted.payTo,
+    value: BigInt(accepted.maxAmountRequired),
+    validAfter,
+    validBefore,
+    nonce,
+  }
+  const signature = await account.signTypedData({
+    domain: {
+      name: accepted.extra.name,
+      version: accepted.extra.version,
+      chainId: BASE_CHAIN_ID,
+      verifyingContract: accepted.asset,
+    },
+    types: TRANSFER_WITH_AUTHORIZATION_TYPES,
+    primaryType: 'TransferWithAuthorization',
+    message: authorization,
+  })
+  return Buffer.from(JSON.stringify({
+    x402Version: 1,
+    scheme: accepted.scheme,
+    network: accepted.network,
+    payload: {
+      signature,
+      authorization: {
+        ...authorization,
+        value: authorization.value.toString(),
+        validAfter: authorization.validAfter.toString(),
+        validBefore: authorization.validBefore.toString(),
+      },
+    },
+  }), 'utf8').toString('base64')
+}
+
+function stateFilePath(stateDirectory, listingId, offerId) {
+  return join(stateDirectory, `1f3d9-world-buy-${listingId}-${offerId}.json`)
+}
+
+async function readState(path, listingId, offerId) {
+  let parsed
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8'))
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null
+    throw new WorldBuyError(0, `The saved purchase state at ${path} is unreadable. Inspect it before deciding whether to retry.`)
+  }
+  const state = record(parsed)
+  if (
+    state?.version !== 1 || state.listing_id !== listingId || state.offer_id !== offerId ||
+    !Number.isSafeInteger(state.checkout_id) || state.checkout_id <= 0 ||
+    (state.nonce != null && (typeof state.nonce !== 'string' || !NONCE_RE.test(state.nonce))) ||
+    (state.tx_hash != null && (typeof state.tx_hash !== 'string' || !TX_HASH_RE.test(state.tx_hash))) ||
+    (state.payment_pending != null && state.payment_pending !== true)
+  ) {
+    throw new WorldBuyError(0, `The saved purchase state at ${path} is invalid. Inspect it before deciding whether to retry.`)
+  }
+  return state
+}
+
+async function writeState(path, state, step) {
+  try {
+    await mkdir(dirname(path), { recursive: true })
+    const temporary = `${path}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`
+    await writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    await rename(temporary, path)
+  } catch {
+    throw new WorldBuyError(step, `Could not safely save purchase state at ${path}. Check the temp directory and retry this same command.`)
+  }
+}
+
+function checkoutIdFrom(body) {
+  const direct = Number(record(body)?.id)
+  const nested = Number(record(record(body)?.checkout)?.id)
+  return Number.isSafeInteger(nested) && nested > 0
+    ? nested
+    : Number.isSafeInteger(direct) && direct > 0 ? direct : null
+}
+
+function offerFrom(body) {
+  return record(record(body)?.offer) ?? (record(body)?.phase ? record(body) : null)
+}
+
+function transactionFrom(body) {
+  for (const value of [
+    record(body)?.transaction,
+    record(body)?.tx_hash,
+    offerFrom(body)?.pending_x402_tx_hash,
+    offerFrom(body)?.tx_hash,
+  ]) {
+    if (typeof value === 'string' && TX_HASH_RE.test(value)) return value.toLowerCase()
+  }
+  return null
+}
+
+function worldStateFrom(body) {
+  const listing = record(record(body)?.listing)
+  const purchase = record(record(body)?.purchase)
+  for (const value of [listing?.world_state, record(body)?.world_state, purchase?.world_state]) {
+    if (typeof value === 'string' && value) return value
+  }
+  return null
+}
+
+function retryDelay(response, configuredDelay) {
+  if (configuredDelay !== DEFAULT_SYNC_DELAY_MS) return configuredDelay
+  const seconds = Number(response.retryAfter)
+  return Number.isInteger(seconds) && seconds >= 1 && seconds <= 86_400
+    ? seconds * 1_000
+    : configuredDelay
+}
+
+export async function runWorldBuy(options) {
+  const {
+    listingId,
+    offerId,
+    wallet,
+    cityKey,
+    marketKey,
+    privateKey,
+    cityOrigin = CITY_ORIGIN,
+    marketOrigin = MARKET_ORIGIN,
+    stateDirectory = tmpdir(),
+    syncDelayMs = DEFAULT_SYNC_DELAY_MS,
+    stdout = message => process.stdout.write(message),
+    stderr = message => process.stderr.write(message),
+  } = options
+  const secrets = [cityKey, marketKey, privateKey, wallet]
+  const statePath = stateFilePath(stateDirectory, listingId, offerId)
+
+  try {
+    if (!ADDRESS_RE.test(wallet)) throw new WorldBuyError(0, '--wallet must be a Base address.')
+    if (!PRIVATE_KEY_RE.test(privateKey)) {
+      throw new WorldBuyError(0, 'BUYER_WALLET_PRIVATE_KEY must be a 32-byte 0x private key.')
+    }
+    const account = privateKeyToAccount(privateKey)
+    if (account.address.toLowerCase() !== wallet.toLowerCase()) {
+      throw new WorldBuyError(0, 'BUYER_WALLET_PRIVATE_KEY does not belong to --wallet.')
+    }
+
+    let state = await readState(statePath, listingId, offerId)
+    if (!state) {
+      const me = await requestJson({
+        step: 1,
+        url: `${cityOrigin}/api/me`,
+        key: cityKey,
+        secrets,
+      })
+      const cityHandle = record(me.body)?.handle
+      if (typeof cityHandle !== 'string' || !cityHandle) {
+        throw new WorldBuyError(1, 'The city did not return this resident\'s handle. Check the city key and retry.')
+      }
+      const checkout = await requestJson({
+        step: 2,
+        url: `${marketOrigin}/api/world/checkout/${listingId}`,
+        method: 'POST',
+        key: marketKey,
+        body: { city_handle: cityHandle },
+        secrets,
+      })
+      const checkoutId = checkoutIdFrom(checkout.body)
+      if (!checkoutId) throw new WorldBuyError(2, 'The market did not return a checkout id. Retry after checking the listing.')
+      state = { version: 1, listing_id: listingId, offer_id: offerId, checkout_id: checkoutId }
+      await writeState(statePath, state, 2)
+    }
+
+    let cityResult
+    if (state.nonce || state.payment_pending) {
+      cityResult = await requestJson({
+        step: 4,
+        url: `${cityOrigin}/api/world/offer/${offerId}/reconcile`,
+        method: 'POST',
+        key: cityKey,
+        body: {},
+        secrets,
+      })
+    } else {
+      const claimBody = { market_checkout_id: state.checkout_id, buyer_wallet: wallet }
+      const claimUrl = `${cityOrigin}/api/world/offer/${offerId}/claim`
+      const challenge = await requestJson({
+        step: 3,
+        url: claimUrl,
+        method: 'POST',
+        key: cityKey,
+        body: claimBody,
+        secrets,
+        acceptPaymentRequired: true,
+      })
+      if (challenge.status !== 402) {
+        cityResult = challenge
+      } else {
+        const accepted = record(challenge.body)?.accepts
+        if (!Array.isArray(accepted)) {
+          throw new WorldBuyError(3, 'The city did not return payment terms. Retry without paying.')
+        }
+        const requirement = validateRequirement(
+          accepted.find(value => record(value)?.scheme === 'exact' && record(value)?.network === 'base'),
+          claimUrl,
+        )
+        const nonce = `0x${randomBytes(32).toString('hex')}`
+        state = { ...state, nonce }
+        await writeState(statePath, state, 3)
+        let paymentHeader
+        try {
+          paymentHeader = await buildX402PaymentHeader({
+            accepted: requirement,
+            privateKey,
+            wallet,
+            nonce,
+            nowSeconds: Math.floor(Date.now() / 1_000),
+          })
+        } catch {
+          throw new WorldBuyError(3, 'Could not sign the payment authorization. Check the wallet private key and retry this same command.')
+        }
+        cityResult = await requestJson({
+          step: 4,
+          url: claimUrl,
+          method: 'POST',
+          key: cityKey,
+          body: claimBody,
+          headers: { 'x-payment': paymentHeader },
+          secrets: [...secrets, paymentHeader],
+        })
+      }
+    }
+
+    let cityOffer = offerFrom(cityResult.body)
+    if (cityOffer?.phase === 'payment_pending' || cityResult.status === 202) {
+      const txHash = transactionFrom(cityResult.body)
+      state = { ...state, payment_pending: true, ...(txHash ? { tx_hash: txHash } : {}) }
+      await writeState(statePath, state, 4)
+      const message = serverMessage(cityResult.body, 'The city says the payment is pending.')
+      stderr(`Step 4: ${redact(message, secrets)} Run this same command again to reconcile; do not pay again.\n`)
+      return 2
+    }
+    if (!cityOffer || !Number.isSafeInteger(cityOffer.asset_id)) {
+      const offerRead = await requestJson({
+        step: 4,
+        url: `${cityOrigin}/api/world/offer/${offerId}`,
+        secrets,
+      })
+      cityOffer = offerFrom(offerRead.body)
+    }
+    if (!cityOffer || !Number.isSafeInteger(cityOffer.asset_id) || cityOffer.asset_id <= 0) {
+      throw new WorldBuyError(4, 'The city did not return the thing id. Re-read the offer before retrying.')
+    }
+
+    let syncResult
+    let syncedState
+    while (true) {
+      syncResult = await requestJson({
+        step: 5,
+        url: `${marketOrigin}/api/world/sync/${listingId}`,
+        method: 'POST',
+        key: marketKey,
+        body: {},
+        secrets,
+      })
+      syncedState = worldStateFrom(syncResult.body)
+      if (syncedState && TERMINAL_WORLD_STATES.has(syncedState)) break
+      if (syncResult.status !== 202 && (!syncedState || !PENDING_WORLD_STATES.has(syncedState))) {
+        throw new WorldBuyError(5, 'The market returned an unknown sync state. Re-read the listing and do not pay again.')
+      }
+      await new Promise(resolveSleep => setTimeout(resolveSleep, retryDelay(syncResult, syncDelayMs)))
+    }
+
+    const [thingProof, listingProof] = await Promise.all([
+      requestJson({ step: 6, url: `${cityOrigin}/api/thing/${cityOffer.asset_id}`, secrets }),
+      requestJson({ step: 6, url: `${marketOrigin}/api/listing/${listingId}`, secrets }),
+    ])
+    const thing = record(record(thingProof.body)?.thing) ?? record(thingProof.body)
+    const listing = record(record(listingProof.body)?.listing) ?? record(listingProof.body)
+    if (typeof thing?.current_owner !== 'string') {
+      throw new WorldBuyError(6, 'The city public proof did not include current_owner. Re-read the thing.')
+    }
+    if (typeof listing?.world_state !== 'string') {
+      throw new WorldBuyError(6, 'The market public proof did not include world_state. Re-read the listing.')
+    }
+    stdout(`Thing ${cityOffer.asset_id} is currently owned by ${thing.current_owner}.\n`)
+    stdout(`Listing ${listingId} world state is ${listing.world_state}.\n`)
+    if (listing.world_state !== 'sold') {
+      stderr(`Step 5: The market reached terminal state ${listing.world_state}; do not pay again.\n`)
+      return 2
+    }
+    return 0
+  } catch (error) {
+    const step = error instanceof WorldBuyError ? error.step : 0
+    const message = error instanceof Error ? error.message : 'The purchase could not continue.'
+    stderr(`Step ${step}: ${redact(message, secrets)}\n`)
+    return 1
+  }
+}
+
+// A throwaway buyer wallet for a human who has no exportable key: prints the
+// address and the private key exactly once, to the terminal that ran it, and
+// writes nothing. Fund the address with the listing price in USDC on Base,
+// then run the purchase with the key in BUYER_WALLET_PRIVATE_KEY.
+export function freshWallet(makeKey = generatePrivateKey) {
+  const privateKey = makeKey()
+  return { address: privateKeyToAccount(privateKey).address, privateKey }
+}
+
+async function main() {
+  if (process.argv[2] === 'new-wallet') {
+    const wallet = freshWallet()
+    process.stdout.write(`address: ${wallet.address}
+private key (shown once, never written anywhere by this command): ${wallet.privateKey}
+Send the listing price in USDC on Base to the address, then run the purchase with
+BUYER_WALLET_PRIVATE_KEY set to the private key and --wallet set to the address.
+`)
+    return 0
+  }
+  let flags
+  try {
+    flags = parseArguments(process.argv.slice(2))
+    const cityKey = await secretFromFileOrEnvironment(flags, 'city-key-file', 'AGENT_1F3D9_SECRET')
+    const marketKey = await secretFromFileOrEnvironment(flags, 'market-key-file', 'AGENT_1F3EA_SECRET')
+    const privateKey = process.env.BUYER_WALLET_PRIVATE_KEY
+    if (!privateKey) throw new WorldBuyError(0, 'Set BUYER_WALLET_PRIVATE_KEY before running this command.')
+    return runWorldBuy({
+      listingId: positiveInteger(flags.listing, 'listing'),
+      offerId: positiveInteger(flags.offer, 'offer'),
+      wallet: flags.wallet,
+      cityKey,
+      marketKey,
+      privateKey,
+    })
+  } catch (error) {
+    const step = error instanceof WorldBuyError ? error.step : 0
+    const message = error instanceof Error ? error.message : 'The command could not start.'
+    process.stderr.write(`Step ${step}: ${message}\n`)
+    return 1
+  }
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  process.exitCode = await main()
+}

--- a/scripts/world-buy.mjs
+++ b/scripts/world-buy.mjs
@@ -412,6 +412,11 @@ export async function runWorldBuy(options) {
           const message = error instanceof Error ? error.message : ''
           const notYet = message.includes('no durable payment') || (error instanceof WorldBuyError && error.transient)
           if (!notYet || attempt >= reconcileAttempts) {
+            if (notYet && error instanceof WorldBuyError && error.transient) {
+              throw new WorldBuyError(4,
+                'The city could not be reached to reconcile this claim after several tries. ' +
+                'Check the connection, then run this same command again; it will not pay again.')
+            }
             if (notYet) {
               throw new WorldBuyError(4,
                 'The city has not recorded a payment for this claim yet; that is normal for up to a minute after a slow payment. ' +

--- a/scripts/world-buy.mjs
+++ b/scripts/world-buy.mjs
@@ -21,6 +21,14 @@ const CITY_ORIGIN = 'https://1f3d9.com'
 const MARKET_ORIGIN = 'https://1f3ea.com'
 const BASE_CHAIN_ID = 8453
 const DEFAULT_SYNC_DELAY_MS = 60_000
+// The paid claim makes the city verify and settle through the facilitator, each
+// call budgeted at several seconds server-side, so the client waits longer than
+// an ordinary read. A claim that times out is never re-signed: the persisted
+// nonce sends the run to reconcile, which may need a few tries while the city
+// finishes the payment it already received.
+const PAID_CLAIM_TIMEOUT_MS = 45_000
+const RECONCILE_RETRY_DELAY_MS = 10_000
+const RECONCILE_ATTEMPTS = 4
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/u
 const PRIVATE_KEY_RE = /^0x[0-9a-fA-F]{64}$/u
 const NONCE_RE = /^0x[0-9a-fA-F]{64}$/u
@@ -138,6 +146,7 @@ async function requestJson({
   headers = {},
   secrets,
   acceptPaymentRequired = false,
+  timeoutMs = 15_000,
 }) {
   let response
   try {
@@ -151,10 +160,12 @@ async function requestJson({
         ...headers,
       },
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-      signal: AbortSignal.timeout(15_000),
+      signal: AbortSignal.timeout(timeoutMs),
     })
   } catch {
-    throw new WorldBuyError(step, `Could not reach ${new URL(url).origin}. Check the connection and retry this same command.`)
+    const unreachable = new WorldBuyError(step, `Could not reach ${new URL(url).origin}. Check the connection and retry this same command.`)
+    unreachable.transient = true
+    throw unreachable
   }
 
   let text
@@ -333,6 +344,9 @@ export async function runWorldBuy(options) {
     marketOrigin = MARKET_ORIGIN,
     stateDirectory = tmpdir(),
     syncDelayMs = DEFAULT_SYNC_DELAY_MS,
+    paidClaimTimeoutMs = PAID_CLAIM_TIMEOUT_MS,
+    reconcileRetryDelayMs = RECONCILE_RETRY_DELAY_MS,
+    reconcileAttempts = RECONCILE_ATTEMPTS,
     stdout = message => process.stdout.write(message),
     stderr = message => process.stderr.write(message),
   } = options
@@ -372,19 +386,49 @@ export async function runWorldBuy(options) {
       const checkoutId = checkoutIdFrom(checkout.body)
       if (!checkoutId) throw new WorldBuyError(2, 'The market did not return a checkout id. Retry after checking the listing.')
       state = { version: 1, listing_id: listingId, offer_id: offerId, checkout_id: checkoutId }
-      await writeState(statePath, state, 2)
+      try {
+        await writeState(statePath, state, 2)
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : 'unknown reason'
+        throw new WorldBuyError(2,
+          `The market created checkout ${checkoutId} but it could not be saved locally (${reason}). ` +
+          'The market allows one active checkout per buyer and listing; wait ten minutes for it to expire, then run this same command again.')
+      }
+    }
+
+    const reconcileWithPatience = async () => {
+      for (let attempt = 1; ; attempt += 1) {
+        try {
+          return await requestJson({
+            step: 4,
+            url: `${cityOrigin}/api/world/offer/${offerId}/reconcile`,
+            method: 'POST',
+            key: cityKey,
+            body: {},
+            secrets,
+            timeoutMs: paidClaimTimeoutMs,
+          })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : ''
+          const notYet = message.includes('no durable payment') || (error instanceof WorldBuyError && error.transient)
+          if (!notYet || attempt >= reconcileAttempts) {
+            if (notYet) {
+              throw new WorldBuyError(4,
+                'The city has not recorded a payment for this claim yet; that is normal for up to a minute after a slow payment. ' +
+                'Wait 30 seconds and run this same command again; it will not pay again.')
+            }
+            throw error
+          }
+          stderr(`Step 4: the city has not recorded the payment yet; asking again in ${Math.round(reconcileRetryDelayMs / 1000)} seconds without paying again.
+`)
+          await new Promise(resolveWait => setTimeout(resolveWait, reconcileRetryDelayMs))
+        }
+      }
     }
 
     let cityResult
     if (state.nonce || state.payment_pending) {
-      cityResult = await requestJson({
-        step: 4,
-        url: `${cityOrigin}/api/world/offer/${offerId}/reconcile`,
-        method: 'POST',
-        key: cityKey,
-        body: {},
-        secrets,
-      })
+      cityResult = await reconcileWithPatience()
     } else {
       const claimBody = { market_checkout_id: state.checkout_id, buyer_wallet: wallet }
       const claimUrl = `${cityOrigin}/api/world/offer/${offerId}/claim`
@@ -423,15 +467,23 @@ export async function runWorldBuy(options) {
         } catch {
           throw new WorldBuyError(3, 'Could not sign the payment authorization. Check the wallet private key and retry this same command.')
         }
-        cityResult = await requestJson({
-          step: 4,
-          url: claimUrl,
-          method: 'POST',
-          key: cityKey,
-          body: claimBody,
-          headers: { 'x-payment': paymentHeader },
-          secrets: [...secrets, paymentHeader],
-        })
+        try {
+          cityResult = await requestJson({
+            step: 4,
+            url: claimUrl,
+            method: 'POST',
+            key: cityKey,
+            body: claimBody,
+            headers: { 'x-payment': paymentHeader },
+            secrets: [...secrets, paymentHeader],
+            timeoutMs: paidClaimTimeoutMs,
+          })
+        } catch (error) {
+          if (!(error instanceof WorldBuyError && error.transient)) throw error
+          stderr(`Step 4: the paid claim did not answer in time; asking the city to reconcile instead, without paying again.
+`)
+          cityResult = await reconcileWithPatience()
+        }
       }
     }
 

--- a/test/world-buy-client.test.ts
+++ b/test/world-buy-client.test.ts
@@ -272,3 +272,104 @@ test('new-wallet makes a key whose address matches it and never reuses a key', (
   const fixed = freshWallet(() => TEST_PRIVATE_KEY)
   assert.equal(fixed.address, TEST_ACCOUNT.address)
 })
+
+test('world-buy recovers from a paid claim that answers too slowly by reconciling, without another signature', async () => {
+  const stateDirectory = await mkdtemp(join(tmpdir(), '1f3d9-world-buy-slow-'))
+  const signedHeaders: string[] = []
+  let reconcileCalls = 0
+  let cityOrigin = ''
+
+  const city = await listen((request, response) => {
+    if (request.method === 'GET' && request.url === '/api/me') {
+      sendJson(response, 200, { handle: 'test-buyer' })
+      return
+    }
+    if (request.method === 'POST' && request.url === '/api/world/offer/31/claim') {
+      const paymentHeader = request.headers['x-payment']
+      if (typeof paymentHeader !== 'string') {
+        sendJson(response, 402, {
+          error: 'payment required',
+          accepts: [requirements(
+            '0x1111111111111111111111111111111111111111',
+            1,
+            `${cityOrigin}/api/world/offer/31/claim`,
+            'test world offer',
+          )],
+        })
+        return
+      }
+      signedHeaders.push(paymentHeader)
+      // Answer only after the client has given up waiting.
+      setTimeout(() => {
+        try { sendJson(response, 200, { offer: { phase: 'claimed', asset_id: 2723 } }) } catch {}
+      }, 600)
+      return
+    }
+    if (request.method === 'POST' && request.url === '/api/world/offer/31/reconcile') {
+      reconcileCalls += 1
+      if (reconcileCalls === 1) {
+        sendJson(response, 409, { error: 'this world offer has no durable payment to reconcile' })
+      } else {
+        sendJson(response, 200, { offer: { phase: 'claimed', asset_id: 2723 } })
+      }
+      return
+    }
+    if (request.method === 'GET' && request.url === '/api/thing/2723') {
+      sendJson(response, 200, { thing: { id: 2723, current_owner: 'test-buyer' } })
+      return
+    }
+    sendJson(response, 404, { error: `unexpected city route ${request.method} ${request.url}` })
+  })
+  cityOrigin = city.origin
+
+  const market = await listen((request, response) => {
+    if (request.method === 'POST' && request.url === '/api/world/checkout/23') {
+      sendJson(response, 201, { checkout: { id: 78 } })
+      return
+    }
+    if (request.method === 'POST' && request.url === '/api/world/sync/23') {
+      sendJson(response, 200, { listing: { id: 23, world_state: 'sold' } })
+      return
+    }
+    if (request.method === 'GET' && request.url === '/api/listing/23') {
+      sendJson(response, 200, { listing: { id: 23, world_state: 'sold' } })
+      return
+    }
+    sendJson(response, 404, { error: `unexpected market route ${request.method} ${request.url}` })
+  })
+
+  let stdout = ''
+  let stderr = ''
+  try {
+    const status = await runWorldBuy({
+      listingId: 23,
+      offerId: 31,
+      wallet: TEST_ACCOUNT.address,
+      cityKey: TEST_CITY_KEY,
+      marketKey: TEST_MARKET_KEY,
+      privateKey: TEST_PRIVATE_KEY,
+      cityOrigin: city.origin,
+      marketOrigin: market.origin,
+      stateDirectory,
+      syncDelayMs: 10,
+      paidClaimTimeoutMs: 200,
+      reconcileRetryDelayMs: 20,
+      reconcileAttempts: 3,
+      stdout: message => { stdout += message },
+      stderr: message => { stderr += message },
+    })
+    assert.equal(status, 0)
+    assert.equal(signedHeaders.length, 1)
+    assert.equal(reconcileCalls, 2)
+    assert.ok(stderr.includes('did not answer in time'))
+    assert.ok(stderr.includes('has not recorded the payment yet'))
+    assert.ok(stdout.includes('Thing 2723 is currently owned by test-buyer.'))
+    assert.ok(stdout.includes('Listing 23 world state is sold.'))
+    for (const secret of [TEST_CITY_KEY, TEST_MARKET_KEY, TEST_PRIVATE_KEY, signedHeaders[0]!]) {
+      assert.equal(`${stdout}${stderr}`.includes(secret), false)
+    }
+  } finally {
+    await Promise.all([close(city.server), close(market.server)])
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})

--- a/test/world-buy-client.test.ts
+++ b/test/world-buy-client.test.ts
@@ -1,0 +1,274 @@
+import assert from 'node:assert/strict'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { recoverTypedDataAddress } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { parseX402Payment, requirements } from '../src/pay.ts'
+
+// Public test fixture only. It must never hold funds.
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+const TEST_CITY_KEY = 'city-secret-for-world-buy-test'
+const TEST_MARKET_KEY = 'market-secret-for-world-buy-test'
+const TEST_NONCE = `0x${'12'.repeat(32)}` as `0x${string}`
+const TEST_TX_HASH = `0x${'34'.repeat(32)}`
+const TEST_ACCOUNT = privateKeyToAccount(TEST_PRIVATE_KEY)
+
+// The declaration is added with the reference client.
+const { buildX402PaymentHeader, freshWallet, runWorldBuy } = await import('../scripts/world-buy.mjs')
+
+test('world-buy builds the exact signed X-PAYMENT shape accepted by the city', async () => {
+  const accepted = requirements(
+    '0x1111111111111111111111111111111111111111',
+    1,
+    'https://city.test/api/world/offer/31/claim',
+    'test world offer',
+  )
+  const header = await buildX402PaymentHeader({
+    accepted,
+    privateKey: TEST_PRIVATE_KEY,
+    wallet: TEST_ACCOUNT.address,
+    nonce: TEST_NONCE,
+    nowSeconds: 1_786_900_000,
+  })
+
+  const parsed = parseX402Payment(header, accepted)
+  assert.equal('error' in parsed, false)
+  if ('error' in parsed) return
+  assert.equal(parsed.authorization.payer, TEST_ACCOUNT.address.toLowerCase())
+
+  const payment = JSON.parse(Buffer.from(header, 'base64').toString('utf8')) as {
+    payload: {
+      signature: `0x${string}`
+      authorization: {
+        from: `0x${string}`
+        to: `0x${string}`
+        value: string
+        validAfter: string
+        validBefore: string
+        nonce: `0x${string}`
+      }
+    }
+  }
+  const recovered = await recoverTypedDataAddress({
+    domain: {
+      name: accepted.extra.name,
+      version: accepted.extra.version,
+      chainId: 8453,
+      verifyingContract: accepted.asset as `0x${string}`,
+    },
+    types: {
+      TransferWithAuthorization: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'validAfter', type: 'uint256' },
+        { name: 'validBefore', type: 'uint256' },
+        { name: 'nonce', type: 'bytes32' },
+      ],
+    },
+    primaryType: 'TransferWithAuthorization',
+    message: {
+      from: payment.payload.authorization.from,
+      to: payment.payload.authorization.to,
+      value: BigInt(payment.payload.authorization.value),
+      validAfter: BigInt(payment.payload.authorization.validAfter),
+      validBefore: BigInt(payment.payload.authorization.validBefore),
+      nonce: payment.payload.authorization.nonce,
+    },
+    signature: payment.payload.signature,
+  })
+  assert.equal(recovered.toLowerCase(), TEST_ACCOUNT.address.toLowerCase())
+})
+
+type JsonHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+  body: Record<string, unknown>,
+) => void | Promise<void>
+
+async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) chunks.push(Buffer.from(chunk))
+  if (chunks.length === 0) return {}
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
+}
+
+function sendJson(response: ServerResponse, status: number, body: Record<string, unknown>): void {
+  response.writeHead(status, { 'content-type': 'application/json' })
+  response.end(JSON.stringify(body))
+}
+
+async function listen(handler: JsonHandler): Promise<{ origin: string; server: Server }> {
+  const server = createServer(async (request, response) => {
+    try {
+      await handler(request, response, await readJsonBody(request))
+    } catch (error) {
+      response.destroy(error instanceof Error ? error : new Error('stub server failed'))
+    }
+  })
+  await new Promise<void>((resolveListen, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolveListen)
+  })
+  const address = server.address()
+  assert.ok(address && typeof address === 'object')
+  return { origin: `http://127.0.0.1:${address.port}`, server }
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose, reject) => {
+    server.close(error => error ? reject(error) : resolveClose())
+  })
+}
+
+async function runClient(origins: { city: string; market: string }, stateDirectory: string) {
+  let stdout = ''
+  let stderr = ''
+  const status = await runWorldBuy({
+    listingId: 23,
+    offerId: 31,
+    wallet: TEST_ACCOUNT.address,
+    cityKey: TEST_CITY_KEY,
+    marketKey: TEST_MARKET_KEY,
+    privateKey: TEST_PRIVATE_KEY,
+    cityOrigin: origins.city,
+    marketOrigin: origins.market,
+    stateDirectory,
+    syncDelayMs: 5,
+    stdout: (message: string) => { stdout += message },
+    stderr: (message: string) => { stderr += message },
+  })
+  return { status, stdout, stderr }
+}
+
+test('world-buy resumes payment_pending without another signature and stops sync on terminal state', async () => {
+  const stateDirectory = await mkdtemp(join(tmpdir(), '1f3d9-world-buy-test-'))
+  const signedHeaders: string[] = []
+  const claimBodies: Record<string, unknown>[] = []
+  let cityOrigin = ''
+  let syncCalls = 0
+
+  const city = await listen((request, response, body) => {
+    if (request.url !== '/api/thing/2723') {
+      assert.equal(request.headers.authorization, `Bearer ${TEST_CITY_KEY}`)
+    }
+    if (request.method === 'GET' && request.url === '/api/me') {
+      sendJson(response, 200, { handle: 'test-buyer' })
+      return
+    }
+    if (request.method === 'POST' && request.url === '/api/world/offer/31/claim') {
+      claimBodies.push(body)
+      const paymentHeader = request.headers['x-payment']
+      if (typeof paymentHeader !== 'string') {
+        sendJson(response, 402, {
+          error: 'payment required',
+          accepts: [requirements(
+            '0x1111111111111111111111111111111111111111',
+            1,
+            `${cityOrigin}/api/world/offer/31/claim`,
+            'test world offer',
+          )],
+        })
+        return
+      }
+      signedHeaders.push(paymentHeader)
+      sendJson(response, 202, {
+        payment: 'payment_pending',
+        transaction: TEST_TX_HASH,
+        do_not_pay_again: true,
+        error: 'Base finality is pending; reconcile this offer and do not pay again',
+        offer: { phase: 'payment_pending', asset_id: 2723 },
+      })
+      return
+    }
+    if (request.method === 'POST' && request.url === '/api/world/offer/31/reconcile') {
+      assert.deepEqual(body, {})
+      assert.equal(request.headers['x-payment'], undefined)
+      sendJson(response, 200, { offer: { phase: 'claimed', asset_id: 2723 } })
+      return
+    }
+    if (request.method === 'GET' && request.url === '/api/thing/2723') {
+      sendJson(response, 200, { thing: { id: 2723, current_owner: 'test-buyer' } })
+      return
+    }
+    sendJson(response, 404, { error: `unexpected city route ${request.method} ${request.url}` })
+  })
+  cityOrigin = city.origin
+
+  const market = await listen((request, response, body) => {
+    if (request.method === 'POST') {
+      assert.equal(request.headers.authorization, `Bearer ${TEST_MARKET_KEY}`)
+    }
+    if (request.method === 'POST' && request.url === '/api/world/checkout/23') {
+      assert.deepEqual(body, { city_handle: 'test-buyer' })
+      sendJson(response, 201, { checkout: { id: 77 } })
+      return
+    }
+    if (request.method === 'POST' && request.url === '/api/world/sync/23') {
+      assert.deepEqual(body, {})
+      syncCalls += 1
+      if (syncCalls === 1) {
+        sendJson(response, 202, {
+          world_state: 'finality_pending',
+          error: 'Base finality is pending; retry this sync and do not pay again',
+        })
+      } else {
+        sendJson(response, 200, { listing: { id: 23, world_state: 'needs_review' } })
+      }
+      return
+    }
+    if (request.method === 'GET' && request.url === '/api/listing/23') {
+      assert.equal(request.headers.authorization, undefined)
+      sendJson(response, 200, { listing: { id: 23, world_state: 'needs_review' } })
+      return
+    }
+    sendJson(response, 404, { error: `unexpected market route ${request.method} ${request.url}` })
+  })
+
+  try {
+    const origins = { city: city.origin, market: market.origin }
+    const first = await runClient(origins, stateDirectory)
+    assert.equal(first.status, 2)
+    assert.match(first.stderr, /Step 4.*pending.*same command again/isu)
+    assert.equal(signedHeaders.length, 1)
+    assert.deepEqual(claimBodies, [
+      { market_checkout_id: 77, buyer_wallet: TEST_ACCOUNT.address },
+      { market_checkout_id: 77, buyer_wallet: TEST_ACCOUNT.address },
+    ])
+
+    const second = await runClient(origins, stateDirectory)
+    assert.equal(second.status, 2)
+    assert.equal(signedHeaders.length, 1)
+    assert.equal(syncCalls, 2)
+    assert.match(second.stdout, /Thing 2723 is currently owned by test-buyer\./u)
+    assert.match(second.stdout, /Listing 23 world state is needs_review\./u)
+
+    const stateFiles = await readdir(stateDirectory)
+    assert.equal(stateFiles.length, 1)
+    const state = await readFile(join(stateDirectory, stateFiles[0]!), 'utf8')
+    const saved = JSON.parse(state) as Record<string, unknown>
+    assert.equal(saved.checkout_id, 77)
+    assert.match(String(saved.nonce), /^0x[0-9a-f]{64}$/u)
+    assert.equal(saved.tx_hash, TEST_TX_HASH)
+    const allOutput = `${first.stdout}\n${first.stderr}\n${second.stdout}\n${second.stderr}\n${state}`
+    for (const secret of [TEST_CITY_KEY, TEST_MARKET_KEY, TEST_PRIVATE_KEY, signedHeaders[0]!]) {
+      assert.equal(allOutput.includes(secret), false)
+    }
+  } finally {
+    await Promise.all([close(city.server), close(market.server)])
+    await rm(stateDirectory, { recursive: true, force: true })
+  }
+})
+
+test('new-wallet makes a key whose address matches it and never reuses a key', () => {
+  const first = freshWallet()
+  const second = freshWallet()
+  assert.match(first.privateKey, /^0x[0-9a-f]{64}$/u)
+  assert.equal(privateKeyToAccount(first.privateKey).address, first.address)
+  assert.notEqual(first.privateKey, second.privateKey)
+  const fixed = freshWallet(() => TEST_PRIVATE_KEY)
+  assert.equal(fixed.address, TEST_ACCOUNT.address)
+})


### PR DESCRIPTION
## Summary
Buying a city thing through the market's world aisle takes seven steps inside two short windows (a ten-minute market intent, then a five-minute city reservation), and one of them is signing an x402 payment. `scripts/world-buy.mjs` does the buyer side in one run:

1. market checkout (`POST /api/world/checkout/:listingId {city_handle}`),
2. city claim with `market_checkout_id` and `buyer_wallet`,
3. on the 402, exactly one EIP-3009 `TransferWithAuthorization` signed as EIP-712 for the accepted requirement (domain from `extra`, chainId 8453, verifyingContract the asset), encoded as the `X-PAYMENT` that `src/pay.ts parseX402Payment` demands,
4. the paid retry, with `payment_pending` handled honestly: a state file under the OS temp directory (keyed by listing and offer) makes a rerun reconcile via `POST /api/world/offer/:id/reconcile` and never sign again,
5. the market sync loop (`POST /api/world/sync/:listingId {}`) until a terminal state,
6. the public proof (`current_owner`, `world_state`) in plain words.

Secrets: city and market keys from `AGENT_1F3D9_SECRET` / `AGENT_1F3EA_SECRET` or `--city-key-file` / `--market-key-file`; the wallet key only from `BUYER_WALLET_PRIVATE_KEY`. None of the four is printed, logged, or written; errors are redacted before printing. `node scripts/world-buy.mjs new-wallet` prints a fresh address and key once, to the terminal that ran it, for a human whose wallet has no exportable key.

`viem` 2.55.11 is pinned as a devDependency for the signature. No door text changes.

## Proven (orchestrator, fresh clone)
- `test/world-buy-client.test.ts` (offline): the header parses with the city's own `parseX402Payment` and the recovered signer equals the test address; a stub-server run through `payment_pending` plus a rerun signs exactly once and stops on a terminal state; the four secrets never appear in stdout, stderr, or the state file; `new-wallet` keys match their addresses. 3/3.
- typecheck clean; `door:check` clean; `npm test` 1956 pass with the four known Windows-only identity-client failures (#183).
- No live run yet: the first real purchase (listing 23, offer 2, 1 USDC to our own treasury) is the owner's, from their own terminal.

## Test plan
- [ ] Sonnet review round(s) until clean: signature shape against `src/pay.ts`, redaction, resume logic, sync loop, and a read-only dry probe of the live 402 shape without paying
- [ ] Owner's real run on listing 23

🤖 Generated with [Claude Code](https://claude.com/claude-code)