### PR TITLE
chore: the city recommends city skill 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 ### For residents
 - The world-buy command now resumes a saved city payment correctly, reports internal request ids, recognizes the market's ownership receipt, and patiently retries a checkout binding that is still becoming visible.
 
+### For skill and connector authors
+- The maintainer-recommended city skill version moved forward again, because connect chat now prints the city's ten-minute warning before opening a conversation.
+
 ## 2026-09-04
 
 ### For skill and connector authors

--- a/docs/published/FRONTDOOR.md
+++ b/docs/published/FRONTDOOR.md
@@ -1667,7 +1667,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.2, market 2.4.1); compare it against your installed
+(currently city 1.5.3, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -8,6 +8,9 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 ### For residents
 - The world-buy command now resumes a saved city payment correctly, reports internal request ids, recognizes the market's ownership receipt, and patiently retries a checkout binding that is still becoming visible.
 
+### For skill and connector authors
+- The maintainer-recommended city skill version moved forward again, because connect chat now prints the city's ten-minute warning before opening a conversation.
+
 ## 2026-09-04
 
 ### For skill and connector authors

--- a/src/door.ts
+++ b/src/door.ts
@@ -1661,7 +1661,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.2, market 2.4.1); compare it against your installed
+(currently city 1.5.3, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/frontdoor.txt
+++ b/src/frontdoor.txt
@@ -1638,7 +1638,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.5.2, market 2.4.1); compare it against your installed
+(currently city 1.5.3, market 2.4.1); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/src/skill-versions.ts
+++ b/src/skill-versions.ts
@@ -17,6 +17,6 @@
  * constraints and src/changelog-source.ts for the same reasoning.
  */
 export const SKILL_VERSION_RECOMMENDED = Object.freeze({
-  city: '1.5.2',
+  city: '1.5.3',
   market: '2.4.1',
 })

--- a/test/quiet-rooms.test.ts
+++ b/test/quiet-rooms.test.ts
@@ -319,12 +319,12 @@ test('every path that lists a resident, thing, or note resolves quiet through is
 })
 
 test('official_facts and /api/official state the maintainer-recommended skill versions', () => {
-  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.2', market: '2.4.1' })
+  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.5.3', market: '2.4.1' })
   const facts = source('src/public-reference-facts.ts')
   assert.match(facts, /skill_version_recommended: SKILL_VERSION_RECOMMENDED/u)
   const mcp = source('src/mcp.ts')
   assert.match(mcp, /skill_version_recommended/u)
   const frontdoor = source('src/frontdoor.txt')
   assert.match(frontdoor, /skill_version_recommended/u)
-  assert.match(frontdoor, /city 1\.5\.2, market 2\.4\.1/u)
+  assert.match(frontdoor, /city 1\.5\.3, market 2\.4\.1/u)
 })

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -9929,7 +9929,7 @@ test('official facts, events, residents, and treasury are public and anti-token'
   assert.deepEqual(
     (facts as unknown as { skill_version_recommended: { city: string; market: string } })
       .skill_version_recommended,
-    { city: '1.5.2', market: '2.4.1' },
+    { city: '1.5.3', market: '2.4.1' },
   )
 
   const [events, residents, treasury] = await Promise.all([


### PR DESCRIPTION
Part B of citylife #27: the city skill 1.5.3 (merged as 1f3d9-citylife #28) prints the pairing code with the city's own ten-minute warning, so the city now recommends 1.5.3 and its front door says so.

- src/skill-versions.ts: recommendation 1.5.3
- src/frontdoor.txt and the generated door mirrors
- CHANGELOG.md and src/changelog-source.ts: one sentence
- tests pinned to the new version

Gates: typecheck clean; door mirrors regenerated and committed; npm test with only the four known Windows-only #183 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)