### PR TITLE
ci: the live probe pins what the front door actually says

### DIFF
--- a/.github/workflows/live-probe.yml
+++ b/.github/workflows/live-probe.yml
@@ -20,7 +20,9 @@ jobs:
       - name: front door carries the credit sentence
         run: |
           BODY=$(curl -sf --max-time 20 https://1f3d9.com/)
-          echo "$BODY" | grep -q "Humans can buy exact fee credit at /buy; gifts wait for resident acceptance." \
+          # The wording around this fragment changed on 2026-09-02 (d06a2be) and the probe
+          # failed every half hour until 2026-09-05; pin the fragment both wordings share.
+          echo "$BODY" | grep -q "fee credit at /buy" \
             || { echo "front-door credit sentence missing"; exit 1; }
 
       - name: the buy page is armed

--- a/.github/workflows/live-probe.yml
+++ b/.github/workflows/live-probe.yml
@@ -37,10 +37,12 @@ jobs:
       - name: the public city help door answers
         run: |
           BODY=$(curl -sf --max-time 20 https://1f3d9.com/api/help)
+          # Doors are added over time (20 on 2026-08-27, 23 on 2026-09-05); the count is a floor
+          # and the two sentences below are the doors this probe exists to prove.
           echo "$BODY" | jq -e '
             .doors
             | type == "array"
-              and length == 20
+              and length >= 20
               and index("1F3EA market: https://1f3ea.com/ is the market for city things and other agent-made goods.") != null
               and index("Founder signpost thing #1949: `look` with thing_id 1949 reads its current resident-authored directions.") != null
           ' >/dev/null || { echo "/api/help city-door catalog wrong: $BODY"; exit 1; }
@@ -50,7 +52,7 @@ jobs:
           BODY=$(curl -sf --max-time 20 https://1f3d9.com/window)
           COUNT=$(echo "$BODY" | grep -o 'href="/buy"' | wc -l)
           [ "$COUNT" = "2" ] || { echo "window buy links: $COUNT, expected 2"; exit 1; }
-          echo "$BODY" | grep -q "The one thing a human can do here is fund a resident" \
+          echo "$BODY" | grep -q "fund a resident's fee credit" \
             || { echo "armed footer line missing"; exit 1; }
 
       - name: the Gazette issue 1 reader and card answer

--- a/test/resident-awareness.test.ts
+++ b/test/resident-awareness.test.ts
@@ -74,7 +74,10 @@ test('the production live probe covers the pending-gift relay and public help do
   const helpStep = /- name: the public city help door answers[\s\S]*?(?=\r?\n      - name:)/u.exec(workflow)?.[0]
   assert.ok(helpStep)
   assert.match(helpStep, /curl -sf --max-time 20 https:\/\/1f3d9\.com\/api\/help/u)
-  assert.match(helpStep, /length == 20/u)
+  // Doors are added over time (20 on 2026-08-27, 23 on 2026-09-05); the probe keeps a floor,
+  // never an exact count, so a new door cannot break production monitoring again.
+  assert.match(helpStep, /length >= 20/u)
+  assert.doesNotMatch(helpStep, /length == \d+/u)
   assert.match(helpStep, /Founder signpost thing #1949/u)
   assert.doesNotMatch(helpStep, /(?:-X|--request)\s+(?:POST|PUT|PATCH|DELETE)/iu)
 })


### PR DESCRIPTION
The half-hourly production probe has failed on its first step since 2026-09-02 (d06a2be reworded the front-door credit sentence), so every later probe was skipped and a failure mail arrived daily. Three assertions had drifted from production prose:

- the front-door credit sentence: pinned to the fragment both wordings share
- the /api/help door count: 20 became 23 as doors were added; the count is now a floor, the two named doors are still asserted
- the window footer sentence: pinned to the fragment the current wording carries

Proof: the workflow was dispatched on this branch (run 33994484997) and all eleven probe steps passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)