### PR TITLE
fix: world-buy reads the market's top-level checkout_id

### DIFF
--- a/scripts/world-buy.mjs
+++ b/scripts/world-buy.mjs
@@ -292,11 +292,17 @@ async function writeState(path, state, step) {
 }
 
 function checkoutIdFrom(body) {
-  const direct = Number(record(body)?.id)
-  const nested = Number(record(record(body)?.checkout)?.id)
-  return Number.isSafeInteger(nested) && nested > 0
-    ? nested
-    : Number.isSafeInteger(direct) && direct > 0 ? direct : null
+  // The market answers a new checkout with a top-level checkout_id; a checkout
+  // read carries { checkout: { id } }; a bare id is accepted for stubs.
+  for (const candidate of [
+    record(body)?.checkout_id,
+    record(record(body)?.checkout)?.id,
+    record(body)?.id,
+  ]) {
+    const value = Number(candidate)
+    if (Number.isSafeInteger(value) && value > 0) return value
+  }
+  return null
 }
 
 function offerFrom(body) {

--- a/test/world-buy-client.test.ts
+++ b/test/world-buy-client.test.ts
@@ -324,7 +324,8 @@ test('world-buy recovers from a paid claim that answers too slowly by reconcilin
 
   const market = await listen((request, response) => {
     if (request.method === 'POST' && request.url === '/api/world/checkout/23') {
-      sendJson(response, 201, { checkout: { id: 78 } })
+      // The market's real answer carries checkout_id at the top level.
+      sendJson(response, 201, { checkout_id: 78, url: 'https://market.test/api/world/checkout/78' })
       return
     }
     if (request.method === 'POST' && request.url === '/api/world/sync/23') {


### PR DESCRIPTION
Seen on the first real run tonight: the market answers POST /api/world/checkout/:listingId with checkout_id at the top level (src/world-checkout-routes.ts in 1f3ea), and the client only looked for checkout.id or id, so it created a checkout and then said the market returned none. checkoutIdFrom now accepts checkout_id, checkout.id, and id; the stub-server test answers with the real shape. Unit 4/4, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)