### PR TITLE
fix: the world claim reservation no longer passes a parameter it never uses

### DIFF
--- a/src/world-market.ts
+++ b/src/world-market.ts
@@ -861,15 +861,15 @@ export function mountWorldMarketRoutes(
           UPDATE transfer_offers SET
             buyer_id = $2,
             reserved_by = $2,
-            buyer_wallet = lower($4),
-            market_listing_id = $5,
-            market_checkout_id = $6,
-            market_buyer = $9,
+            buyer_wallet = lower($3),
+            market_listing_id = $4,
+            market_checkout_id = $5,
+            market_buyer = $8,
             reserved_at = clock_timestamp(),
             reserved_until = clock_timestamp() + interval '5 minutes'
           WHERE id = $1 AND channel = 'world' AND asset_type = 'thing' AND status = 'open'
             AND seller_id <> $2
-            AND market_origin = $7 AND market_draft_id = $8
+            AND market_origin = $6 AND market_draft_id = $7
             AND (reserved_until IS NULL OR reserved_until <= clock_timestamp())
             AND pending_x402_tx_hash IS NULL
             AND NOT EXISTS (
@@ -878,7 +878,7 @@ export function mountWorldMarketRoutes(
                 AND payment_attempts.offer_id = transfer_offers.id
                 AND payment_attempts.status IN ('settling', 'payment_pending', 'needs_review')
             )
-            AND (market_listing_id IS NULL OR market_listing_id = $5)
+            AND (market_listing_id IS NULL OR market_listing_id = $4)
             AND EXISTS (
               SELECT 1 FROM things
               WHERE things.id = transfer_offers.asset_id
@@ -889,7 +889,6 @@ export function mountWorldMarketRoutes(
         `, [
           offer.id,
           buyer.id,
-          buyer.handle,
           requestedWallet,
           checkout.listingId,
           checkout.id,

--- a/test/sql-placeholders.test.ts
+++ b/test/sql-placeholders.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import test from 'node:test'
+
+// Postgres refuses to prepare a statement whose parameter it cannot type
+// (error 42P18), and a placeholder that the SQL never references has no type.
+// The fake database in the unit tests never notices; production did, on the
+// first real world-aisle claim (2026-09-04). This scans every static
+// query(`...`, [...]) pair in src and requires every $1..$n to be referenced.
+// Statements built from interpolated fragments are skipped: their placeholders
+// live in the fragments.
+const SRC = join(process.cwd(), 'src')
+const files = readdirSync(SRC).filter(name => name.endsWith('.ts'))
+const pairs = /query\(\s*`([^`]*)`\s*,\s*\[([^\]]*)\]/gsu
+
+test('every static SQL statement references every parameter it is given', () => {
+  const problems: string[] = []
+  let checked = 0
+  for (const name of files) {
+    const source = readFileSync(join(SRC, name), 'utf8')
+    for (const match of source.matchAll(pairs)) {
+      const sql = match[1] ?? ''
+      const params = match[2] ?? ''
+      if (sql.includes('${')) continue
+      const count = params.split(',').map(part => part.trim()).filter(part => part && !part.startsWith('//')).length
+      if (count === 0) continue
+      checked += 1
+      const used = new Set([...sql.matchAll(/\$(\d+)/gu)].map(hit => Number(hit[1])))
+      const line = source.slice(0, match.index).split(/\r?\n/u).length
+      for (let index = 1; index <= count; index += 1) {
+        if (!used.has(index)) problems.push(`${name}:${line} never references $${index} of ${count}`)
+      }
+      for (const index of used) {
+        if (index > count) problems.push(`${name}:${line} references $${index} but is given ${count}`)
+      }
+    }
+  }
+  assert.ok(checked > 20, `expected to check many statements, checked ${checked}`)
+  assert.deepEqual(problems, [])
+})

--- a/test/world-market.test.ts
+++ b/test/world-market.test.ts
@@ -463,7 +463,10 @@ function makeHarness(
       const active = offer.reserved_until != null && Date.parse(offer.reserved_until) > Date.parse(state.now)
       if (active) return []
       const buyerId = Number(params[1])
-      const buyer = String(params[2])
+      // The real statement stores buyer_id only; the public read joins the
+      // handle from residents, the way this fake's authenticate() knows them.
+      const handles: Record<number, string> = { 7: 'tiny-lantern', 8: 'neighbor', 9: 'someone-else' }
+      const buyer = handles[buyerId] ?? String(buyerId)
       const reservedAt = state.now
       const reservedUntil = new Date(Date.parse(state.now) + 300_000).toISOString()
       const rebound = {
@@ -471,10 +474,10 @@ function makeHarness(
         buyer_id: buyerId,
         buyer,
         reserved_by: buyerId,
-        buyer_wallet: String(params[3]),
-        market_listing_id: Number(params[4]),
-        market_checkout_id: Number(params[5]),
-        market_buyer: String(params[8]),
+        buyer_wallet: String(params[2]),
+        market_listing_id: Number(params[3]),
+        market_checkout_id: Number(params[4]),
+        market_buyer: String(params[7]),
         reserved_at: reservedAt,
         reserved_until: reservedUntil,
       }
@@ -1221,7 +1224,7 @@ test('market buyer identity is retained as an immutable public checkout binding'
   const publicRecord = await harness.app.request('/api/world/offer/101')
   assert.equal((await publicRecord.json() as { offer: FakeOffer }).offer.market_buyer, 'market-buyer')
   const reserveSql = harness.getState().queries.find(call => call.text.includes('world-market:reserve'))?.text ?? ''
-  assert.match(reserveSql, /market_buyer\s*=\s*\$9/i)
+  assert.match(reserveSql, /market_buyer\s*=\s*\$\d+/i)
 })
 
 test('payment closes ownership atomically and a retry returns the same public receipt', async () => {


### PR DESCRIPTION
The first real world-aisle claim tonight (offer 3, checkout 6) answered 500. The city's own log row says it: `NeonDbError 42P18` on `POST /api/world/offer/:offerId/claim`. The reservation UPDATE (`/* world-market:reserve */`) was given nine parameters and never referenced `$3` (the buyer handle, which the public read joins from residents), and Postgres cannot type a parameter no clause uses. The unit fake never noticed; this statement had never run against a real database.

## What changed
- `src/world-market.ts`: the unused parameter is gone and `$4..$9` become `$3..$8`.
- `test/world-market.test.ts`: the fake reads the same positions and derives the buyer handle from the id, as the real read does; one assertion that pinned `market_buyer = $9` now requires a parameter without pinning its number.
- `test/sql-placeholders.test.ts` (new): scans every static `query(\`...\`, [...])` in `src` and requires every given parameter to be referenced and none beyond the count; it fails on main and passes here.

## Proven (orchestrator, fresh clone)
- Reproduced live, read-only: the claim probe returned 500 with a request_id, and the runtime log row carried `error_code 42P18`.
- typecheck clean; `npm test` green apart from the four known Windows-only identity-client failures (#183); the new test fails without the fix.

Blocks the first purchase; merge as soon as a confirm round is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)