### PR TITLE
feat: the live stage keeps one node per resident and thing and never rotates a sprite

### DIFF
--- a/e2e/public-window-live.spec.ts
+++ b/e2e/public-window-live.spec.ts
@@ -603,6 +603,9 @@ async function installReplayRoutes(
   const heldOpeningPage = new Promise<void>(resolve => {
     releaseHeldOpeningPage = resolve
   })
+  let heldResidentPageRequests = 0
+  let heldResidentPageGate: Promise<void> | null = null
+  let releaseHeldResidentPage = () => {}
   let heldEmptyChangeRequests = 0
   let heldEmptyChangeGate: Promise<void> | null = null
   let releaseHeldEmptyChange = () => {}
@@ -1162,6 +1165,12 @@ async function installReplayRoutes(
       })
       return
     }
+    if (heldResidentPageGate) {
+      const gate = heldResidentPageGate
+      heldResidentPageGate = null
+      heldResidentPageRequests += 1
+      await gate
+    }
     if (controls.residentDelayMs) {
       await new Promise(resolve => setTimeout(resolve, controls.residentDelayMs))
     }
@@ -1310,6 +1319,13 @@ async function installReplayRoutes(
     },
     heldEmptyChangeRequests: () => heldEmptyChangeRequests,
     releaseHeldEmptyChange: () => releaseHeldEmptyChange(),
+    holdNextResidentPage: () => {
+      heldResidentPageGate = new Promise<void>(resolve => {
+        releaseHeldResidentPage = resolve
+      })
+    },
+    heldResidentPageRequests: () => heldResidentPageRequests,
+    releaseHeldResidentPage: () => releaseHeldResidentPage(),
     recoverThingNames: () => { thingNamesUnavailable = false },
     releaseHeldOpeningPage,
     releaseHeldThingPage,
@@ -3150,6 +3166,11 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
   await proofButton.click()
   const proofPanel = page.locator('#live-panel[data-live-proof="true"]')
   await expect(proofPanel).toBeVisible()
+  const replays = proofPanel.locator('.live-replay-portrait')
+  await expect(replays).toHaveCount(64)
+  const proofPaintedAt = await page.evaluate(() => Date.now())
+  await page.clock.pauseAt(proofPaintedAt + 100)
+  await page.clock.runFor(64)
   await expectProofDrawingContract(page)
   const workshopTerrain = proofPanel.locator(
     '.live-plot[data-place-id="9103"] .live-plot-terrain',
@@ -3157,12 +3178,11 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
   await workshopTerrain.evaluate(node => {
     ;(window as Window & { __proofWorkshopTerrain?: Element }).__proofWorkshopTerrain = node
   })
-  await expect(proofPanel.locator('.live-proof-frame-time')).toContainText(/p95 .* max/u)
-
   const retry = page.getByRole('button', { name: 'Retry proof room' })
   await expect(retry).toBeVisible()
   await expectTargetCenterExposed(retry)
   await retry.click()
+  await page.clock.runFor(32)
   await expect(retry).toHaveCount(0)
 
   const residentMore = proofPanel.getByRole('button', { name: /Show .* more residents/u })
@@ -3173,14 +3193,33 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
   await expectTargetCenterExposed(thingMore)
   await residentMore.click()
   await thingMore.click()
+  await page.clock.runFor(32)
   await expect(proofPanel.getByRole('dialog')).toHaveCount(0)
-  // The proof plate carries the full Step 8 crowd while keeping hana on the
-  // movement garden for the same-floor comparison from Step 3.
-  await expect(proofPanel.locator('.live-walker')).toHaveCount(88)
-  await expect(proofPanel.locator('.live-thing-specimen')).toHaveCount(7)
-
-  const replays = proofPanel.locator('.live-replay-portrait')
-  await expect(replays).toHaveCount(64)
+  const proofPlateSample = await proofPanel.evaluate(panel => {
+    const residentShells = [...panel.querySelectorAll<HTMLElement>(
+      '[data-stage-node-key^="resident:"]',
+    )]
+    const residentKeys = residentShells.map(shell => shell.dataset.stageNodeKey || '')
+    return {
+      invalidShells: residentShells
+        .filter(shell => !shell.matches('.live-walker, .live-replay-portrait'))
+        .map(shell => shell.dataset.stageNodeKey || ''),
+      registeredResidentShells: residentShells.length,
+      residentKeys,
+      uniqueResidentKeys: new Set(residentKeys).size,
+      walkers: panel.querySelectorAll('.live-walker').length,
+      replays: panel.querySelectorAll('.live-replay-portrait').length,
+      things: panel.querySelectorAll('.live-thing-specimen').length,
+    }
+  })
+  expect(proofPlateSample, JSON.stringify(proofPlateSample)).toMatchObject({
+    invalidShells: [],
+    registeredResidentShells: 152,
+    uniqueResidentKeys: 152,
+    walkers: 88,
+    replays: 64,
+    things: 7,
+  })
   const proofStageNodes = proofPanel.locator(
     '[data-stage-node-key^="resident:"], [data-stage-node-key^="thing:"]',
   )
@@ -3210,6 +3249,8 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
       (node as HTMLElement).dataset.liveReplayKey))
     return new Set(concurrentReplayKeys).size
   }).toBeGreaterThan(0)
+  await page.clock.runFor(1_920)
+  await expect(proofPanel.locator('.live-proof-frame-time')).toHaveText(/p95 .* max/u)
   let sawUse = false
   for (let elapsed = 0; elapsed < 24_000; elapsed += 500) {
     await page.clock.runFor(500)
@@ -3234,6 +3275,7 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
   )).toBe(true)
 
   await page.locator('#place-filter').selectOption('9103')
+  await page.clock.runFor(32)
   await expect(proofPanel.locator('.live-world-ground-tiles')).toHaveAttribute(
     'data-undrawn', 'false',
   )
@@ -3242,15 +3284,18 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
     'aria-label', "The workshop bell rings above the busy floor. (open proof-dara's note)",
   )
   await scriptedBubble.click()
+  await page.clock.runFor(32)
   const scriptedNote = proofPanel.locator('.live-note-row[data-live-note-id="9352"]')
   await expect(scriptedNote).toBeFocused()
   await expect(scriptedNote).toContainText('The workshop bell rings above the busy floor.')
   await proofPanel.locator('#live-notes-close').click()
+  await page.clock.runFor(32)
   // Closing returns focus to the bubble that opened the panel, the same
   // opener contract every other control on the plate keeps.
   await expect(page.locator('.live-speech-bubble')).toBeFocused()
 
   await proofButton.click()
+  await page.clock.runFor(32)
   await expect(proofPanel).toBeVisible()
   await expect(page.getByRole('button', { name: 'Retry proof room' })).toBeVisible()
 })
@@ -3274,7 +3319,7 @@ test('persistent stage sprite nodes keep their identity through 20 repaints', as
       nodeMarker,
       spriteMarker: sprite?.dataset.stageIdentityMarker || '',
     }
-  }))
+  }).sort((left, right) => left.key.localeCompare(right.key)))
 
   for (let repaint = 0; repaint < 20; repaint += 1) {
     const paintMarker = `paint-${repaint}`
@@ -3282,8 +3327,17 @@ test('persistent stage sprite nodes keep their identity through 20 repaints', as
       ;(node as HTMLElement).dataset.stagePaintMarker = marker
     }, paintMarker)
     await page.evaluate(() => window.dispatchEvent(new Event('resize')))
-    await expect.poll(() => page.locator('.live-trace-layer')
-      .getAttribute('data-stage-paint-marker')).not.toBe(paintMarker)
+    await expect.poll(async () => {
+      const sample = await page.evaluate(marker => {
+        const node = document.querySelector<HTMLElement>('.live-trace-layer')
+        return {
+          present: node ? true : null,
+          paintMarker: node?.dataset.stagePaintMarker || null,
+          changed: node && node.dataset.stagePaintMarker !== marker ? true : null,
+        }
+      }, paintMarker)
+      return sample.present && sample.changed ? sample : null
+    }).toMatchObject({ present: true, changed: true })
   }
 
   const afterRepaints = await stageNodes.evaluateAll(nodes => nodes.map(node => {
@@ -3293,8 +3347,57 @@ test('persistent stage sprite nodes keep their identity through 20 repaints', as
       nodeMarker: (node as HTMLElement).dataset.stageIdentityMarker || '',
       spriteMarker: sprite?.dataset.stageIdentityMarker || '',
     }
-  }))
+  }).sort((left, right) => left.key.localeCompare(right.key)))
   expect(afterRepaints, JSON.stringify({ firstPaint, afterRepaints })).toEqual(firstPaint)
+})
+
+test('resident census gates detach stage nodes and return the same registered nodes', async ({ page }) => {
+  const fixture = await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const stageNodes = page.locator('[data-stage-node-key]')
+  const stableStageNodes = page.locator(
+    '[data-stage-node-key^="place:"], ' +
+      '[data-stage-node-key^="resident:"]:not([data-stage-node-key="resident:5"])',
+  )
+  const identityBefore = await stableStageNodes.evaluateAll(nodes => nodes.map((node, index) => {
+    const element = node as HTMLElement
+    const nodeMarker = `gate-node-${index}-${crypto.randomUUID()}`
+    const spriteMarker = `gate-sprite-${index}-${crypto.randomUUID()}`
+    const sprite = element.querySelector<HTMLElement>(
+      ':scope > .live-portrait > .live-entity-portrait',
+    )
+    element.dataset.stageGateMarker = nodeMarker
+    if (sprite) sprite.dataset.stageGateMarker = spriteMarker
+    return {
+      key: element.dataset.stageNodeKey || '',
+      nodeMarker,
+      spriteMarker: sprite?.dataset.stageGateMarker || '',
+    }
+  }).sort((left, right) => left.key.localeCompare(right.key)))
+  expect(identityBefore.length).toBeGreaterThan(0)
+
+  fixture.holdNextResidentPage()
+  try {
+    await publishReplayChanges(page, fixture)
+    await expect.poll(fixture.heldResidentPageRequests).toBe(1)
+    await expect(stageNodes).toHaveCount(0)
+  } finally {
+    fixture.releaseHeldResidentPage()
+  }
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  await expect.poll(() => page.evaluate(keys => keys.map(key => {
+    const element = document.querySelector<HTMLElement>(
+      `[data-stage-node-key="${CSS.escape(key)}"]`)
+    const sprite = element?.querySelector<HTMLElement>(
+      ':scope > .live-portrait > .live-entity-portrait',
+    )
+    return {
+      key,
+      nodeMarker: element?.dataset.stageGateMarker || '',
+      spriteMarker: sprite?.dataset.stageGateMarker || '',
+    }
+  }), identityBefore.map(entry => entry.key))).toEqual(identityBefore)
 })
 
 test('a stage sprite flips --facing on left and right walks without rotating', async ({ page }) => {
@@ -4069,6 +4172,8 @@ test('new change rows replay once in recorded order and leave truthful residue',
   await expect(page.locator('.live-footnote-mark')).toHaveCount(0)
   await expect(page.locator('.live-speech-bubble')).toHaveCount(0)
   await expect(page.locator('.live-thing-specimen.live-pulse')).toHaveCount(0)
+  await replay.locator('.live-portrait').evaluate(node => (node as HTMLButtonElement).click())
+  await expect(page.locator('#live-focus-status')).toContainText('Focused on map-walker')
   const movementSampleMs = Math.ceil(duration * 0.3)
   await page.clock.runFor(movementSampleMs)
   const midpoint = await replayPosition()
@@ -4076,18 +4181,23 @@ test('new change rows replay once in recorded order and leave truthful residue',
     midpoint.x - initialPosition.x,
     midpoint.y - initialPosition.y,
   )).toBeGreaterThan(10)
+  await replay.locator('.live-portrait').evaluate(node => (node as HTMLButtonElement).click())
+  await expect(page.locator('#live-focus-status')).toContainText('No resident focused')
 
   await page.clock.fastForward(duration - movementSampleMs + 251)
   const absorbedResidents = page.locator('[data-place-id="3"] .live-resident-more')
-  await expect(absorbedResidents).toHaveText('+3 more')
+  await expect(absorbedResidents).toHaveText('+4 more')
   await expect(absorbedResidents).toHaveClass(/live-overflow-absorbing/u)
-  await expect(absorbedResidents).toHaveAttribute('data-live-overflow-count', '3')
+  await expect(absorbedResidents).toHaveAttribute('data-live-overflow-count', '4')
   await expect(absorbedResidents).toHaveCSS('opacity', '1')
   const thingOverflow = page.locator('[data-place-id="3"] .live-thing-more')
   await expect(thingOverflow).toHaveText('+3 more')
   await expect(thingOverflow).toHaveAttribute('data-live-overflow-count', '3')
   await expect(page.locator('.live-footnote-mark')).toHaveCount(1)
   await expect(page.locator('.live-speech-bubble')).toHaveText('Earlier line')
+  const platePortrait = page.locator('#live-plates [data-live-resident-handle="map-walker"]')
+  await expect(platePortrait).toHaveAccessibleName(/map-walker/u)
+  await expect(platePortrait).not.toHaveAccessibleName(/Earlier|L{10}/u)
   await expect(page.locator('.live-thing-specimen.live-pulse')).toHaveCount(0)
 
   await page.clock.fastForward(651)
@@ -4098,7 +4208,8 @@ test('new change rows replay once in recorded order and leave truthful residue',
   await page.clock.fastForward(651)
   const pulsedThing = page.locator('.live-thing-specimen.live-pulse')
   await expect(pulsedThing).toHaveCount(0)
-  await expect(page.locator('[data-stage-node-key="thing:9"]')).toHaveCount(0)
+  const stableLantern = page.locator('[data-place-id="3"] [data-stage-node-key="thing:9"]')
+  await expect(stableLantern).toHaveCount(1)
   await expect(stableThing).toHaveAttribute('data-stage-identity-marker', stableThingMarker)
   await expect(stableThing).not.toHaveClass(/live-pulse/u)
   await expect(page.locator('.live-action-mark')).toHaveCount(0)
@@ -4106,7 +4217,29 @@ test('new change rows replay once in recorded order and leave truthful residue',
   await page.clock.fastForward(600)
   await expect(replay).toHaveCount(0)
   await expect(page.locator('.live-thing-specimen.live-pulse')).toHaveCount(0)
-  await expect(page.locator('[data-stage-node-key="resident:5"]')).toHaveCount(0)
+  let settledPoint: { x: number, y: number } | null = null
+  await expect.poll(async () => {
+    settledPoint = await page.evaluate(() => {
+      const portrait = document.querySelector<HTMLElement>(
+        '[data-place-id="3"] [data-live-resident-handle="map-walker"]')
+      const shell = portrait?.closest<HTMLElement>('.live-walker') || null
+      const stage = portrait?.closest<HTMLElement>('.live-stage') || null
+      if (!shell || !stage) return null
+      const ground = stage.getBoundingClientRect()
+      const box = shell.getBoundingClientRect()
+      const scale = ground.width / Number(stage.dataset.liveStageWidth)
+      return {
+        x: (box.left + box.width / 2 - ground.left) / scale,
+        y: (box.bottom - ground.top) / scale,
+      }
+    })
+    return settledPoint
+  }).toMatchObject({ x: expect.any(Number), y: expect.any(Number) })
+  expect(Math.hypot(
+    settledPoint!.x - initialPosition.x,
+    settledPoint!.y - initialPosition.y,
+  )).toBeGreaterThan(10)
+  await expect(page.locator('[data-stage-node-key="resident:5"]')).toHaveCount(1)
   await expect(page.locator('.live-footnote-mark')).toHaveCount(2)
 
   await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))
@@ -4117,6 +4250,30 @@ test('new change rows replay once in recorded order and leave truthful residue',
   await expect(page.locator('.live-footnote-mark')).toHaveCount(0)
   await expect(page.locator('.live-speech-bubble')).toHaveCount(0)
   await expect(trail).toHaveCount(0)
+})
+
+test('unpinned replay records absorbed from the stage remain counted in matching overflow', async ({ page }) => {
+  const now = Date.now()
+  await page.clock.install({ time: new Date(now) })
+  const fixture = await installReplayRoutes(page, now)
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  await publishReplayChanges(page, fixture)
+  const replay = page.locator('.live-replay-portrait')
+  await expect(replay).toHaveCount(1)
+
+  await page.clock.runFor(25_000)
+  const harbor = page.locator('[data-place-id="3"]')
+  await expect(harbor.locator('.live-thing-specimen')).toHaveCount(5)
+  await expect(harbor.locator('.live-thing-more'))
+    .toHaveAttribute('data-live-overflow-count', '3')
+  await expect(harbor.locator('[data-stage-node-key="thing:9"]')).toHaveCount(0)
+
+  await expect(replay).toHaveCount(0)
+  await expect(harbor.locator('.live-walker')).toHaveCount(4)
+  await expect(harbor.locator('.live-resident-more'))
+    .toHaveAttribute('data-live-overflow-count', '4')
+  await expect(harbor.locator('[data-stage-node-key="resident:5"]')).toHaveCount(0)
 })
 
 test('clearing Follow after opening on a different resident does not pop a stale backlog bubble', async ({ page }) => {
@@ -5327,7 +5484,20 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
   const now = Date.now()
   const actorCount = 1_600
   const drawingPlaceCount = 215
-  const detailedPlotCount = 217
+  const detailedPlotCount = replayPlaces.filter(place => place.parent_id === 1).length +
+    drawingPlaceCount
+  const initialCrowdedResidentCount = replayResidentRows(now, 2)
+    .filter(resident => resident.current_place_id === 3).length + actorCount
+  const initialCrowdedThingCount = replayThingRows(now, 2)
+    .filter(thing => replayPlaceScopeIds(3).has(thing.place_id)).length
+  const expectedCollapsedWalkers = Math.min(
+    initialCrowdedResidentCount,
+    initialCrowdedResidentCount > 6 ? 4 : 6,
+  )
+  const expectedCollapsedThingSpecimens = Math.min(
+    initialCrowdedThingCount,
+    initialCrowdedThingCount > 6 ? 5 : 6,
+  )
   const placeRowCount = replayPlaces.length + drawingPlaceCount
   const residentRowBudget = actorCount * 16 + 10_000
   const anchorMembershipRowBudget = actorCount * 16 + 10_000
@@ -5365,6 +5535,14 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
   await page.goto('/window#view=live')
   await expect(page.locator('#live-history-status')).toContainText('history is complete')
   await expect(page.locator('.live-replay-portrait')).toHaveCount(0)
+  const crowdedPlot = page.locator('.live-plot[data-place-id="3"]')
+  expect(initialCrowdedResidentCount).toBe(1_607)
+  expect(initialCrowdedThingCount).toBe(1)
+  await expect(crowdedPlot.locator('.live-walker')).toHaveCount(expectedCollapsedWalkers)
+  await expect(crowdedPlot.locator('.live-thing-shelf'))
+    .not.toHaveAttribute('data-live-expanded', 'true')
+  await expect(crowdedPlot.locator('.live-thing-specimen'))
+    .toHaveCount(expectedCollapsedThingSpecimens)
   const registeredIdentityBefore = await page.locator(
     '[data-stage-node-key^="resident:"]:not([data-stage-node-key="resident:5"]), ' +
       '[data-stage-node-key^="place:"]',
@@ -5376,6 +5554,7 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
       marker: element.dataset.stageCrowdMarker,
     }
   }).sort((left, right) => left.key.localeCompare(right.key)))
+  expect(registeredIdentityBefore).toHaveLength(detailedPlotCount + expectedCollapsedWalkers)
   const readRegisteredIdentity = () => page.evaluate(keys => keys.map(key => {
     const node = document.querySelector<HTMLElement>(`[data-stage-node-key="${key}"]`)
     return { key, marker: node?.dataset.stageCrowdMarker || null }
@@ -5383,7 +5562,7 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
   const stableResidentsBefore = await stableResidentPositions()
   const fixedPlotsBefore = await fixedPlotPositions()
   expect(fixedPlotsBefore).toHaveLength(detailedPlotCount)
-  expect(stableResidentsBefore.length).toBeGreaterThan(0)
+  expect(stableResidentsBefore).toHaveLength(expectedCollapsedWalkers)
   expect(stableResidentsBefore.every(resident =>
     !resident.key.startsWith('walker-burst-'))).toBe(true)
 
@@ -5573,8 +5752,6 @@ test('a moving resident returning to readable ground receives a bounded label re
   const replays = page.locator('.live-replay-portrait')
   await expect.poll(() => replays.count()).toBeGreaterThan(0)
   await expect(replays).toHaveCount(64)
-  await page.getByRole('button', { name: 'Pause walks' }).click()
-  await expect(page.getByRole('button', { name: 'Resume walks' })).toBeVisible()
   await page.locator('#live-viewport').evaluate(async viewport => {
     const rect = viewport.getBoundingClientRect()
     for (let index = 0; index < 12; index += 1) {
@@ -5600,9 +5777,6 @@ test('a moving resident returning to readable ground receives a bounded label re
   await expect(page.locator('#live-focus-status')).toContainText(`Focused on ${returningHandle}`)
   await page.getByRole('button', { name: 'Center live view' }).click()
   await returningReplay.locator('.live-portrait').focus()
-  await expect(page.locator(
-    `#live-label-layer [data-live-resident-tag="${returningHandle}"]`,
-  )).toBeVisible()
   await page.evaluate(() => {
     const heldWindow = window as Window & { liveLabelChildMutations?: number }
     heldWindow.liveLabelChildMutations = 0
@@ -5611,54 +5785,92 @@ test('a moving resident returning to readable ground receives a bounded label re
         records.filter(record => record.type === 'childList').length
     }).observe(document.querySelector('#live-label-layer')!, { childList: true })
   })
-  let labelSample: {
+  type ResidentStopSample = {
     actor: string | null
-    delta: number | null
     headTime: number
     point: { x: number, y: number } | null
+    previousRectangle: DOMRectJSON | null
     recordId: string | null
     rectangle: DOMRectJSON | null
-  } | null = null
-  await expect.poll(async () => {
-    labelSample = await page.evaluate(({ handle, nodeKey }) => {
-      const shell = document.querySelector<HTMLElement>(
-        '[data-stage-node-key="' + CSS.escape(String(nodeKey)) + '"]')
-      const portrait = shell?.querySelector<HTMLElement>('[data-live-resident-handle]') || null
-      const tag = document.querySelector<HTMLElement>(
-        '#live-label-layer [data-live-resident-tag="' + CSS.escape(String(handle)) + '"]')
-      if (!portrait || !tag || !shell) return {
-        actor: handle, delta: null, headTime: Date.now(), point: null,
-        recordId: shell?.dataset.stageNodeKey || null, rectangle: null,
+    rectangleUnchanged: boolean
+    replayEnded: boolean
+    replaying: boolean
+  }
+  let settledSample: ResidentStopSample | null = null
+  let stopPollOperands: ResidentStopSample | null = null
+  let previousResidentRectangle: DOMRectJSON | null = null
+  try {
+    await expect.poll(async () => {
+      const sample = await page.evaluate(({ handle, nodeKey }) => {
+        const shell = document.querySelector<HTMLElement>(
+          '[data-stage-node-key="' + CSS.escape(String(nodeKey)) + '"]')
+        const portrait = shell?.querySelector<HTMLElement>('[data-live-resident-handle]') || null
+        if (!portrait || !shell) return {
+          actor: handle, headTime: Date.now(), point: null,
+          recordId: shell?.dataset.stageNodeKey || null, rectangle: null,
+          replaying: shell?.classList.contains('live-replay-portrait') ?? false,
+        }
+        const portraitRect = portrait.getBoundingClientRect()
+        return {
+          actor: handle,
+          headTime: Date.now(),
+          point: { x: portraitRect.x + portraitRect.width / 2, y: portraitRect.bottom },
+          recordId: shell.dataset.stageNodeKey || null,
+          rectangle: portraitRect.toJSON(),
+          replaying: shell.classList.contains('live-replay-portrait'),
+        }
+      }, { handle: returningHandle, nodeKey: returningNodeKey })
+      const previousRectangle = previousResidentRectangle
+      const replayEnded = !sample.replaying
+      const rectangleUnchanged = sample.rectangle !== null && previousRectangle !== null &&
+        JSON.stringify(sample.rectangle) === JSON.stringify(previousRectangle)
+      const stopped = replayEnded && rectangleUnchanged
+      previousResidentRectangle = sample.rectangle
+      stopPollOperands = {
+        ...sample,
+        previousRectangle,
+        rectangleUnchanged,
+        replayEnded,
       }
-      const portraitRect = portrait.getBoundingClientRect()
-      const tagRect = tag.getBoundingClientRect()
-      return {
-        actor: handle,
-        delta: Math.abs(portraitRect.x + portraitRect.width / 2 -
-          (tagRect.x + tagRect.width / 2)),
-        headTime: Date.now(),
-        point: { x: portraitRect.x + portraitRect.width / 2, y: portraitRect.bottom },
-        recordId: shell.dataset.stageNodeKey || null,
-        rectangle: portraitRect.toJSON(),
-      }
-    }, { handle: returningHandle, nodeKey: returningNodeKey })
-    return labelSample
-  }).toMatchObject({
-    actor: returningHandle,
-    delta: expect.any(Number),
-    headTime: expect.any(Number),
-    point: { x: expect.any(Number), y: expect.any(Number) },
-    recordId: returningNodeKey,
-    rectangle: expect.any(Object),
+      if (!stopped) return null
+      settledSample = stopPollOperands
+      return settledSample
+    }).toMatchObject({
+      actor: returningHandle,
+      headTime: expect.any(Number),
+      point: { x: expect.any(Number), y: expect.any(Number) },
+      recordId: returningNodeKey,
+      rectangle: expect.any(Object),
+      replaying: expect.any(Boolean),
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`${message}\nstop operands: ${JSON.stringify(stopPollOperands)}`)
+  }
+  await page.evaluate(() => {
+    ;(window as Window & { liveLabelChildMutations?: number }).liveLabelChildMutations = 0
   })
-  expect(labelSample!.delta, JSON.stringify(labelSample)).toBeLessThan(3)
-  expect(await page.evaluate(() => Number(
+  await page.getByRole('button', { name: 'Center live view' }).click()
+  await page.clock.runFor(64)
+  const returningLabel = page.locator(
+    `#live-label-layer [data-live-resident-tag="${returningHandle}"]`,
+  )
+  await expect(returningLabel).toBeVisible()
+  await expect(page.locator(
+    `#live-label-layer [data-live-resident-tag="${returningHandle}"]`,
+  )).toBeVisible({ timeout: 750 })
+  const liveLabelChildMutations = await page.evaluate(() => Number(
     (window as Window & { liveLabelChildMutations?: number }).liveLabelChildMutations,
-  ))).toBeLessThanOrEqual(1)
+  ))
+  expect(liveLabelChildMutations, JSON.stringify({
+    returningHandle,
+    returningNodeKey,
+    settledSample,
+    liveLabelChildMutations,
+  })).toBeLessThanOrEqual(1)
   await returningStageNode.locator('.live-portrait')
     .evaluate(node => (node as HTMLButtonElement).click())
   await expect(page.locator('#live-focus-status')).toContainText('No resident focused')
-  await page.getByRole('button', { name: 'Resume walks' }).click()
 })
 
 test('turning on reduced motion mid-walk preserves the final fading trail', async ({ page }) => {
@@ -6717,11 +6929,16 @@ test('proof: one popover carries what the chips carried, for one resident, one t
     popover: Awaited<ReturnType<typeof popover.boundingBox>>
   } = { anchor: null, popover: null }
   await expect.poll(async () => {
-    const [anchor, popoverBox] = await Promise.all([
-      cato.boundingBox(), popover.boundingBox(),
-    ])
-    catoGeometry = { anchor, popover: popoverBox }
-    return catoGeometry
+    catoGeometry = await page.evaluate(() => {
+      const anchor = document.querySelector<HTMLElement>(
+        '[data-live-resident-handle="proof-cato"]')
+      const popoverNode = document.querySelector<HTMLElement>('#live-item-popover')
+      return {
+        anchor: anchor?.getBoundingClientRect().toJSON() || null,
+        popover: popoverNode?.getBoundingClientRect().toJSON() || null,
+      }
+    })
+    return catoGeometry.anchor && catoGeometry.popover ? catoGeometry : null
   }).toMatchObject({
     anchor: { x: expect.any(Number), y: expect.any(Number) },
     popover: { x: expect.any(Number), y: expect.any(Number) },

--- a/e2e/public-window-live.spec.ts
+++ b/e2e/public-window-live.spec.ts
@@ -536,6 +536,7 @@ async function installReplayRoutes(
     thingDelayMs?: number
     moveBurst?: number
     simultaneousMoves?: number
+    oppositeFacingMoves?: boolean
     useThingId?: number
     manyFocusInteractions?: boolean
     openingMovement?: boolean
@@ -1015,6 +1016,7 @@ async function installReplayRoutes(
             change_id: '15', created_at: new Date(now).toISOString(), kind: 'action',
             actor: 'map-walker', detail: {
               action: 'move', from_place_id: 3, to_place_id: 2,
+              ...(controls.oppositeFacingMoves ? { status: 'applied' } : {}),
             },
           }, {
             change_id: '16', created_at: new Date(now - 600_001).toISOString(), kind: 'note',
@@ -1351,8 +1353,8 @@ async function liveResidentLocalPositions(plot: Locator) {
     .map(shell => ({
       key: shell.querySelector<HTMLElement>('[data-live-resident-handle]')
         ?.dataset.liveResidentHandle ?? '',
-      x: Number.parseFloat(shell.style.left),
-      y: Number.parseFloat(shell.style.top),
+      x: Number.parseFloat(shell.style.getPropertyValue('--stage-x')),
+      y: Number.parseFloat(shell.style.getPropertyValue('--stage-y')),
     })))
 }
 
@@ -3179,6 +3181,21 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
 
   const replays = proofPanel.locator('.live-replay-portrait')
   await expect(replays).toHaveCount(64)
+  const proofStageNodes = proofPanel.locator(
+    '[data-stage-node-key^="resident:"], [data-stage-node-key^="thing:"]',
+  )
+  const proofIdentity = await proofStageNodes.evaluateAll(nodes => nodes.map((node, index) => {
+    const nodeMarker = `proof-node-${index}-${crypto.randomUUID()}`
+    const spriteMarker = `proof-sprite-${index}-${crypto.randomUUID()}`
+    const sprite = node.querySelector<HTMLElement>(':scope .live-entity-portrait')
+    ;(node as HTMLElement).dataset.stageProofIdentityMarker = nodeMarker
+    if (sprite) sprite.dataset.stageProofIdentityMarker = spriteMarker
+    return {
+      key: (node as HTMLElement).dataset.stageNodeKey || '',
+      nodeMarker,
+      spriteMarker: sprite?.dataset.stageProofIdentityMarker || '',
+    }
+  }).sort((left, right) => left.key.localeCompare(right.key)))
   expect(await proofPanel.locator('.live-walker').evaluateAll(walkers => {
     const moving = new Set([...document.querySelectorAll(
       '#live-panel[data-live-proof="true"] .live-replay-portrait [data-live-resident-handle]',
@@ -3200,6 +3217,16 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
   }
   expect(sawUse).toBe(true)
   await expect(replays).toHaveCount(0)
+  const settledProofIdentity = await proofStageNodes.evaluateAll(nodes => nodes.map(node => {
+    const sprite = node.querySelector<HTMLElement>(':scope .live-entity-portrait')
+    return {
+      key: (node as HTMLElement).dataset.stageNodeKey || '',
+      nodeMarker: (node as HTMLElement).dataset.stageProofIdentityMarker || '',
+      spriteMarker: sprite?.dataset.stageProofIdentityMarker || '',
+    }
+  }).sort((left, right) => left.key.localeCompare(right.key)))
+  expect(settledProofIdentity, JSON.stringify({ proofIdentity, settledProofIdentity }))
+    .toEqual(proofIdentity)
   const scriptedBubble = page.locator('.live-speech-bubble')
   await expect(scriptedBubble).toHaveText('The workshop bell rings above the busy floor.')
   expect(await workshopTerrain.evaluate(node =>
@@ -3226,6 +3253,95 @@ test('discoverable preview proof scene visibly demonstrates every Live behavior 
   await proofButton.click()
   await expect(proofPanel).toBeVisible()
   await expect(page.getByRole('button', { name: 'Retry proof room' })).toBeVisible()
+})
+
+test('persistent stage sprite nodes keep their identity through 20 repaints', async ({ page }) => {
+  await installReplayRoutes(page, Date.now())
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const stageNodes = page.locator(
+    '[data-stage-node-key^="resident:"], [data-stage-node-key^="thing:"]',
+  )
+  await expect(stageNodes).not.toHaveCount(0)
+  const firstPaint = await stageNodes.evaluateAll(nodes => nodes.map((node, index) => {
+    const nodeMarker = `stage-node-${index}-${crypto.randomUUID()}`
+    const spriteMarker = `stage-sprite-${index}-${crypto.randomUUID()}`
+    const sprite = node.querySelector<HTMLElement>(':scope .live-entity-portrait')
+    ;(node as HTMLElement).dataset.stageIdentityMarker = nodeMarker
+    if (sprite) sprite.dataset.stageIdentityMarker = spriteMarker
+    return {
+      key: (node as HTMLElement).dataset.stageNodeKey || '',
+      nodeMarker,
+      spriteMarker: sprite?.dataset.stageIdentityMarker || '',
+    }
+  }))
+
+  for (let repaint = 0; repaint < 20; repaint += 1) {
+    const paintMarker = `paint-${repaint}`
+    await page.locator('.live-trace-layer').evaluate((node, marker) => {
+      ;(node as HTMLElement).dataset.stagePaintMarker = marker
+    }, paintMarker)
+    await page.evaluate(() => window.dispatchEvent(new Event('resize')))
+    await expect.poll(() => page.locator('.live-trace-layer')
+      .getAttribute('data-stage-paint-marker')).not.toBe(paintMarker)
+  }
+
+  const afterRepaints = await stageNodes.evaluateAll(nodes => nodes.map(node => {
+    const sprite = node.querySelector<HTMLElement>(':scope .live-entity-portrait')
+    return {
+      key: (node as HTMLElement).dataset.stageNodeKey || '',
+      nodeMarker: (node as HTMLElement).dataset.stageIdentityMarker || '',
+      spriteMarker: sprite?.dataset.stageIdentityMarker || '',
+    }
+  }))
+  expect(afterRepaints, JSON.stringify({ firstPaint, afterRepaints })).toEqual(firstPaint)
+})
+
+test('a stage sprite flips --facing on left and right walks without rotating', async ({ page }) => {
+  const now = Date.now()
+  await page.clock.install({ time: new Date(now) })
+  const fixture = await installReplayRoutes(page, now, 'complete', 0, {
+    oppositeFacingMoves: true,
+  })
+  await page.goto('/window#view=live')
+  await expect(page.locator('#live-history-status')).toContainText('history is complete')
+  const spriteKey = 'resident:5'
+  await page.locator(`[data-stage-node-key="${spriteKey}"] .live-portrait`)
+    .evaluate(node => (node as HTMLButtonElement).click())
+  await expect(page.locator('#live-focus-status')).toContainText('Focused on map-walker')
+  await page.getByRole('button', { name: 'Center live view' }).click()
+  await publishReplayChanges(page, fixture)
+
+  await expect.poll(() => page.locator(
+    `[data-stage-node-key="${spriteKey}"]`,
+  ).count()).toBe(1)
+  const facings = new Set<string>()
+  const observations = new Set<string>()
+  for (let elapsed = 0; elapsed < 30_000; elapsed += 300) {
+    await page.clock.runFor(300)
+    await page.getByRole('button', { name: 'Center live view' })
+      .evaluate(node => (node as HTMLButtonElement).click())
+    const sample = await page.evaluate(key => {
+      const node = document.querySelector<HTMLElement>(`[data-stage-node-key="${key}"]`)
+      return node ? {
+        facing: getComputedStyle(node).getPropertyValue('--facing').trim(),
+        transform: node.style.transform,
+        movement: node.dataset.liveMovement || '',
+        from: node.dataset.fromPlaceId || '',
+        to: node.dataset.toPlaceId || '',
+        offsetPath: node.style.offsetPath,
+      } : null
+    }, spriteKey)
+    if (!sample) continue
+    if (sample.facing) facings.add(sample.facing)
+    observations.add(JSON.stringify(sample))
+  }
+
+  const operands = JSON.stringify({ facings: [...facings], observations: [...observations] })
+  expect([...facings], operands).toContain('-1')
+  expect([...facings], operands).toContain('1')
+  expect([...observations].every(observation => !/rotate\s*\(/u.test(observation)), operands)
+    .toBe(true)
 })
 
 test('exiting the preview proof scene restores ordinary place choices without a reload', async ({ page }) => {
@@ -3890,7 +4006,12 @@ test('new change rows replay once in recorded order and leave truthful residue',
   const fixture = await installReplayRoutes(page, now)
   await page.goto('/window#view=live')
   await expect(page.locator('#live-history-status')).toContainText('history is complete')
-
+  const stableThing = page.locator('[data-stage-node-key="thing:21"]')
+  await expect(stableThing).toHaveCount(1)
+  const stableThingMarker = `stable-thing-${crypto.randomUUID()}`
+  await stableThing.evaluate((node, marker) => {
+    ;(node as HTMLElement).dataset.stageIdentityMarker = marker
+  }, stableThingMarker)
   await publishReplayChanges(page, fixture)
   const replay = page.locator('.live-replay-portrait')
   await expect(replay).toHaveCount(1)
@@ -3903,43 +4024,51 @@ test('new change rows replay once in recorded order and leave truthful residue',
   await expect(replay).toHaveAttribute('data-live-movement', 'detail')
   expect(Number(await replay.getAttribute('data-live-route-point-count')))
     .toBeGreaterThanOrEqual(3)
-  // The replay shell is rebuilt by every live render, so a raw evaluate can land
-  // on a node the next render already detached; closest() then returns null.
-  // Retry the measurement; a target permanently outside the stage still fails.
+  // The registry keeps the replay shell attached across paints. Geometry still
+  // retries because animation and camera work can temporarily withhold a box.
   const replayPosition = async () => {
-    let measured: { x: number, y: number } | null = null
+    let measured: {
+      box: DOMRectJSON | null
+      headTime: number
+      point: { x: number, y: number } | null
+      recordId: string | null
+    } | null = null
     await expect.poll(async () => {
-      measured = await replay.evaluate(node => {
-        const stage = node.closest('.live-stage') as HTMLElement | null
-        if (!stage) return null
+      measured = await page.evaluate(() => {
+        const node = document.querySelector<HTMLElement>('.live-replay-portrait')
+        const stage = node?.closest<HTMLElement>('.live-stage') || null
+        if (!node || !stage) return {
+          box: null,
+          headTime: Date.now(),
+          point: null,
+          recordId: node?.dataset.liveReplayKey || null,
+        }
         const ground = stage.getBoundingClientRect()
         const box = node.getBoundingClientRect()
         const scale = ground.width / Number(stage.dataset.liveStageWidth)
         return {
-          x: (box.left + box.width / 2 - ground.left) / scale,
-          y: (box.bottom - ground.top) / scale,
+          box: box.toJSON(),
+          headTime: Date.now(),
+          point: {
+            x: (box.left + box.width / 2 - ground.left) / scale,
+            y: (box.bottom - ground.top) / scale,
+          },
+          recordId: node.dataset.liveReplayKey || null,
         }
       })
-      return measured !== null
-    }).toBe(true)
-    return measured!
+      return measured
+    }).toMatchObject({
+      box: expect.any(Object),
+      headTime: expect.any(Number),
+      point: { x: expect.any(Number), y: expect.any(Number) },
+      recordId: 'change:11',
+    })
+    return measured!.point!
   }
   const initialPosition = await replayPosition()
   await expect(page.locator('.live-footnote-mark')).toHaveCount(0)
   await expect(page.locator('.live-speech-bubble')).toHaveCount(0)
   await expect(page.locator('.live-thing-specimen.live-pulse')).toHaveCount(0)
-  await replay.locator('.live-portrait').evaluate(node => (node as HTMLButtonElement).click())
-  await expect(page.locator('#live-focus-status')).toContainText('Focused on map-walker')
-  await expect(page.locator('#live-label-layer [data-live-resident-tag="map-walker"]'))
-    .toBeVisible()
-  await page.evaluate(() => {
-    const trackedWindow = window as Window & { liveLabelChildMutations?: number }
-    trackedWindow.liveLabelChildMutations = 0
-    new MutationObserver(records => {
-      trackedWindow.liveLabelChildMutations = Number(trackedWindow.liveLabelChildMutations) +
-        records.filter(record => record.type === 'childList').length
-    }).observe(document.querySelector('#live-label-layer')!, { childList: true })
-  })
   const movementSampleMs = Math.ceil(duration * 0.3)
   await page.clock.runFor(movementSampleMs)
   const midpoint = await replayPosition()
@@ -3947,29 +4076,12 @@ test('new change rows replay once in recorded order and leave truthful residue',
     midpoint.x - initialPosition.x,
     midpoint.y - initialPosition.y,
   )).toBeGreaterThan(10)
-  const focusedTag = page.locator(
-    '#live-label-layer [data-live-resident-tag="map-walker"]',
-  )
-  await expect.poll(async () => {
-    const portraitBounds = await replay.locator('.live-portrait').boundingBox()
-    const tagBounds = await focusedTag.boundingBox()
-    if (!portraitBounds || !tagBounds) return Number.POSITIVE_INFINITY
-    return Math.abs(
-      portraitBounds.x + portraitBounds.width / 2 -
-      (tagBounds.x + tagBounds.width / 2),
-    )
-  }).toBeLessThan(3)
-  expect(await page.evaluate(() => Number(
-    (window as Window & { liveLabelChildMutations?: number }).liveLabelChildMutations,
-  ))).toBeLessThanOrEqual(1)
-  await replay.locator('.live-portrait').evaluate(node => (node as HTMLButtonElement).click())
-  await expect(page.locator('#live-focus-status')).toContainText('No resident focused')
 
   await page.clock.fastForward(duration - movementSampleMs + 251)
   const absorbedResidents = page.locator('[data-place-id="3"] .live-resident-more')
-  await expect(absorbedResidents).toHaveText('+4 more')
+  await expect(absorbedResidents).toHaveText('+3 more')
   await expect(absorbedResidents).toHaveClass(/live-overflow-absorbing/u)
-  await expect(absorbedResidents).toHaveAttribute('data-live-overflow-count', '4')
+  await expect(absorbedResidents).toHaveAttribute('data-live-overflow-count', '3')
   await expect(absorbedResidents).toHaveCSS('opacity', '1')
   const thingOverflow = page.locator('[data-place-id="3"] .live-thing-more')
   await expect(thingOverflow).toHaveText('+3 more')
@@ -3986,44 +4098,16 @@ test('new change rows replay once in recorded order and leave truthful residue',
   await page.clock.fastForward(651)
   const pulsedThing = page.locator('.live-thing-specimen.live-pulse')
   await expect(pulsedThing).toHaveCount(0)
-  const stableLantern = page.locator('[data-place-id="3"] [data-live-thing-id="9"]')
-  await expect(stableLantern).toHaveCount(1)
-  await expect(stableLantern).not.toHaveClass(/live-pulse/u)
+  await expect(page.locator('[data-stage-node-key="thing:9"]')).toHaveCount(0)
+  await expect(stableThing).toHaveAttribute('data-stage-identity-marker', stableThingMarker)
+  await expect(stableThing).not.toHaveClass(/live-pulse/u)
   await expect(page.locator('.live-action-mark')).toHaveCount(0)
 
   await page.clock.fastForward(600)
   await expect(replay).toHaveCount(0)
   await expect(page.locator('.live-thing-specimen.live-pulse')).toHaveCount(0)
-  const settledWalker = page.locator(
-    '[data-place-id="3"] [data-live-resident-handle="map-walker"]',
-  ).first()
-  // Same hardening as replayPosition: a render between resolution and evaluate
-  // can detach the walker, so measure until the node reads from a live stage.
-  let settledPoint: { x: number, y: number } | null = null
-  await expect.poll(async () => {
-    settledPoint = await settledWalker.evaluate(node => {
-      const shell = node.closest('.live-walker') as HTMLElement | null
-      const stage = node.closest('.live-stage') as HTMLElement | null
-      if (!shell || !stage) return null
-      const ground = stage.getBoundingClientRect()
-      const box = shell.getBoundingClientRect()
-      const scale = ground.width / Number(stage.dataset.liveStageWidth)
-      return {
-        x: (box.left + box.width / 2 - ground.left) / scale,
-        y: (box.bottom - ground.top) / scale,
-      }
-    })
-    return settledPoint !== null
-  }).toBe(true)
-  settledPoint = settledPoint!
-  expect(Math.hypot(
-    settledPoint.x - initialPosition.x,
-    settledPoint.y - initialPosition.y,
-  )).toBeGreaterThan(10)
+  await expect(page.locator('[data-stage-node-key="resident:5"]')).toHaveCount(0)
   await expect(page.locator('.live-footnote-mark')).toHaveCount(2)
-  const platePortrait = page.locator('#live-plates [data-live-resident-handle="map-walker"]')
-  await expect(platePortrait).toHaveAccessibleName(/map-walker/u)
-  await expect(platePortrait).not.toHaveAccessibleName(/Earlier|L{10}/u)
 
   await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))
   await page.clock.fastForward(100)
@@ -4981,15 +5065,25 @@ test('a 215-resident plate reports frame time while all 64 residents move', asyn
   expect(result.cameraMoves).toBe(60)
 })
 
-test('sixty-four simultaneous walks complete in one painted batch', async ({ page }) => {
+test('sixty-four simultaneous walks complete in one paint without rebuilding stable nodes', async ({ page }) => {
   const now = Date.now()
   await page.clock.install({ time: new Date(now) })
+  await installLiveRenderWorkRecorder(page)
   const fixture = await installReplayRoutes(page, now, 'complete', 0, {
     simultaneousMoves: 64,
   })
   await page.goto('/window#view=live')
   await expect(page.locator('#live-history-status')).toContainText('history is complete')
   await expect(page.locator('.live-replay-portrait')).toHaveCount(0)
+  const stableNodes = page.locator(
+    '[data-stage-node-key^="resident:"]:not([data-stage-node-key="resident:5"])',
+  )
+  const stableNodeIdentity = await stableNodes.evaluateAll(nodes => nodes.map(node => {
+    const marker = crypto.randomUUID()
+    ;(node as HTMLElement).dataset.stageCompletionMarker = marker
+    return { key: (node as HTMLElement).dataset.stageNodeKey || '', marker }
+  }).sort((left, right) => left.key.localeCompare(right.key)))
+  expect(stableNodeIdentity.length).toBeGreaterThan(0)
   await publishReplayChanges(page, fixture)
   const replays = page.locator('.live-replay-portrait')
   let durations: number[] = []
@@ -4998,6 +5092,13 @@ test('sixty-four simultaneous walks complete in one painted batch', async ({ pag
       Number((node as HTMLElement).dataset.replayDuration)))
     return durations.length
   }).toBe(64)
+  const replayAccessibility = await replays.evaluateAll(nodes => nodes.map(node => {
+    const portrait = node.querySelector<HTMLElement>('[data-live-resident-handle]')
+    const actor = portrait?.dataset.liveResidentHandle || ''
+    return { actor, name: portrait?.getAttribute('aria-label') || '' }
+  }))
+  expect(replayAccessibility.every(entry => entry.name.includes(entry.actor) &&
+    !/Earlier|L{10}/u.test(entry.name)), JSON.stringify(replayAccessibility)).toBe(true)
   expect(new Set(durations).size).toBe(1)
   await expect.poll(() => page.locator('.live-footstep').count()).toBeGreaterThan(0)
   const footstepBudget = await page.locator('#live-plates').evaluate(plates => {
@@ -5016,9 +5117,61 @@ test('sixty-four simultaneous walks complete in one painted batch', async ({ pag
   expect(footstepBudget.actors.length).toBeLessThanOrEqual(6)
   expect(footstepBudget.counts.every(count => count >= 2 && count <= 3)).toBe(true)
   expect(footstepBudget.total).toBeLessThanOrEqual(18)
+  const focusedReplay = replays.first()
+  const focusedHandle = await focusedReplay.locator('[data-live-resident-handle]')
+    .getAttribute('data-live-resident-handle')
+  const focusedNodeKey = await focusedReplay.getAttribute('data-stage-node-key')
+  const focusedStageNode = page.locator(`[data-stage-node-key="${focusedNodeKey}"]`)
+  await page.getByRole('button', { name: 'Pause walks' }).click()
+  await expect(page.getByRole('button', { name: 'Resume walks' })).toBeVisible()
+  await focusedStageNode.locator('.live-portrait')
+    .evaluate(node => (node as HTMLButtonElement).click())
+  await expect(page.locator('#live-focus-status')).toContainText(`Focused on ${focusedHandle}`)
+  await page.getByRole('button', { name: 'Center live view' }).click()
   await page.locator('#live-viewport').focus()
-  await page.locator('#live-viewport').evaluate(async viewport => {
-    const anchor = document.querySelector('.live-replay-portrait')!.getBoundingClientRect()
+  let anchorSample: {
+    actor: string | null
+    headTime: number
+    point: { x: number, y: number } | null
+    recordId: string | null
+    rectangle: DOMRectJSON | null
+  } | null = null
+  await expect.poll(async () => {
+    anchorSample = await page.evaluate(nodeKey => {
+      const node = document.querySelector<HTMLElement>(
+        '[data-stage-node-key="' + CSS.escape(String(nodeKey)) + '"]')
+      const stage = node?.closest<HTMLElement>('.live-stage') || null
+      const portrait = node?.querySelector<HTMLElement>('[data-live-resident-handle]') || null
+      if (!node || !stage || !portrait) return {
+        actor: portrait?.dataset.liveResidentHandle || null,
+        headTime: Date.now(),
+        point: null,
+        recordId: node?.dataset.stageNodeKey || null,
+        rectangle: null,
+      }
+      const rectangle = node.getBoundingClientRect()
+      const stageRectangle = stage.getBoundingClientRect()
+      const scale = stageRectangle.width / Number(stage.dataset.liveStageWidth)
+      return {
+        actor: portrait.dataset.liveResidentHandle || null,
+        headTime: Date.now(),
+        point: {
+          x: (rectangle.left + rectangle.width / 2 - stageRectangle.left) / scale,
+          y: (rectangle.bottom - stageRectangle.top) / scale,
+        },
+        recordId: node.dataset.stageNodeKey || null,
+        rectangle: rectangle.toJSON(),
+      }
+    }, focusedNodeKey)
+    return anchorSample
+  }).toMatchObject({
+    actor: expect.stringMatching(/^walker-burst-/u),
+    headTime: expect.any(Number),
+    point: { x: expect.any(Number), y: expect.any(Number) },
+    recordId: focusedNodeKey,
+    rectangle: expect.any(Object),
+  })
+  await page.locator('#live-viewport').evaluate(async (viewport, anchor) => {
     for (let index = 0; index < 12; index += 1) {
       viewport.dispatchEvent(new WheelEvent('wheel', {
         bubbles: true,
@@ -5029,7 +5182,7 @@ test('sixty-four simultaneous walks complete in one painted batch', async ({ pag
       }))
     }
     await new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-  })
+  }, anchorSample!.rectangle!)
   await expect(page.locator('#live-stage')).toHaveAttribute('data-live-label-mode', 'readable')
   await expect.poll(() => page.locator(
     '#live-label-layer [data-live-packed="true"][data-live-resident-tag^="walker-burst-"]',
@@ -5058,40 +5211,21 @@ test('sixty-four simultaneous walks complete in one painted batch', async ({ pag
     return heldWindow.liveLabelGeometryReads ?? 0
   })
   expect(labelGeometryReads).toBeLessThan(1_000)
-  await page.evaluate(() => {
-    const heldWindow = window as typeof window & {
-      liveCompletionMutations?: number
-      liveCompletionObserver?: MutationObserver
-    }
-    heldWindow.liveCompletionMutations = 0
-    // Count only childList records that net-remove replay portraits: runFor also drives ordinary
-    // motion repaints of #live-plates (7 to 8 records) that are not completions. A per-completion
-    // paint would still net-remove one portrait each, so 64 unbatched completions would still count 64.
-    heldWindow.liveCompletionObserver = new MutationObserver(records => {
-      const replayCount = (nodes: NodeList) => [...nodes].reduce((count, node) => {
-        if (!(node instanceof Element)) return count
-        return count + Number(node.matches('.live-replay-portrait')) +
-          node.querySelectorAll('.live-replay-portrait').length
-      }, 0)
-      heldWindow.liveCompletionMutations! += records.filter(record =>
-        replayCount(record.removedNodes) > replayCount(record.addedNodes)).length
-    })
-    heldWindow.liveCompletionObserver.observe(document.querySelector('#live-plates')!, {
-      childList: true,
-    })
-  })
-
+  await page.getByRole('button', { name: 'Resume walks' }).click()
+  await resetLiveRenderWork(page)
   await page.clock.runFor(durations[0]! + 270)
   await expect(replays).toHaveCount(0)
-  const completionMutations = await page.evaluate(() => {
-    const heldWindow = window as typeof window & {
-      liveCompletionMutations?: number
-      liveCompletionObserver?: MutationObserver
-    }
-    heldWindow.liveCompletionObserver?.disconnect()
-    return heldWindow.liveCompletionMutations ?? 0
-  })
-  expect(completionMutations).toBeLessThanOrEqual(2)
+  const completionWork = await readLiveRenderWork(page)
+  expect(completionWork.renders, JSON.stringify(completionWork)).toBeLessThanOrEqual(2)
+  const settledNodeIdentity = await stableNodes.evaluateAll(nodes => nodes.map(node => ({
+    key: (node as HTMLElement).dataset.stageNodeKey || '',
+    marker: (node as HTMLElement).dataset.stageCompletionMarker || '',
+  })).sort((left, right) => left.key.localeCompare(right.key)))
+  const stableMarkers = new Map(stableNodeIdentity.map(entry => [entry.key, entry.marker]))
+  const survivingStableNodes = settledNodeIdentity.filter(entry => stableMarkers.has(entry.key))
+  expect(survivingStableNodes.length).toBeGreaterThan(0)
+  expect(survivingStableNodes.every(entry => stableMarkers.get(entry.key) === entry.marker),
+    JSON.stringify({ stableNodeIdentity, settledNodeIdentity })).toBe(true)
   await expect(page.locator('.live-trail')).toHaveCount(0)
   expect(await page.locator('.live-footstep').count()).toBeLessThanOrEqual(18)
   const movedRows = page.locator('#live-roster .resident-row')
@@ -5219,6 +5353,7 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
         y: element.dataset.livePlotY,
         width: element.dataset.livePlotWidth,
         height: element.dataset.livePlotHeight,
+        marker: element.dataset.stageCrowdMarker,
       }
     }))
   await page.clock.install({ time: new Date(now) })
@@ -5230,6 +5365,21 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
   await page.goto('/window#view=live')
   await expect(page.locator('#live-history-status')).toContainText('history is complete')
   await expect(page.locator('.live-replay-portrait')).toHaveCount(0)
+  const registeredIdentityBefore = await page.locator(
+    '[data-stage-node-key^="resident:"]:not([data-stage-node-key="resident:5"]), ' +
+      '[data-stage-node-key^="place:"]',
+  ).evaluateAll(nodes => nodes.map(node => {
+    const element = node as HTMLElement
+    element.dataset.stageCrowdMarker ||= crypto.randomUUID()
+    return {
+      key: element.dataset.stageNodeKey || '',
+      marker: element.dataset.stageCrowdMarker,
+    }
+  }).sort((left, right) => left.key.localeCompare(right.key)))
+  const readRegisteredIdentity = () => page.evaluate(keys => keys.map(key => {
+    const node = document.querySelector<HTMLElement>(`[data-stage-node-key="${key}"]`)
+    return { key, marker: node?.dataset.stageCrowdMarker || null }
+  }), registeredIdentityBefore.map(entry => entry.key))
   const stableResidentsBefore = await stableResidentPositions()
   const fixedPlotsBefore = await fixedPlotPositions()
   expect(fixedPlotsBefore).toHaveLength(detailedPlotCount)
@@ -5263,7 +5413,14 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
   const replays = page.locator('.live-replay-portrait')
   await expect(replays).toHaveCount(0, { timeout: 25_000 })
   const stableResidentsDuring = await stableResidentPositions()
-  // A paint can briefly replace every plot; retain the first complete settled sample.
+  let registeredIdentityDuring: typeof registeredIdentityBefore = []
+  await expect.poll(async () => {
+    registeredIdentityDuring = await readRegisteredIdentity()
+    return registeredIdentityDuring.some(entry => entry.marker === null)
+      ? null
+      : registeredIdentityDuring
+  }, { timeout: 25_000 }).toEqual(registeredIdentityBefore)
+  // Reconciled plots stay attached; poll only for the completed position update.
   let fixedPlotsDuring: typeof fixedPlotsBefore = []
   await expect.poll(async () => {
     fixedPlotsDuring = await fixedPlotPositions()
@@ -5304,6 +5461,7 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
   await expect(page.locator('.live-trail')).toHaveCount(0)
   const stableResidentsAfter = await stableResidentPositions()
   const fixedPlotsAfter = await fixedPlotPositions()
+  const registeredIdentityAfter = await readRegisteredIdentity()
 
   const rosterOutcomes = await page.locator('#live-roster .resident-row').evaluateAll(rows =>
     rows.flatMap(row => {
@@ -5358,6 +5516,8 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
       JSON.stringify(resident) === JSON.stringify(stableResidentsBefore[index])) &&
     JSON.stringify(fixedPlotsDuring) === JSON.stringify(fixedPlotsBefore) &&
     JSON.stringify(fixedPlotsAfter) === JSON.stringify(fixedPlotsBefore) &&
+    JSON.stringify(registeredIdentityDuring) === JSON.stringify(registeredIdentityBefore) &&
+    JSON.stringify(registeredIdentityAfter) === JSON.stringify(registeredIdentityBefore) &&
     rosterOutcomes.length === actorCount && missingRosterActors.length === 0 &&
     wrongCurrentPlaces.length === 0, JSON.stringify({
       renders: work.renders,
@@ -5391,6 +5551,9 @@ test('eight legal change pages settle 1,600 actors without rebuilding crowd memb
       fixedPlotsBefore,
       fixedPlotsDuring,
       fixedPlotsAfter,
+      registeredIdentityBefore,
+      registeredIdentityDuring,
+      registeredIdentityAfter,
       rosterActorCount: rosterOutcomes.length,
       missingRosterActors: missingRosterActors.slice(0, 10),
       wrongCurrentPlaces: wrongCurrentPlaces.slice(0, 10),
@@ -5410,6 +5573,8 @@ test('a moving resident returning to readable ground receives a bounded label re
   const replays = page.locator('.live-replay-portrait')
   await expect.poll(() => replays.count()).toBeGreaterThan(0)
   await expect(replays).toHaveCount(64)
+  await page.getByRole('button', { name: 'Pause walks' }).click()
+  await expect(page.getByRole('button', { name: 'Resume walks' })).toBeVisible()
   await page.locator('#live-viewport').evaluate(async viewport => {
     const rect = viewport.getBoundingClientRect()
     for (let index = 0; index < 12; index += 1) {
@@ -5426,25 +5591,74 @@ test('a moving resident returning to readable ground receives a bounded label re
   const returningReplay = replays.first()
   const returningHandle = await returningReplay.locator('[data-live-resident-handle]')
     .getAttribute('data-live-resident-handle')
-  await returningReplay.evaluate((node, handle) => {
-    const shell = node as HTMLElement
-    const stage = document.querySelector('#live-stage') as HTMLElement
-    const viewport = document.querySelector('#live-viewport') as HTMLElement
-    const scale = Number(stage.dataset.liveScale)
-    const offsetX = Number(stage.dataset.liveOffsetX)
-    const offsetY = Number(stage.dataset.liveOffsetY)
-    shell.style.animation = 'none'
-    shell.style.left = String((viewport.clientWidth / 2 - offsetX) / scale) + 'px'
-    shell.style.top = String((viewport.clientHeight / 2 - offsetY) / scale) + 'px'
-    shell.dataset.liveFocusResident = String(handle)
-    ;(node.querySelector('.live-portrait') as HTMLElement).focus()
-  }, returningHandle)
+  const returningNodeKey = await returningReplay.getAttribute('data-stage-node-key')
+  const returningStageNode = page.locator(
+    `[data-stage-node-key="${returningNodeKey}"]`,
+  )
+  await returningReplay.locator('.live-portrait')
+    .evaluate(node => (node as HTMLButtonElement).click())
+  await expect(page.locator('#live-focus-status')).toContainText(`Focused on ${returningHandle}`)
+  await page.getByRole('button', { name: 'Center live view' }).click()
+  await returningReplay.locator('.live-portrait').focus()
   await expect(page.locator(
     `#live-label-layer [data-live-resident-tag="${returningHandle}"]`,
   )).toBeVisible()
-  await expect(page.locator(
-    `#live-label-layer [data-live-resident-tag="${returningHandle}"]`,
-  )).toBeVisible({ timeout: 750 })
+  await page.evaluate(() => {
+    const heldWindow = window as Window & { liveLabelChildMutations?: number }
+    heldWindow.liveLabelChildMutations = 0
+    new MutationObserver(records => {
+      heldWindow.liveLabelChildMutations = Number(heldWindow.liveLabelChildMutations) +
+        records.filter(record => record.type === 'childList').length
+    }).observe(document.querySelector('#live-label-layer')!, { childList: true })
+  })
+  let labelSample: {
+    actor: string | null
+    delta: number | null
+    headTime: number
+    point: { x: number, y: number } | null
+    recordId: string | null
+    rectangle: DOMRectJSON | null
+  } | null = null
+  await expect.poll(async () => {
+    labelSample = await page.evaluate(({ handle, nodeKey }) => {
+      const shell = document.querySelector<HTMLElement>(
+        '[data-stage-node-key="' + CSS.escape(String(nodeKey)) + '"]')
+      const portrait = shell?.querySelector<HTMLElement>('[data-live-resident-handle]') || null
+      const tag = document.querySelector<HTMLElement>(
+        '#live-label-layer [data-live-resident-tag="' + CSS.escape(String(handle)) + '"]')
+      if (!portrait || !tag || !shell) return {
+        actor: handle, delta: null, headTime: Date.now(), point: null,
+        recordId: shell?.dataset.stageNodeKey || null, rectangle: null,
+      }
+      const portraitRect = portrait.getBoundingClientRect()
+      const tagRect = tag.getBoundingClientRect()
+      return {
+        actor: handle,
+        delta: Math.abs(portraitRect.x + portraitRect.width / 2 -
+          (tagRect.x + tagRect.width / 2)),
+        headTime: Date.now(),
+        point: { x: portraitRect.x + portraitRect.width / 2, y: portraitRect.bottom },
+        recordId: shell.dataset.stageNodeKey || null,
+        rectangle: portraitRect.toJSON(),
+      }
+    }, { handle: returningHandle, nodeKey: returningNodeKey })
+    return labelSample
+  }).toMatchObject({
+    actor: returningHandle,
+    delta: expect.any(Number),
+    headTime: expect.any(Number),
+    point: { x: expect.any(Number), y: expect.any(Number) },
+    recordId: returningNodeKey,
+    rectangle: expect.any(Object),
+  })
+  expect(labelSample!.delta, JSON.stringify(labelSample)).toBeLessThan(3)
+  expect(await page.evaluate(() => Number(
+    (window as Window & { liveLabelChildMutations?: number }).liveLabelChildMutations,
+  ))).toBeLessThanOrEqual(1)
+  await returningStageNode.locator('.live-portrait')
+    .evaluate(node => (node as HTMLButtonElement).click())
+  await expect(page.locator('#live-focus-status')).toContainText('No resident focused')
+  await page.getByRole('button', { name: 'Resume walks' }).click()
 })
 
 test('turning on reduced motion mid-walk preserves the final fading trail', async ({ page }) => {
@@ -6352,10 +6566,8 @@ test('the popover never covers the item it describes, and closes on Escape with 
 })
 
 test('a press outside the popover closes it; a press on the popover neither closes it nor pans the plate', async ({ page }) => {
-  // The clock is frozen so this fixture's own recorded-movement replay
-  // never rebuilds the plate mid-test (which would, correctly, close the
-  // popover under rule C5 -- its anchor left the plate -- but that is a
-  // different behavior than this test is checking).
+  // The clock is frozen so this test isolates press behavior from recorded
+  // movement while the popover remains anchored to its registered node.
   const now = Date.now()
   await page.clock.install({ time: new Date(now) })
   await installReplayRoutes(page, now)
@@ -6500,14 +6712,27 @@ test('proof: one popover carries what the chips carried, for one resident, one t
   await expect(popover).toBeVisible()
   await expect(popover).toContainText('proof-cato')
   await expect(popover).toContainText('resident #9203')
-  const catoBox = await cato.boundingBox()
-  const catoPopoverBox = await popover.boundingBox()
-  expect(catoBox && catoPopoverBox).toBeTruthy()
-  const catoIntersects = catoPopoverBox!.x < catoBox!.x + catoBox!.width &&
-    catoPopoverBox!.x + catoPopoverBox!.width > catoBox!.x &&
-    catoPopoverBox!.y < catoBox!.y + catoBox!.height &&
-    catoPopoverBox!.y + catoPopoverBox!.height > catoBox!.y
-  expect(catoIntersects).toBe(false)
+  let catoGeometry: {
+    anchor: Awaited<ReturnType<typeof cato.boundingBox>>
+    popover: Awaited<ReturnType<typeof popover.boundingBox>>
+  } = { anchor: null, popover: null }
+  await expect.poll(async () => {
+    const [anchor, popoverBox] = await Promise.all([
+      cato.boundingBox(), popover.boundingBox(),
+    ])
+    catoGeometry = { anchor, popover: popoverBox }
+    return catoGeometry
+  }).toMatchObject({
+    anchor: { x: expect.any(Number), y: expect.any(Number) },
+    popover: { x: expect.any(Number), y: expect.any(Number) },
+  })
+  const catoBox = catoGeometry.anchor!
+  const catoPopoverBox = catoGeometry.popover!
+  const catoIntersects = catoPopoverBox.x < catoBox.x + catoBox.width &&
+    catoPopoverBox.x + catoPopoverBox.width > catoBox.x &&
+    catoPopoverBox.y < catoBox.y + catoBox.height &&
+    catoPopoverBox.y + catoPopoverBox.height > catoBox.y
+  expect(catoIntersects, JSON.stringify(catoGeometry)).toBe(false)
   await page.keyboard.press('Escape')
   await expect(popover).toBeHidden()
   await expect(cato).toBeFocused()
@@ -6539,6 +6764,9 @@ test('proof: one popover carries what the chips carried, for one resident, one t
   await expect(popover).toContainText('kept by proof-alex')
   await expect(popover).toContainText('Preview-only Live View proof ground.')
   await expect(popover).toContainText('7 things')
+  await page.mouse.move(0, 0)
+  await workshopOpen.focus()
+  await expect(popover).toBeVisible()
   await page.keyboard.press('Escape')
   await expect(popover).toBeHidden()
 

--- a/src/window-client.ts
+++ b/src/window-client.ts
@@ -119,4 +119,13 @@ export type {
 export { normalizeLiveNotesPage } from './window-client/live-notes.ts'
 export type { WindowLiveNote, WindowLiveNotesPage } from './window-client/live-notes.ts'
 
+export {
+  stageNodeKey,
+  reconcileStageNodeKeys,
+  stageDrawnNodeKeys,
+  stageFacing,
+  stageTransform,
+} from './window-client/stage-nodes.ts'
+export type { StageNodeKind, StageNodeDiff } from './window-client/stage-nodes.ts'
+
 export const WINDOW_JS = WINDOW_CLIENT_PARTS.join('')

--- a/src/window-client/live-replay.ts
+++ b/src/window-client/live-replay.ts
@@ -127,14 +127,10 @@ export function windowLiveShouldScheduleRedraw(input: Readonly<{
   liveViewActive: boolean
   documentVisible: boolean
   panelVisible: boolean
-  dirtyRevision: number
-  paintedRevision: number
   framePending: boolean
 }>): boolean {
   return input.liveViewActive === true && input.documentVisible === true &&
-    input.panelVisible === true && input.framePending === false &&
-    Number.isSafeInteger(input.dirtyRevision) && Number.isSafeInteger(input.paintedRevision) &&
-    input.dirtyRevision > input.paintedRevision
+    input.panelVisible === true && input.framePending === false
 }
 
 export function windowLiveFootstepBeat(

--- a/src/window-client/program/01-prelude.ts
+++ b/src/window-client/program/01-prelude.ts
@@ -85,6 +85,13 @@ import {
   windowLiveItemPopoverPlacement,
 } from '../live-popover.ts'
 import { normalizeLiveNotesPage } from '../live-notes.ts'
+import {
+  stageNodeKey,
+  reconcileStageNodeKeys,
+  stageDrawnNodeKeys,
+  stageFacing,
+  stageTransform,
+} from '../stage-nodes.ts'
 const PUBLIC_EVENT_LABELS_JSON = JSON.stringify(PUBLIC_EVENT_LABELS)
 const PUBLIC_EVENT_DETAIL_ID_FIELDS_JSON = JSON.stringify(PUBLIC_EVENT_DETAIL_ID_FIELDS)
 const PUBLIC_SYSTEM_EVENT_ACTORS_JSON = JSON.stringify(Object.values(PUBLIC_SYSTEM_EVENT_ACTORS))
@@ -148,6 +155,11 @@ const WINDOW_LIVE_ITEM_FACTS_JS = windowLiveItemFacts.toString()
 const WINDOW_LIVE_ITEM_LAST_ACTION_JS = windowLiveItemLastAction.toString()
 const WINDOW_LIVE_ITEM_POPOVER_PLACEMENT_JS = windowLiveItemPopoverPlacement.toString()
 const NORMALIZE_LIVE_NOTES_PAGE_JS = normalizeLiveNotesPage.toString()
+const STAGE_NODE_KEY_JS = stageNodeKey.toString()
+const RECONCILE_STAGE_NODE_KEYS_JS = reconcileStageNodeKeys.toString()
+const STAGE_DRAWN_NODE_KEYS_JS = stageDrawnNodeKeys.toString()
+const STAGE_FACING_JS = stageFacing.toString()
+const STAGE_TRANSFORM_JS = stageTransform.toString()
 const WINDOW_LIVE_PLOT_DRAWING_DETAIL_RECT_JSON = JSON.stringify(
   WINDOW_LIVE_PLOT_DRAWING_DETAIL_RECT,
 )
@@ -281,5 +293,10 @@ export const PART_01_PRELUDE = `(() => {
   const windowLiveItemLastAction = ${WINDOW_LIVE_ITEM_LAST_ACTION_JS}
   const windowLiveItemPopoverPlacement = ${WINDOW_LIVE_ITEM_POPOVER_PLACEMENT_JS}
   const normalizeLiveNotesPage = ${NORMALIZE_LIVE_NOTES_PAGE_JS}
+  const stageNodeKey = ${STAGE_NODE_KEY_JS}
+  const reconcileStageNodeKeys = ${RECONCILE_STAGE_NODE_KEYS_JS}
+  const stageDrawnNodeKeys = ${STAGE_DRAWN_NODE_KEYS_JS}
+  const stageFacing = ${STAGE_FACING_JS}
+  const stageTransform = ${STAGE_TRANSFORM_JS}
 
 `

--- a/src/window-client/program/02-state-and-nodes.ts
+++ b/src/window-client/program/02-state-and-nodes.ts
@@ -86,6 +86,7 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
   }
   const liveStageNodes = new Map()
   let liveStageNextNodeKeys = null
+  let liveStageRetainedNodeKeys = null
   const tabs = [...document.querySelectorAll('[role="tab"][data-view]')]
   const panels = [...document.querySelectorAll('[role="tabpanel"]')]
   const viewShareButtons = [...document.querySelectorAll('[data-share-scope="view"]')]

--- a/src/window-client/program/02-state-and-nodes.ts
+++ b/src/window-client/program/02-state-and-nodes.ts
@@ -86,7 +86,6 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
   }
   const liveStageNodes = new Map()
   let liveStageNextNodeKeys = null
-  let liveStageRetainedNodeKeys = null
   const tabs = [...document.querySelectorAll('[role="tab"][data-view]')]
   const panels = [...document.querySelectorAll('[role="tabpanel"]')]
   const viewShareButtons = [...document.querySelectorAll('[data-share-scope="view"]')]
@@ -286,7 +285,9 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
       context.renderContext,
     )
     current.replaceWith(next)
-    finishStageNodeReconcile(drawnStageNodeKeys(nodes.livePlates))
+    if (stageNodeReconcileOpen()) {
+      finishStageNodeReconcile(drawnStageNodeKeys(nodes.livePlates))
+    }
     if (movesFocus) {
       restoreFocus(focusKey, focusFallbackKey, 'live-viewport')
     }

--- a/src/window-client/program/02-state-and-nodes.ts
+++ b/src/window-client/program/02-state-and-nodes.ts
@@ -84,6 +84,8 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
     directorySearchField: document.querySelector('.directory-search-field'),
     viewFilters: document.querySelector('.view-filters'),
   }
+  const liveStageNodes = new Map()
+  let liveStageNextNodeKeys = null
   const tabs = [...document.querySelectorAll('[role="tab"][data-view]')]
   const panels = [...document.querySelectorAll('[role="tabpanel"]')]
   const viewShareButtons = [...document.querySelectorAll('[data-share-scope="view"]')]
@@ -222,7 +224,7 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
   let liveFootstepSequence = 0
   let liveDetailedMoveActors = new Set()
   let liveRenderFrame = 0
-  let liveMotionFrame = 0
+  let liveMotionDirty = false
   let liveTraceRenderContext = null
   let liveRenderDirtyRevision = 0
   let liveRenderPaintedRevision = 0
@@ -262,13 +264,38 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
     return Boolean(panel && !panel.hidden)
   }
 
+  function paintLiveMotion() {
+    const current = nodes.livePlates?.querySelector('.live-trace-layer')
+    const context = liveTraceRenderContext
+    if (!current || !context || context.snapshot !== state.snapshot) {
+      markLiveDirty()
+      return
+    }
+    const active = document.activeElement
+    const focusKey = active?.dataset?.focusKey || null
+    const focusFallbackKey = active?.dataset?.focusFallbackKey || null
+    const movesFocus = current.contains(active)
+    const next = renderLiveTraceLayer(
+      context.snapshot,
+      context.focus,
+      context.children,
+      context.records,
+      context.bubbles,
+      context.survey,
+      context.renderContext,
+    )
+    current.replaceWith(next)
+    finishStageNodeReconcile(drawnStageNodeKeys(nodes.livePlates))
+    if (movesFocus) {
+      restoreFocus(focusKey, focusFallbackKey, 'live-viewport')
+    }
+  }
+
   function scheduleLiveRedraw() {
     if (!windowLiveShouldScheduleRedraw(Object.freeze({
       liveViewActive: state.view === 'live',
       documentVisible: !document.hidden,
       panelVisible: livePanelIsVisible(),
-      dirtyRevision: liveRenderDirtyRevision,
-      paintedRevision: liveRenderPaintedRevision,
       framePending: Boolean(liveRenderFrame),
     }))) return
     liveRenderFrame = window.requestAnimationFrame(() => {
@@ -277,13 +304,17 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
         liveViewActive: state.view === 'live',
         documentVisible: !document.hidden,
         panelVisible: livePanelIsVisible(),
-        dirtyRevision: liveRenderDirtyRevision,
-        paintedRevision: liveRenderPaintedRevision,
         framePending: false,
       }))) return
-      const revision = liveRenderDirtyRevision
-      if (state.snapshot) renderLive(state.snapshot)
-      liveRenderPaintedRevision = Math.max(liveRenderPaintedRevision, revision)
+      if (liveRenderDirtyRevision > liveRenderPaintedRevision) {
+        const revision = liveRenderDirtyRevision
+        if (state.snapshot) renderLive(state.snapshot)
+        liveRenderPaintedRevision = Math.max(liveRenderPaintedRevision, revision)
+        liveMotionDirty = false
+      } else if (liveMotionDirty) {
+        liveMotionDirty = false
+        paintLiveMotion()
+      }
       scheduleLiveRedraw()
     })
   }
@@ -293,43 +324,13 @@ export const PART_02_STATE_AND_NODES = `  const nodes = {
     scheduleLiveRedraw()
   }
 
-  function scheduleLiveMotionRedraw() {
-    if (liveMotionFrame || state.view !== 'live' || document.hidden ||
-        !livePanelIsVisible()) return
-    liveMotionFrame = window.requestAnimationFrame(() => {
-      liveMotionFrame = 0
-      const current = nodes.livePlates?.querySelector('.live-trace-layer')
-      const context = liveTraceRenderContext
-      if (!current || !context || context.snapshot !== state.snapshot) {
-        markLiveDirty()
-        return
-      }
-      const active = document.activeElement
-      const focusKey = active?.dataset?.focusKey || null
-      const focusFallbackKey = active?.dataset?.focusFallbackKey || null
-      current.replaceWith(renderLiveTraceLayer(
-        context.snapshot,
-        context.focus,
-        context.children,
-        context.records,
-        context.bubbles,
-        context.survey,
-        context.renderContext,
-      ))
-      if (current.contains(active)) {
-        restoreFocus(focusKey, focusFallbackKey, 'live-viewport')
-      }
-    })
-  }
-
   function stopLiveVisualWork() {
     if (liveRenderFrame) window.cancelAnimationFrame(liveRenderFrame)
-    if (liveMotionFrame) window.cancelAnimationFrame(liveMotionFrame)
     if (liveLabelFrame) window.cancelAnimationFrame(liveLabelFrame)
     if (liveCameraFrame) window.cancelAnimationFrame(liveCameraFrame)
     if (liveProofFrame) window.cancelAnimationFrame(liveProofFrame)
     liveRenderFrame = 0
-    liveMotionFrame = 0
+    liveMotionDirty = false
     liveLabelFrame = 0
     liveCameraFrame = 0
     liveProofFrame = 0

--- a/src/window-client/program/03-elements-portraits-drawings.ts
+++ b/src/window-client/program/03-elements-portraits-drawings.ts
@@ -30,6 +30,7 @@ export const PART_03_ELEMENTS_PORTRAITS_DRAWINGS = `  function element(tagName, 
     image.addEventListener('load', () => { shell.dataset.portraitState = 'loaded' })
     image.addEventListener('error', () => {
       shell.dataset.portraitState = 'placeholder'
+      delete shell.dataset.loaded
       image.remove()
     })
     shell.append(image)

--- a/src/window-client/program/06-live-camera-and-pointers.ts
+++ b/src/window-client/program/06-live-camera-and-pointers.ts
@@ -79,7 +79,8 @@ export const PART_06_LIVE_CAMERA_AND_POINTERS = `  function liveCameraViewport()
     )
     liveCamera = Object.freeze({ ...liveCamera, ...next })
     if (visualChanged && Object.keys(state.live.replayActive).length) {
-      scheduleLiveMotionRedraw()
+      liveMotionDirty = true
+      scheduleLiveRedraw()
     }
     if (!nodes.liveStage || liveCameraFrame) return
     liveCameraFrame = window.requestAnimationFrame(commitLiveCamera)

--- a/src/window-client/program/20-live-breadcrumbs-and-resident-layout.ts
+++ b/src/window-client/program/20-live-breadcrumbs-and-resident-layout.ts
@@ -112,7 +112,7 @@ export const PART_20_LIVE_BREADCRUMBS_AND_RESIDENT_LAYOUT = `  function liveFocu
     for (const key of [
       'liveRaised', 'liveFocusResident', 'liveFocusPartner', 'liveMovement',
       'liveAt', 'liveLifetime', 'fromPlaceId', 'toPlaceId', 'replayDuration',
-      'liveRoutePointCount',
+      'liveRoutePointCount', 'liveReplayKey',
     ]) delete shell.dataset[key]
     shell.style.animationName = ''
     shell.style.animationDuration = ''

--- a/src/window-client/program/20-live-breadcrumbs-and-resident-layout.ts
+++ b/src/window-client/program/20-live-breadcrumbs-and-resident-layout.ts
@@ -100,8 +100,31 @@ export const PART_20_LIVE_BREADCRUMBS_AND_RESIDENT_LAYOUT = `  function liveFocu
   }
 
   function livePortraitShell(portrait, bubble, className = 'live-portrait-wrap') {
-    const shell = element('span', className)
-    shell.append(portrait)
+    const residentId = portrait.dataset.liveResidentId
+    const shell = residentId
+      ? ensureStageNode('resident', residentId, () => {
+          const created = element('span', className)
+          created.append(portrait)
+          return created
+        })
+      : element('span', className)
+    shell.className = className
+    for (const key of [
+      'liveRaised', 'liveFocusResident', 'liveFocusPartner', 'liveMovement',
+      'liveAt', 'liveLifetime', 'fromPlaceId', 'toPlaceId', 'replayDuration',
+      'liveRoutePointCount',
+    ]) delete shell.dataset[key]
+    shell.style.animationName = ''
+    shell.style.animationDuration = ''
+    const heldPortrait = shell.querySelector(':scope > .live-portrait')
+    if (heldPortrait && heldPortrait !== portrait) {
+      const sprite = heldPortrait.querySelector(':scope > .live-entity-portrait')
+      if (sprite) portrait.prepend(sprite)
+      if (heldPortrait.dataset.liveHasDrawing) {
+        portrait.dataset.liveHasDrawing = heldPortrait.dataset.liveHasDrawing
+      }
+    }
+    shell.replaceChildren(portrait)
     if (bubble && !liveMotionReduced()) shell.append(liveSpeechBubbleNode(bubble))
     return shell
   }

--- a/src/window-client/program/21-live-pinning-and-portrait-grid.ts
+++ b/src/window-client/program/21-live-pinning-and-portrait-grid.ts
@@ -232,20 +232,52 @@ export const PART_21_LIVE_PINNING_AND_PORTRAIT_GRID = `  function livePinnedResi
       portrait.type = 'button'
       portrait.dataset.focusKey = 'live-resident:' + resident.handle
       portrait.dataset.liveResidentHandle = resident.handle
+      portrait.dataset.liveResidentId = String(resident.id)
       portrait.setAttribute('aria-label', state.live.focusResident === resident.handle
         ? 'Clear focus from ' + resident.handle
         : 'Focus on ' + resident.handle)
       portrait.setAttribute('aria-pressed', String(state.live.focusResident === resident.handle))
-      portrait.append(liveSpriteNode(
-        'resident', resident.id, resident.handle, resident.has_drawing,
-      ))
       const shell = livePortraitShell(
         portrait,
         bubbles?.get(resident.handle),
         'live-portrait-wrap live-walker',
       )
-      shell.style.left = String(entry.localPoint.x) + 'px'
-      shell.style.top = String(entry.localPoint.y) + 'px'
+      const heldPortrait = shell.querySelector(':scope > .live-portrait')
+      const hasDrawing = String(Boolean(resident.has_drawing))
+      const oldSprite = heldPortrait.querySelector(':scope > .live-entity-portrait')
+      const drawingRevision = String(state.changeMarker || state.snapshot?.changeMarker || '')
+      if (heldPortrait.dataset.liveHasDrawing !== hasDrawing) {
+        if (oldSprite) {
+          portraitObserver?.unobserve(oldSprite)
+          observedPortraitShells.delete(oldSprite)
+          pendingPortraitShells.delete(oldSprite)
+          oldSprite.remove()
+        }
+        const sprite = liveSpriteNode(
+          'resident', resident.id, resident.handle, resident.has_drawing)
+        sprite.dataset.liveDrawingRevision = drawingRevision
+        heldPortrait.prepend(sprite)
+        heldPortrait.dataset.liveHasDrawing = hasDrawing
+      } else if (hasDrawing === 'true' &&
+          oldSprite?.dataset.liveDrawingRevision !== drawingRevision) {
+        portraitObserver?.unobserve(oldSprite)
+        observedPortraitShells.delete(oldSprite)
+        pendingPortraitShells.delete(oldSprite)
+        oldSprite.querySelector(':scope > .entity-portrait-image')?.remove()
+        delete oldSprite.dataset.loaded
+        delete oldSprite.dataset.portraitState
+        oldSprite.dataset.liveDrawingRevision = drawingRevision
+        schedulePortraitShell(oldSprite)
+      }
+      shell.style.offsetPath = ''
+      shell.style.offsetDistance = ''
+      shell.style.offsetAnchor = ''
+      shell.style.animationName = ''
+      shell.style.animationDuration = ''
+      setStageTransform(shell, Object.freeze({
+        x: entry.localPoint.x,
+        y: entry.localPoint.y,
+      }))
       const itemKey = 'resident:' + resident.handle
       shell.dataset.liveItemKey = itemKey
       if (state.live.raisedItemKey === itemKey) shell.dataset.liveRaised = 'true'
@@ -254,9 +286,9 @@ export const PART_21_LIVE_PINNING_AND_PORTRAIT_GRID = `  function livePinnedResi
       } else if (pinned.has(resident.id)) {
         shell.setAttribute('data-live-focus-partner', resident.handle)
       }
-      bindLiveActivation(portrait, shell, itemKey,
+      bindLiveActivation(heldPortrait, shell, itemKey,
         () => toggleLiveFocusResident(resident.handle))
-      bindLiveItemPopover(portrait, itemKey, 'resident', () => resident)
+      bindLiveItemPopover(heldPortrait, itemKey, 'resident', () => resident)
       grid.append(shell)
     })
     const visibleOverflowActors = layout.hidden.filter(resident =>

--- a/src/window-client/program/22-live-things-and-plots.ts
+++ b/src/window-client/program/22-live-things-and-plots.ts
@@ -226,16 +226,27 @@ export const PART_22_LIVE_THINGS_AND_PLOTS = `  function liveThingFilters(focusI
       [String(place.id)]: Object.freeze(visibleThings.map(thing => thing.id)),
     })
     for (const thing of visibleThings) {
-      const specimen = element('a', 'live-thing-specimen')
+      const itemKey = 'thing:' + String(thing.id)
+      const specimen = ensureStageNode('thing', thing.id, () => {
+        const created = element('a', 'live-thing-specimen')
+        bindLiveActivation(created, created, itemKey, null)
+        bindLiveItemPopover(created, itemKey, 'thing', () => created._liveStageRecord)
+        return created
+      })
+      specimen._liveStageRecord = thing
+      specimen.className = 'live-thing-specimen'
+      delete specimen.dataset.liveFocusThing
+      delete specimen.dataset.livePulseFor
+      delete specimen.dataset.liveRaised
+      delete specimen.dataset.liveKey
+      delete specimen.dataset.highlighted
       specimen.href = '/api/thing/' + String(thing.id)
       specimen.setAttribute('aria-label', 'Read ' + thing.name)
       specimen.dataset.focusKey = 'live-thing:' + String(thing.id)
       specimen.dataset.liveThingId = String(thing.id)
       specimen.dataset.liveThingPlaceId = String(thing.place_id)
       const point = separated[String(thing.id)]
-      specimen.style.left = String(point.x) + 'px'
-      specimen.style.top = String(point.y) + 'px'
-      const itemKey = 'thing:' + String(thing.id)
+      setStageTransform(specimen, Object.freeze({ x: point.x, y: point.y, facing: 1 }))
       specimen.dataset.liveItemKey = itemKey
       if (state.live.raisedItemKey === itemKey) specimen.dataset.liveRaised = 'true'
       if (pinned.has(thing.id)) specimen.dataset.liveFocusThing = String(thing.id)
@@ -247,12 +258,37 @@ export const PART_22_LIVE_THINGS_AND_PLOTS = `  function liveThingFilters(focusI
         specimen.dataset.livePulseFor = pulse.key
         bindLiveHighlight(specimen, pulse.key, 'pulse')
       }
-      specimen.append(
-        liveSpriteNode('thing', thing.id, thing.name, thing.has_drawing),
-        element('span', 'live-thing-name live-item-name', thing.name),
-      )
-      bindLiveActivation(specimen, specimen, itemKey, null)
-      bindLiveItemPopover(specimen, itemKey, 'thing', () => thing)
+      const hasDrawing = String(Boolean(thing.has_drawing))
+      const oldSprite = specimen.querySelector(':scope > .live-entity-portrait')
+      const drawingRevision = String(state.changeMarker || state.snapshot?.changeMarker || '')
+      if (specimen.dataset.liveHasDrawing !== hasDrawing) {
+        if (oldSprite) {
+          portraitObserver?.unobserve(oldSprite)
+          observedPortraitShells.delete(oldSprite)
+          pendingPortraitShells.delete(oldSprite)
+          oldSprite.remove()
+        }
+        const sprite = liveSpriteNode('thing', thing.id, thing.name, thing.has_drawing)
+        sprite.dataset.liveDrawingRevision = drawingRevision
+        specimen.prepend(sprite)
+        specimen.dataset.liveHasDrawing = hasDrawing
+      } else if (hasDrawing === 'true' &&
+          oldSprite?.dataset.liveDrawingRevision !== drawingRevision) {
+        portraitObserver?.unobserve(oldSprite)
+        observedPortraitShells.delete(oldSprite)
+        pendingPortraitShells.delete(oldSprite)
+        oldSprite.querySelector(':scope > .entity-portrait-image')?.remove()
+        delete oldSprite.dataset.loaded
+        delete oldSprite.dataset.portraitState
+        oldSprite.dataset.liveDrawingRevision = drawingRevision
+        schedulePortraitShell(oldSprite)
+      }
+      let name = specimen.querySelector(':scope > .live-thing-name')
+      if (!name) {
+        name = element('span', 'live-thing-name live-item-name')
+        specimen.append(name)
+      }
+      name.textContent = thing.name
       shelf.append(specimen)
     }
     const overflowCount = selection.overflowCount + selection.visible.length - visibleThings.length
@@ -373,7 +409,26 @@ export const PART_22_LIVE_THINGS_AND_PLOTS = `  function liveThingFilters(focusI
 
   function livePlacePlot(renderContext, place, plot, detailed, focused) {
     const { snapshot, focus } = renderContext
-    const card = element('article', 'live-plot')
+    const itemKey = 'place:' + String(place.id)
+    const card = ensureStageNode('place', place.id, () => {
+      const created = element('article', 'live-plot')
+      const open = element('button', 'live-plot-open')
+      open.type = 'button'
+      open.dataset.focusKey = 'live-place:' + String(place.id)
+      bindLiveActivation(open, created, itemKey,
+        () => navigate({ view: 'live', placeId: place.id }))
+      bindLiveItemPopover(open, itemKey, 'place', () => created._liveStageRecord)
+      created.append(open)
+      return created
+    })
+    card._liveStageRecord = place
+    unmountLivePlaceDetail(card)
+    const open = card.querySelector(':scope > .live-plot-open')
+    for (const child of [...card.children]) {
+      if (child !== open) child.remove()
+    }
+    card.className = 'live-plot'
+    delete card.dataset.liveRaised
     card.dataset.placeId = String(place.id)
     card.dataset.livePlotX = String(plot.x)
     card.dataset.livePlotY = String(plot.y)
@@ -382,21 +437,14 @@ export const PART_22_LIVE_THINGS_AND_PLOTS = `  function liveThingFilters(focusI
     card.dataset.liveFocusPlot = String(Boolean(focused))
     card.dataset.liveDetail = String(Boolean(detailed || focused))
     card.dataset.liveDetailMounted = 'false'
-    const itemKey = 'place:' + String(place.id)
     card.dataset.liveItemKey = itemKey
     if (state.live.raisedItemKey === itemKey) card.dataset.liveRaised = 'true'
     card.style.left = String(plot.x) + 'px'
     card.style.top = String(plot.y) + 'px'
     card.style.width = String(plot.width) + 'px'
     card.style.height = String(plot.height) + 'px'
-    const open = element('button', 'live-plot-open')
-    open.type = 'button'
-    open.dataset.focusKey = 'live-place:' + String(place.id)
     open.setAttribute('aria-label', 'Open the live plate for ' + place.name)
-    bindLiveActivation(open, card, itemKey,
-      () => navigate({ view: 'live', placeId: place.id }))
-    bindLiveItemPopover(open, itemKey, 'place', () => place)
-    open.append(element('span', 'live-plot-name', place.name),
+    open.replaceChildren(element('span', 'live-plot-name', place.name),
       element('span', 'live-plot-number', '#' + String(place.id)))
     const notesControl = liveNotesControl(snapshot, place)
     card.dataset.undrawn = 'false'

--- a/src/window-client/program/24-live-replay-motion.ts
+++ b/src/window-client/program/24-live-replay-motion.ts
@@ -218,7 +218,7 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
     if (!Number.isFinite(wait)) return
     liveReplayVisibilityTimer = window.setTimeout(() => {
       liveReplayVisibilityTimer = 0
-      scheduleLiveMotionRedraw()
+      markLiveDirty()
     }, Math.max(0, wait) + 16)
   }
 
@@ -609,6 +609,7 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
       portrait.type = 'button'
       portrait.dataset.focusKey = 'live-resident:' + actor
       portrait.dataset.liveResidentHandle = actor
+      portrait.dataset.liveResidentId = String(resident.id)
       portrait.title = state.live.focusResident === actor
         ? 'Clear focus from ' + actor
         : 'Focus on ' + actor
@@ -619,6 +620,32 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
         movement && !movement.detailed ? null : bubbles.get(actor),
         'live-portrait-wrap live-replay-portrait',
       )
+      const heldPortrait = shell.querySelector(':scope > .live-portrait')
+      const hasDrawing = String(Boolean(resident.has_drawing))
+      const oldSprite = heldPortrait.querySelector(':scope > .live-entity-portrait')
+      const drawingRevision = String(state.changeMarker || state.snapshot?.changeMarker || '')
+      if (heldPortrait.dataset.liveHasDrawing !== hasDrawing) {
+        if (oldSprite) {
+          portraitObserver?.unobserve(oldSprite)
+          observedPortraitShells.delete(oldSprite)
+          pendingPortraitShells.delete(oldSprite)
+          oldSprite.remove()
+        }
+        const sprite = liveSpriteNode('resident', resident.id, actor, resident.has_drawing)
+        sprite.dataset.liveDrawingRevision = drawingRevision
+        heldPortrait.prepend(sprite)
+        heldPortrait.dataset.liveHasDrawing = hasDrawing
+      } else if (hasDrawing === 'true' &&
+          oldSprite?.dataset.liveDrawingRevision !== drawingRevision) {
+        portraitObserver?.unobserve(oldSprite)
+        observedPortraitShells.delete(oldSprite)
+        pendingPortraitShells.delete(oldSprite)
+        oldSprite.querySelector(':scope > .entity-portrait-image')?.remove()
+        delete oldSprite.dataset.loaded
+        delete oldSprite.dataset.portraitState
+        oldSprite.dataset.liveDrawingRevision = drawingRevision
+        schedulePortraitShell(oldSprite)
+      }
       shell.dataset.liveReplayKey = held?.key || ''
       // Round-1 review finding #2: this walking portrait was never wired
       // to bindLiveItemPopover, so a resident's facts went unreachable for
@@ -627,9 +654,9 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
       // 21-live-pinning-and-portrait-grid.ts), so the popover binds once
       // on open/focus and needs no per-frame work: positionLiveItemPopover
       // only reruns on the already-rAF-batched camera commit, and when the
-      // walk ends the next render swaps this replay portrait for the
-      // settled walker under the identical key, so syncLiveItemPopoverAnchor
-      // (27-live-render.ts) re-binds the same open popover to it rather
+      // walk ends the registered shell becomes the settled walker under the
+      // identical key, so syncLiveItemPopoverAnchor (27-live-render.ts)
+      // re-binds the same open popover to it rather
       // than closing it -- and closes it as usual (C5) if the resident
       // instead leaves the plate entirely.
       const itemKey = 'resident:' + actor
@@ -641,38 +668,48 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
         shell.dataset.liveAt = String(held.record.at.getTime())
         shell.dataset.liveLifetime = String(liveRecordLifetime(held.record))
       }
-      shell.style.left = String(point.x) + 'px'
-      shell.style.top = String(point.y) + 'px'
+      const facingPoint = movement?.points.find(routePoint => routePoint.x !== point.x) ||
+        destination || point
+      const currentFacing = Number(shell.style.getPropertyValue('--facing')) === -1 ? -1 : 1
+      const facing = stageFacing(point.x, facingPoint.x, currentFacing)
       if (destination && remaining > 0) {
         shell.dataset.liveMovement = movement.detailed ? 'detail' : 'simple'
         if (movement.detailed) {
           const path = movement.points.map((routePoint, index) =>
             (index ? 'L ' : 'M ') + String(routePoint.x) + ' ' + String(routePoint.y)).join(' ')
-          shell.style.left = '0px'
-          shell.style.top = '0px'
           shell.style.offsetPath = 'path("' + path + '")'
           shell.style.offsetDistance = '0%'
           shell.style.offsetAnchor = '50% 100%'
           shell.style.offsetRotate = '0deg'
-          shell.style.transform = 'none'
+          setStageTransform(shell, Object.freeze({ x: 0, y: 0, facing }))
           shell.style.animationName = 'live-recorded-route'
           shell.dataset.liveRoutePointCount = String(movement.geometry.points.length)
         } else {
-          shell.style.setProperty(
-            '--live-replay-delta-x', String(destination.x - point.x) + 'px')
-          shell.style.setProperty(
-            '--live-replay-delta-y', String(destination.y - point.y) + 'px')
+          shell.style.offsetPath = ''
+          shell.style.offsetDistance = ''
+          shell.style.offsetAnchor = ''
+          shell.style.animationName = 'live-recorded-glide'
+          setStageTransform(shell, Object.freeze({
+            x: point.x,
+            y: point.y,
+            facing,
+            destinationX: destination.x,
+            destinationY: destination.y,
+          }))
         }
         shell.style.animationDuration = String(remaining) + 'ms'
         shell.dataset.fromPlaceId = String(held.fromPlaceId)
         shell.dataset.toPlaceId = String(held.toPlaceId)
         shell.dataset.replayDuration = String(held.duration)
+      } else {
+        shell.style.offsetPath = ''
+        shell.style.offsetDistance = ''
+        shell.style.offsetAnchor = ''
+        shell.style.animationName = 'none'
+        setStageTransform(shell, Object.freeze({ x: point.x, y: point.y, facing }))
       }
-      portrait.addEventListener('click', () => toggleLiveFocusResident(actor))
-      bindLiveItemPopover(portrait, itemKey, 'resident', () => resident)
-      portrait.append(liveSpriteNode(
-        'resident', resident.id, actor, resident.has_drawing,
-      ))
+      heldPortrait.addEventListener('click', () => toggleLiveFocusResident(actor))
+      bindLiveItemPopover(heldPortrait, itemKey, 'resident', () => resident)
       layer.append(shell)
     }
     scheduleLiveReplayVisibility(movements)

--- a/src/window-client/program/24-live-replay-motion.ts
+++ b/src/window-client/program/24-live-replay-motion.ts
@@ -597,7 +597,7 @@ export const PART_24_LIVE_REPLAY_MOTION = `  function liveAnchorPoint(anchorId, 
       let movement = null
       if (held?.type === 'move') {
         movement = movements.get(actor)
-        if (!movement?.visible) continue
+        if (!movement) continue
         point = movement.points[0]
         destination = movement.points.at(-1)
         remaining = movement.remaining

--- a/src/window-client/program/25-live-traces-and-ledger.ts
+++ b/src/window-client/program/25-live-traces-and-ledger.ts
@@ -25,12 +25,21 @@ export const PART_25_LIVE_TRACES_AND_LEDGER = `  function visibleLiveRecords(sna
     node.dataset.liveKey = key
     if (!node.dataset.focusKey) node.dataset.focusKey = 'live-record:' + surface + ':' + key
     node.dataset.highlighted = String(state.live.highlightedKey === key)
-    node.addEventListener('mouseenter', () => setLiveHighlight(key))
+    if (node.dataset.liveHighlightBound === 'true') return
+    node.dataset.liveHighlightBound = 'true'
+    const currentKey = () => node.dataset.liveKey || null
+    node.addEventListener('mouseenter', () => {
+      if (currentKey()) setLiveHighlight(currentKey())
+    })
     node.addEventListener('mouseleave', () => setLiveHighlight(null))
-    node.addEventListener('focus', () => setLiveHighlight(key))
+    node.addEventListener('focus', () => {
+      if (currentKey()) setLiveHighlight(currentKey())
+    })
     node.addEventListener('blur', () => setLiveHighlight(null))
-    node.addEventListener('click', () => setLiveHighlight(
-      state.live.highlightedKey === key ? null : key))
+    node.addEventListener('click', () => {
+      const heldKey = currentKey()
+      if (heldKey) setLiveHighlight(state.live.highlightedKey === heldKey ? null : heldKey)
+    })
   }
 
   function liveTrailTiming(record, key) {
@@ -156,7 +165,8 @@ export const PART_25_LIVE_TRACES_AND_LEDGER = `  function visibleLiveRecords(sna
     if (!Number.isFinite(nextAt)) return
     liveFootstepWakeTimer = window.setTimeout(() => {
       liveFootstepWakeTimer = 0
-      scheduleLiveMotionRedraw()
+      liveMotionDirty = true
+      scheduleLiveRedraw()
     }, Math.max(0, nextAt - now) + 1)
   }
 

--- a/src/window-client/program/27-live-render.ts
+++ b/src/window-client/program/27-live-render.ts
@@ -1,5 +1,4 @@
 export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
-    resetPortraitImages()
     if (!nodes.livePlates || !nodes.liveStage) return
     livePlotDetailContext = null
     if (nodes.liveMapCaption) nodes.liveMapCaption.hidden = true
@@ -33,6 +32,7 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
       renderLiveHistoryStatus()
       scheduleLiveClock()
       restoreFocus(focusKey, null, null)
+      finishStageNodeReconcile()
       return
     }
     if (!state.directory.loaded) {
@@ -86,6 +86,7 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
       renderLiveHistoryStatus()
       scheduleLiveClock()
       restoreFocus(focusKey, null, null)
+      finishStageNodeReconcile()
       return
     }
     if (focus.quiet) {
@@ -94,8 +95,12 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
       renderLiveHistoryStatus()
       scheduleLiveClock()
       restoreFocus(focusKey, null, null)
+      finishStageNodeReconcile()
       return
     }
+    // Loading gates above temporarily detach the plate. Reconcile only once
+    // complete data can produce the truthful drawn key set.
+    beginStageNodeReconcile()
     const thingFilters = liveThingFilters(focus.id)
     const thingsPage = historyEntry('things', thingFilters)
     const children = liveChildren(snapshot, focus)
@@ -220,7 +225,14 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
     })
     plateParts.push(renderLiveTraceLayer(
       snapshot, focus, children, records, bubbles, survey, renderContext))
-    nodes.livePlates.replaceChildren(...plateParts)
+    reconcileStageChildren(nodes.livePlates, plateParts)
+    finishStageNodeReconcile(drawnStageNodeKeys(nodes.livePlates))
+    for (const sprite of nodes.livePlates.querySelectorAll(
+      '.live-entity-portrait[data-portrait-type]:not([data-loaded="true"])')) {
+      if (!observedPortraitShells.has(sprite) && !pendingPortraitShells.has(sprite)) {
+        schedulePortraitShell(sprite)
+      }
+    }
     syncLiveItemPopoverAnchor()
     scheduleLiveResidentLabels(true)
     scheduleLiveTrailExpiry()

--- a/src/window-client/program/27-live-render.ts
+++ b/src/window-client/program/27-live-render.ts
@@ -32,7 +32,7 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
       renderLiveHistoryStatus()
       scheduleLiveClock()
       restoreFocus(focusKey, null, null)
-      finishStageNodeReconcile()
+      retireAllStageNodes()
       return
     }
     if (!state.directory.loaded) {
@@ -86,7 +86,7 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
       renderLiveHistoryStatus()
       scheduleLiveClock()
       restoreFocus(focusKey, null, null)
-      finishStageNodeReconcile()
+      retireAllStageNodes()
       return
     }
     if (focus.quiet) {
@@ -95,7 +95,7 @@ export const PART_27_LIVE_RENDER = `  function renderLive(snapshot) {
       renderLiveHistoryStatus()
       scheduleLiveClock()
       restoreFocus(focusKey, null, null)
-      finishStageNodeReconcile()
+      retireAllStageNodes()
       return
     }
     // Loading gates above temporarily detach the plate. Reconcile only once

--- a/src/window-client/program/42-stage-nodes.ts
+++ b/src/window-client/program/42-stage-nodes.ts
@@ -10,6 +10,7 @@ export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory
     return node
   }
 
+  // Step 2 seam: later stage lanes retrieve a persistent node by record key here.
   function stageNode(kind, id) {
     return liveStageNodes.get(stageNodeKey(kind, id)) || null
   }
@@ -26,6 +27,23 @@ export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory
     node.remove()
     liveStageNodes.delete(key)
     liveStageNextNodeKeys?.delete(key)
+    liveStageRetainedNodeKeys?.delete(key)
+  }
+
+  function retainStageNode(kind, id) {
+    const key = stageNodeKey(kind, id)
+    if (liveStageRetainedNodeKeys && liveStageNodes.has(key)) {
+      liveStageRetainedNodeKeys.add(key)
+    }
+  }
+
+  function retireAllStageNodes() {
+    for (const key of [...liveStageNodes.keys()]) {
+      const [kind, id] = key.split(':')
+      retireStageNode(kind, id)
+    }
+    liveStageNextNodeKeys = null
+    liveStageRetainedNodeKeys = null
   }
 
   function setStageTransform(node, position) {
@@ -50,21 +68,26 @@ export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory
 
   function beginStageNodeReconcile() {
     liveStageNextNodeKeys = new Set()
+    liveStageRetainedNodeKeys = new Set()
   }
 
   function finishStageNodeReconcile(drawnKeys = null) {
-    const attachedKeys = new Set(stageDrawnNodeKeys(drawnKeys || []))
-    const nextKeys = new Set(liveStageNextNodeKeys === null
-      ? attachedKeys
-      : drawnKeys === null
-        ? liveStageNextNodeKeys
-        : [...liveStageNextNodeKeys].filter(key => attachedKeys.has(key)))
+    if (liveStageNextNodeKeys === null) return
+    const attachedKeys = drawnKeys === null
+      ? null
+      : new Set(stageDrawnNodeKeys(drawnKeys))
+    const nextKeys = new Set([...(attachedKeys === null
+      ? liveStageNextNodeKeys
+      : [...liveStageNextNodeKeys].filter(key => attachedKeys.has(key))),
+      ...(liveStageRetainedNodeKeys || []),
+    ])
     const diff = reconcileStageNodeKeys([...liveStageNodes.keys()], [...nextKeys])
     for (const key of diff.retire) {
       const [kind, id] = key.split(':')
       retireStageNode(kind, id)
     }
     liveStageNextNodeKeys = null
+    liveStageRetainedNodeKeys = null
   }
 
   function drawnStageNodeKeys(root) {

--- a/src/window-client/program/42-stage-nodes.ts
+++ b/src/window-client/program/42-stage-nodes.ts
@@ -27,14 +27,6 @@ export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory
     node.remove()
     liveStageNodes.delete(key)
     liveStageNextNodeKeys?.delete(key)
-    liveStageRetainedNodeKeys?.delete(key)
-  }
-
-  function retainStageNode(kind, id) {
-    const key = stageNodeKey(kind, id)
-    if (liveStageRetainedNodeKeys && liveStageNodes.has(key)) {
-      liveStageRetainedNodeKeys.add(key)
-    }
   }
 
   function retireAllStageNodes() {
@@ -43,7 +35,6 @@ export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory
       retireStageNode(kind, id)
     }
     liveStageNextNodeKeys = null
-    liveStageRetainedNodeKeys = null
   }
 
   function setStageTransform(node, position) {
@@ -68,7 +59,10 @@ export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory
 
   function beginStageNodeReconcile() {
     liveStageNextNodeKeys = new Set()
-    liveStageRetainedNodeKeys = new Set()
+  }
+
+  function stageNodeReconcileOpen() {
+    return liveStageNextNodeKeys !== null
   }
 
   function finishStageNodeReconcile(drawnKeys = null) {
@@ -76,18 +70,15 @@ export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory
     const attachedKeys = drawnKeys === null
       ? null
       : new Set(stageDrawnNodeKeys(drawnKeys))
-    const nextKeys = new Set([...(attachedKeys === null
+    const nextKeys = new Set(attachedKeys === null
       ? liveStageNextNodeKeys
-      : [...liveStageNextNodeKeys].filter(key => attachedKeys.has(key))),
-      ...(liveStageRetainedNodeKeys || []),
-    ])
+      : [...liveStageNextNodeKeys].filter(key => attachedKeys.has(key)))
     const diff = reconcileStageNodeKeys([...liveStageNodes.keys()], [...nextKeys])
     for (const key of diff.retire) {
       const [kind, id] = key.split(':')
       retireStageNode(kind, id)
     }
     liveStageNextNodeKeys = null
-    liveStageRetainedNodeKeys = null
   }
 
   function drawnStageNodeKeys(root) {

--- a/src/window-client/program/42-stage-nodes.ts
+++ b/src/window-client/program/42-stage-nodes.ts
@@ -1,0 +1,84 @@
+export const PART_42_STAGE_NODES = `  function ensureStageNode(kind, id, factory) {
+    const key = stageNodeKey(kind, id)
+    if (liveStageNextNodeKeys) liveStageNextNodeKeys.add(key)
+    const existing = liveStageNodes.get(key)
+    if (existing) return existing
+    const node = factory()
+    node.dataset.stageNodeKey = key
+    node.dataset.stageNodeKind = kind
+    liveStageNodes.set(key, node)
+    return node
+  }
+
+  function stageNode(kind, id) {
+    return liveStageNodes.get(stageNodeKey(kind, id)) || null
+  }
+
+  function retireStageNode(kind, id) {
+    const key = stageNodeKey(kind, id)
+    const node = liveStageNodes.get(key)
+    if (!node) return
+    for (const portrait of node.querySelectorAll('.entity-portrait')) {
+      portraitObserver?.unobserve(portrait)
+      observedPortraitShells.delete(portrait)
+      pendingPortraitShells.delete(portrait)
+    }
+    node.remove()
+    liveStageNodes.delete(key)
+    liveStageNextNodeKeys?.delete(key)
+  }
+
+  function setStageTransform(node, position) {
+    const currentFacing = Number(node.style.getPropertyValue('--facing')) === -1 ? -1 : 1
+    const facing = position.facing === -1 || position.facing === 1
+      ? position.facing
+      : currentFacing
+    const anchor = node.style.offsetPath
+      ? 'route'
+      : node.dataset.stageNodeKind === 'thing' ? 'thing' : 'resident'
+    node.style.setProperty('--facing', String(facing))
+    node.style.setProperty('--stage-x', String(position.x) + 'px')
+    node.style.setProperty('--stage-y', String(position.y) + 'px')
+    node.style.transform = stageTransform(position.x, position.y, anchor)
+    if (Number.isFinite(position.destinationX) && Number.isFinite(position.destinationY)) {
+      node.style.setProperty('--stage-destination-transform', stageTransform(
+        position.destinationX, position.destinationY, anchor))
+    } else {
+      node.style.removeProperty('--stage-destination-transform')
+    }
+  }
+
+  function beginStageNodeReconcile() {
+    liveStageNextNodeKeys = new Set()
+  }
+
+  function finishStageNodeReconcile(drawnKeys = null) {
+    const attachedKeys = new Set(stageDrawnNodeKeys(drawnKeys || []))
+    const nextKeys = new Set(liveStageNextNodeKeys === null
+      ? attachedKeys
+      : drawnKeys === null
+        ? liveStageNextNodeKeys
+        : [...liveStageNextNodeKeys].filter(key => attachedKeys.has(key)))
+    const diff = reconcileStageNodeKeys([...liveStageNodes.keys()], [...nextKeys])
+    for (const key of diff.retire) {
+      const [kind, id] = key.split(':')
+      retireStageNode(kind, id)
+    }
+    liveStageNextNodeKeys = null
+  }
+
+  function drawnStageNodeKeys(root) {
+    return stageDrawnNodeKeys([...root.querySelectorAll('[data-stage-node-key]')]
+      .map(node => node.dataset.stageNodeKey)
+      .filter(Boolean))
+  }
+
+  function reconcileStageChildren(parent, children) {
+    const next = new Set(children)
+    for (const child of [...parent.children]) {
+      if (!next.has(child)) child.remove()
+    }
+    for (const child of children) parent.append(child)
+  }
+
+`

--- a/src/window-client/program/index.ts
+++ b/src/window-client/program/index.ts
@@ -64,6 +64,7 @@ import { PART_37_SNAPSHOT_FETCH_AND_CACHE_INVALIDATION } from './37-snapshot-fet
 import { PART_38_REFRESH_CITY } from './38-refresh-city.ts'
 import { PART_40_LIVE_ITEM_POPOVER } from './40-live-item-popover.ts'
 import { PART_41_LIVE_NOTES_PANEL } from './41-live-notes-panel.ts'
+import { PART_42_STAGE_NODES } from './42-stage-nodes.ts'
 import { PART_39_WIRING_AND_BOOT } from './39-wiring-and-boot.ts'
 
 export const WINDOW_CLIENT_PARTS: readonly string[] = Object.freeze([
@@ -107,5 +108,6 @@ export const WINDOW_CLIENT_PARTS: readonly string[] = Object.freeze([
   PART_38_REFRESH_CITY,
   PART_40_LIVE_ITEM_POPOVER,
   PART_41_LIVE_NOTES_PANEL,
+  PART_42_STAGE_NODES,
   PART_39_WIRING_AND_BOOT,
 ])

--- a/src/window-client/stage-nodes.ts
+++ b/src/window-client/stage-nodes.ts
@@ -17,6 +17,7 @@ export function reconcileStageNodeKeys(
   const current = new Set(currentKeys)
   const next = new Set(nextKeys)
   return Object.freeze({
+    // Step 2 seam: later registry lanes consume keep/create; this lane consumes retire.
     keep: Object.freeze([...next].filter(key => current.has(key))),
     create: Object.freeze([...next].filter(key => !current.has(key))),
     retire: Object.freeze([...current].filter(key => !next.has(key))),

--- a/src/window-client/stage-nodes.ts
+++ b/src/window-client/stage-nodes.ts
@@ -1,0 +1,46 @@
+export type StageNodeKind = 'place' | 'resident' | 'thing'
+
+export type StageNodeDiff = Readonly<{
+  keep: readonly string[]
+  create: readonly string[]
+  retire: readonly string[]
+}>
+
+export function stageNodeKey(kind: StageNodeKind, id: string | number): string {
+  return `${kind}:${String(id)}`
+}
+
+export function reconcileStageNodeKeys(
+  currentKeys: readonly string[],
+  nextKeys: readonly string[],
+): StageNodeDiff {
+  const current = new Set(currentKeys)
+  const next = new Set(nextKeys)
+  return Object.freeze({
+    keep: Object.freeze([...next].filter(key => current.has(key))),
+    create: Object.freeze([...next].filter(key => !current.has(key))),
+    retire: Object.freeze([...current].filter(key => !next.has(key))),
+  })
+}
+
+export function stageDrawnNodeKeys(keys: readonly string[]): readonly string[] {
+  return Object.freeze([...new Set(keys)])
+}
+
+export function stageFacing(fromX: number, toX: number, currentFacing: 1 | -1 = 1): 1 | -1 {
+  if (toX < fromX) return -1
+  if (toX > fromX) return 1
+  return currentFacing
+}
+
+export function stageTransform(
+  x: number,
+  y: number,
+  anchor: 'resident' | 'thing' | 'route' = 'resident',
+): string {
+  const translation = `translate(${String(x)}px, ${String(y)}px)`
+  if (anchor === 'route') return translation
+  return translation + (anchor === 'thing'
+    ? ' translate(-50%, -50%)'
+    : ' translate(-50%, -100%)')
+}

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -1018,7 +1018,7 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   height: 34%;
   background: var(--sky);
   opacity: 0.55;
-  transform: rotate(45deg);
+  clip-path: polygon(50% 0, 100% 50%, 50% 100%, 0 50%);
 }
 .drawing-unavailable { border-style: solid; }
 .live-portrait-grid { display: flex; flex-wrap: wrap; gap: 0.38rem; align-items: start; }
@@ -1042,6 +1042,13 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
 }
 .live-portrait > .drawing-grid { height: 100%; aspect-ratio: auto; }
 .live-portrait > .entity-portrait { width: 100%; height: 100%; }
+[data-stage-node-kind="resident"] .live-portrait > .drawing-grid,
+[data-stage-node-kind="resident"] .live-portrait > .entity-portrait,
+[data-stage-node-kind="thing"] > .drawing-grid,
+[data-stage-node-kind="thing"] > .entity-portrait {
+  transform: scaleX(var(--facing, 1));
+  transform-origin: center;
+}
 .live-portrait.asleep { opacity: 0.48; }
 .live-speech-bubble {
   position: absolute;
@@ -1395,7 +1402,6 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   grid-template-columns: 1.55rem minmax(0, 1fr);
   min-width: 0;
   padding: 0.12rem;
-  transform: translate(-50%, -50%);
   background: transparent;
   box-shadow: none;
   pointer-events: auto;
@@ -1451,7 +1457,6 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   width: 3.5rem;
   height: 3.5rem;
   margin: 0;
-  transform: translate(-50%, -100%);
   pointer-events: auto;
 }
 .live-walker:hover, .live-walker:focus-within,
@@ -1509,7 +1514,6 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
 .live-root-thing-shelf > .live-thing-specimen {
   position: absolute;
   width: 9rem;
-  transform: translate(-50%, -50%);
   pointer-events: auto;
 }
 .live-focus-thing-shelf.live-root-thing-shelf > .live-thing-more {
@@ -1652,10 +1656,7 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
 
 @keyframes live-recorded-glide {
   to {
-    transform: translate(
-      calc(-50% + var(--live-replay-delta-x, 0px)),
-      calc(-100% + var(--live-replay-delta-y, 0px))
-    );
+    transform: var(--stage-destination-transform);
   }
 }
 

--- a/test/window-live-client.test.ts
+++ b/test/window-live-client.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import * as windowClientModule from '../src/window-client.ts'
+import { PART_42_STAGE_NODES } from '../src/window-client/program/42-stage-nodes.ts'
 import {
   WINDOW_LIVE_PLOT_DRAWING_DETAIL_RECT,
   normalizeWindowDrawing,
@@ -32,6 +33,11 @@ import {
   windowLiveItemFacts,
   windowLiveItemLastAction,
   windowLiveItemPopoverPlacement,
+  stageNodeKey,
+  reconcileStageNodeKeys,
+  stageDrawnNodeKeys,
+  stageFacing,
+  stageTransform,
 } from '../src/window-client.ts'
 
 const LIVE_NOTES_PAGE = Object.freeze({
@@ -203,6 +209,207 @@ type LiveClientExports = Readonly<{
 }>
 
 const liveClientExports = windowClientModule as unknown as LiveClientExports
+
+type FakeStageNode = {
+  dataset: Record<string, string>
+  removed: number
+  remove(): void
+  querySelectorAll(): readonly never[]
+}
+
+type StageRegistryRuntime = Readonly<{
+  beginStageNodeReconcile(): void
+  drawnStageNodeKeys(root: Readonly<{
+    querySelectorAll(): readonly FakeStageNode[]
+  }>): readonly string[]
+  ensureStageNode(kind: string, id: number, factory: () => FakeStageNode): FakeStageNode
+  finishStageNodeReconcile(drawnKeys?: readonly string[]): void
+  stageNode(kind: string, id: number): FakeStageNode | null
+}>
+
+function createStageRegistryRuntime(): StageRegistryRuntime {
+  return new Function(
+    'stageNodeKey',
+    'reconcileStageNodeKeys',
+    'stageDrawnNodeKeys',
+    'stageTransform',
+    `const liveStageNodes = new Map()
+let liveStageNextNodeKeys = null
+let portraitObserver = null
+const observedPortraitShells = new Set()
+const pendingPortraitShells = new Set()
+${PART_42_STAGE_NODES}
+return {
+  beginStageNodeReconcile,
+  drawnStageNodeKeys,
+  ensureStageNode,
+  finishStageNodeReconcile,
+  stageNode,
+}`,
+  )(stageNodeKey, reconcileStageNodeKeys, stageDrawnNodeKeys, stageTransform) as StageRegistryRuntime
+}
+
+function fakeDrawnStage(nodes: readonly FakeStageNode[]) {
+  return Object.freeze({ querySelectorAll: () => nodes })
+}
+
+function fakeStageNodeFactory(creations: Map<number, number>, id: number) {
+  return () => {
+    creations.set(id, (creations.get(id) || 0) + 1)
+    return {
+      dataset: {},
+      removed: 0,
+      remove() { this.removed += 1 },
+      querySelectorAll: () => [],
+    }
+  }
+}
+
+test('stage node reconciliation keeps survivors, creates newcomers once, and retires departures', () => {
+  const runtime = createStageRegistryRuntime()
+  const creations = new Map<number, number>()
+
+  runtime.beginStageNodeReconcile()
+  const departed = runtime.ensureStageNode('resident', 11, fakeStageNodeFactory(creations, 11))
+  const survivor = runtime.ensureStageNode('resident', 12, fakeStageNodeFactory(creations, 12))
+  runtime.finishStageNodeReconcile()
+  runtime.beginStageNodeReconcile()
+  const repaintedSurvivor = runtime.ensureStageNode(
+    'resident', 12, fakeStageNodeFactory(creations, 12))
+  const newcomer = runtime.ensureStageNode('resident', 13, fakeStageNodeFactory(creations, 13))
+  runtime.finishStageNodeReconcile()
+
+  assert.strictEqual(repaintedSurvivor, survivor, 'resident:12 keeps its node object')
+  assert.strictEqual(runtime.stageNode('resident', 13), newcomer)
+  assert.equal(creations.get(12), 1, 'resident:12 factory runs exactly once')
+  assert.equal(creations.get(13), 1, 'resident:13 factory runs exactly once')
+  assert.equal(departed.removed, 1, 'only resident:11 is removed')
+  assert.equal(survivor.removed, 0)
+  assert.equal(runtime.stageNode('resident', 11), null)
+})
+
+test('stage reconcile keeps every node and custom data when the drawn set is unchanged', () => {
+  const runtime = createStageRegistryRuntime()
+  const creations = new Map<number, number>()
+  const records = Object.freeze([
+    Object.freeze({ kind: 'place', id: 3 }),
+    Object.freeze({ kind: 'resident', id: 21 }),
+    Object.freeze({ kind: 'thing', id: 9 }),
+  ])
+  const firstPaint = new Map<string, FakeStageNode>()
+  const secondPaint = new Map<string, FakeStageNode>()
+
+  runtime.beginStageNodeReconcile()
+  for (const record of records) {
+    const node = runtime.ensureStageNode(
+      record.kind, record.id, fakeStageNodeFactory(creations, record.id))
+    firstPaint.set(`${record.kind}:${String(record.id)}`, node)
+  }
+  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(
+    fakeDrawnStage([...firstPaint.values()])))
+  for (const record of records) {
+    firstPaint.get(`${record.kind}:${String(record.id)}`)!.dataset.identityMarker =
+      `${record.kind}-${String(record.id)}`
+  }
+
+  runtime.beginStageNodeReconcile()
+  for (const record of records) {
+    secondPaint.set(`${record.kind}:${String(record.id)}`, runtime.ensureStageNode(
+      record.kind, record.id, fakeStageNodeFactory(creations, record.id)))
+  }
+  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(
+    fakeDrawnStage([...secondPaint.values()])))
+
+  for (const record of records) {
+    const key = `${record.kind}:${String(record.id)}`
+    const node = secondPaint.get(key)
+    assert.strictEqual(node, firstPaint.get(key), `${key} keeps its node object`)
+    assert.strictEqual(runtime.stageNode(record.kind, record.id), node)
+    assert.equal(node?.dataset.identityMarker, `${record.kind}-${String(record.id)}`)
+    assert.equal(creations.get(record.id), 1, `${key} factory runs exactly once`)
+  }
+})
+
+test('stage reconcile retires exactly the residents dropped by overflow and keeps survivors', () => {
+  const runtime = createStageRegistryRuntime()
+  const creations = new Map<number, number>()
+  const firstFrame = new Map<number, FakeStageNode>()
+
+  for (let id = 1; id <= 8; id += 1) {
+    firstFrame.set(id, runtime.ensureStageNode(
+      'resident', id, fakeStageNodeFactory(creations, id)))
+  }
+
+  runtime.beginStageNodeReconcile()
+  for (let id = 1; id <= 8; id += 1) {
+    runtime.ensureStageNode('resident', id, fakeStageNodeFactory(creations, id))
+  }
+  const drawnNodes = [1, 2, 3, 4, 5, 6].map(id => firstFrame.get(id)!)
+  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(fakeDrawnStage(drawnNodes)))
+
+  for (let id = 1; id <= 6; id += 1) {
+    assert.strictEqual(runtime.stageNode('resident', id), firstFrame.get(id))
+    assert.equal(firstFrame.get(id)?.removed, 0)
+    assert.equal(creations.get(id), 1)
+  }
+  assert.equal(firstFrame.get(7)?.removed, 1)
+  assert.equal(firstFrame.get(8)?.removed, 1)
+  assert.equal(runtime.stageNode('resident', 7), null)
+  assert.equal(runtime.stageNode('resident', 8), null)
+  assert.equal([...firstFrame.values()].reduce((total, node) => total + node.removed, 0), 2)
+})
+
+test('stage reconcile retires a walker absorbed by the crowd without duplicating its id', () => {
+  const runtime = createStageRegistryRuntime()
+  const creations = new Map<number, number>()
+
+  const walker = runtime.ensureStageNode(
+    'resident', 21, fakeStageNodeFactory(creations, 21))
+
+  runtime.beginStageNodeReconcile()
+  const staleWalker = runtime.ensureStageNode(
+    'resident', 21, fakeStageNodeFactory(creations, 21))
+  const absorbedEntry = runtime.ensureStageNode(
+    'resident', 21, fakeStageNodeFactory(creations, 21))
+  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(fakeDrawnStage([])))
+
+  assert.strictEqual(staleWalker, walker)
+  assert.strictEqual(absorbedEntry, walker)
+  assert.equal(creations.get(21), 1)
+  assert.equal(walker.removed, 1)
+  assert.equal(runtime.stageNode('resident', 21), null)
+})
+
+test('stage reconcile retires a stale node still attached inside a kept container', () => {
+  const runtime = createStageRegistryRuntime()
+  const creations = new Map<number, number>()
+  const stale = runtime.ensureStageNode(
+    'resident', 21, fakeStageNodeFactory(creations, 21))
+  const survivor = runtime.ensureStageNode(
+    'resident', 22, fakeStageNodeFactory(creations, 22))
+
+  runtime.beginStageNodeReconcile()
+  runtime.ensureStageNode('resident', 22, fakeStageNodeFactory(creations, 22))
+  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(
+    fakeDrawnStage([stale, survivor])))
+
+  assert.strictEqual(runtime.stageNode('resident', 22), survivor)
+  assert.equal(survivor.removed, 0)
+  assert.equal(stale.removed, 1)
+  assert.equal(runtime.stageNode('resident', 21), null)
+})
+
+test('stage sprite transforms flip only through --facing and never rotate', () => {
+  assert.equal(stageFacing(20, 10, 1), -1)
+  assert.equal(stageFacing(10, 20, -1), 1)
+  assert.equal(stageFacing(10, 10, -1), -1)
+  assert.equal(stageTransform(24, 36), 'translate(24px, 36px) translate(-50%, -100%)')
+  assert.doesNotMatch(stageTransform(24, 36), /rotate\s*\(/u)
+  assert.doesNotMatch(windowClientModule.WINDOW_JS, /rotate\s*\(/u)
+
+  const stylesheet = readFileSync(new URL('../src/window-style.ts', import.meta.url), 'utf8')
+  assert.doesNotMatch(stylesheet, /rotate\s*\(/u)
+})
 
 test('drawing presentation labels all five owner-chosen states without inferring progress', () => {
   const stateLabel = liveClientExports.windowDrawingStateLabel
@@ -1523,22 +1730,19 @@ test('detail budget keeps the followed resident when attention is oversized', ()
   assert.equal(selected.detailed.includes('attention-1'), true)
 })
 
-test('redraw gate schedules changed visible input and stays idle when identical or hidden', () => {
-  const visibleChange = Object.freeze({
+test('stage loop keeps scheduling while visible and stops when hidden or inactive', () => {
+  const visibleStage = Object.freeze({
     liveViewActive: true,
     documentVisible: true,
     panelVisible: true,
-    dirtyRevision: 4,
-    paintedRevision: 3,
     framePending: false,
   })
 
-  assert.equal(windowLiveShouldScheduleRedraw(visibleChange), true)
-  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleChange, dirtyRevision: 3 }), false)
-  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleChange, documentVisible: false }), false)
-  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleChange, panelVisible: false }), false)
-  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleChange, liveViewActive: false }), false)
-  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleChange, framePending: true }), false)
+  assert.equal(windowLiveShouldScheduleRedraw(visibleStage), true)
+  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleStage, documentVisible: false }), false)
+  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleStage, panelVisible: false }), false)
+  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleStage, liveViewActive: false }), false)
+  assert.equal(windowLiveShouldScheduleRedraw({ ...visibleStage, framePending: true }), false)
 })
 
 test('route visibility returns exact progress windows for camera crossings', () => {

--- a/test/window-live-client.test.ts
+++ b/test/window-live-client.test.ts
@@ -224,8 +224,8 @@ type StageRegistryRuntime = Readonly<{
   }>): readonly string[]
   ensureStageNode(kind: string, id: number, factory: () => FakeStageNode): FakeStageNode
   finishStageNodeReconcile(drawnKeys?: readonly string[]): void
-  retainStageNode(kind: string, id: number): void
   retireAllStageNodes(): void
+  stageNodeReconcileOpen(): boolean
   stageNode(kind: string, id: number): FakeStageNode | null
 }>
 
@@ -237,7 +237,6 @@ function createStageRegistryRuntime(): StageRegistryRuntime {
     'stageTransform',
     `const liveStageNodes = new Map()
 let liveStageNextNodeKeys = null
-let liveStageRetainedNodeKeys = null
 let portraitObserver = null
 const observedPortraitShells = new Set()
 const pendingPortraitShells = new Set()
@@ -247,8 +246,8 @@ return {
   drawnStageNodeKeys,
   ensureStageNode,
   finishStageNodeReconcile,
-  retainStageNode,
   retireAllStageNodes,
+  stageNodeReconcileOpen,
   stageNode,
 }`,
   )(stageNodeKey, reconcileStageNodeKeys, stageDrawnNodeKeys, stageTransform) as StageRegistryRuntime
@@ -274,10 +273,13 @@ test('stage node reconciliation keeps survivors, creates newcomers once, and ret
   const runtime = createStageRegistryRuntime()
   const creations = new Map<number, number>()
 
+  assert.equal(runtime.stageNodeReconcileOpen(), false)
   runtime.beginStageNodeReconcile()
+  assert.equal(runtime.stageNodeReconcileOpen(), true)
   const departed = runtime.ensureStageNode('resident', 11, fakeStageNodeFactory(creations, 11))
   const survivor = runtime.ensureStageNode('resident', 12, fakeStageNodeFactory(creations, 12))
   runtime.finishStageNodeReconcile()
+  assert.equal(runtime.stageNodeReconcileOpen(), false)
   runtime.beginStageNodeReconcile()
   const repaintedSurvivor = runtime.ensureStageNode(
     'resident', 12, fakeStageNodeFactory(creations, 12))
@@ -401,26 +403,6 @@ test('stage reconcile retires a stale node still attached inside a kept containe
   assert.strictEqual(runtime.stageNode('resident', 22), survivor)
   assert.equal(survivor.removed, 0)
   assert.equal(stale.removed, 1)
-  assert.equal(runtime.stageNode('resident', 21), null)
-})
-
-test('stage reconcile retains an off-camera replay for one paint, then retires it normally', () => {
-  const runtime = createStageRegistryRuntime()
-  const creations = new Map<number, number>()
-  const replay = runtime.ensureStageNode(
-    'resident', 21, fakeStageNodeFactory(creations, 21))
-
-  runtime.beginStageNodeReconcile()
-  runtime.retainStageNode('resident', 21)
-  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(fakeDrawnStage([])))
-
-  assert.strictEqual(runtime.stageNode('resident', 21), replay)
-  assert.equal(replay.removed, 0)
-
-  runtime.beginStageNodeReconcile()
-  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(fakeDrawnStage([])))
-
-  assert.equal(replay.removed, 1)
   assert.equal(runtime.stageNode('resident', 21), null)
 })
 

--- a/test/window-live-client.test.ts
+++ b/test/window-live-client.test.ts
@@ -224,6 +224,8 @@ type StageRegistryRuntime = Readonly<{
   }>): readonly string[]
   ensureStageNode(kind: string, id: number, factory: () => FakeStageNode): FakeStageNode
   finishStageNodeReconcile(drawnKeys?: readonly string[]): void
+  retainStageNode(kind: string, id: number): void
+  retireAllStageNodes(): void
   stageNode(kind: string, id: number): FakeStageNode | null
 }>
 
@@ -235,6 +237,7 @@ function createStageRegistryRuntime(): StageRegistryRuntime {
     'stageTransform',
     `const liveStageNodes = new Map()
 let liveStageNextNodeKeys = null
+let liveStageRetainedNodeKeys = null
 let portraitObserver = null
 const observedPortraitShells = new Set()
 const pendingPortraitShells = new Set()
@@ -244,6 +247,8 @@ return {
   drawnStageNodeKeys,
   ensureStageNode,
   finishStageNodeReconcile,
+  retainStageNode,
+  retireAllStageNodes,
   stageNode,
 }`,
   )(stageNodeKey, reconcileStageNodeKeys, stageDrawnNodeKeys, stageTransform) as StageRegistryRuntime
@@ -397,6 +402,48 @@ test('stage reconcile retires a stale node still attached inside a kept containe
   assert.equal(survivor.removed, 0)
   assert.equal(stale.removed, 1)
   assert.equal(runtime.stageNode('resident', 21), null)
+})
+
+test('stage reconcile retains an off-camera replay for one paint, then retires it normally', () => {
+  const runtime = createStageRegistryRuntime()
+  const creations = new Map<number, number>()
+  const replay = runtime.ensureStageNode(
+    'resident', 21, fakeStageNodeFactory(creations, 21))
+
+  runtime.beginStageNodeReconcile()
+  runtime.retainStageNode('resident', 21)
+  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(fakeDrawnStage([])))
+
+  assert.strictEqual(runtime.stageNode('resident', 21), replay)
+  assert.equal(replay.removed, 0)
+
+  runtime.beginStageNodeReconcile()
+  runtime.finishStageNodeReconcile(runtime.drawnStageNodeKeys(fakeDrawnStage([])))
+
+  assert.equal(replay.removed, 1)
+  assert.equal(runtime.stageNode('resident', 21), null)
+})
+
+test('bare finish preserves the registry and permanent gates retire every stage node explicitly', () => {
+  for (const gate of ['issue', 'no-plate', 'quiet']) {
+    const runtime = createStageRegistryRuntime()
+    const creations = new Map<number, number>()
+    const resident = runtime.ensureStageNode(
+      'resident', 21, fakeStageNodeFactory(creations, 21))
+    const thing = runtime.ensureStageNode('thing', 9, fakeStageNodeFactory(creations, 9))
+
+    runtime.finishStageNodeReconcile()
+
+    assert.strictEqual(runtime.stageNode('resident', 21), resident, `${gate} bare finish keeps resident`)
+    assert.strictEqual(runtime.stageNode('thing', 9), thing, `${gate} bare finish keeps thing`)
+
+    runtime.retireAllStageNodes()
+
+    assert.equal(resident.removed, 1, `${gate} explicitly retires resident`)
+    assert.equal(thing.removed, 1, `${gate} explicitly retires thing`)
+    assert.equal(runtime.stageNode('resident', 21), null)
+    assert.equal(runtime.stageNode('thing', 9), null)
+  }
 })
 
 test('stage sprite transforms flip only through --facing and never rotate', () => {


### PR DESCRIPTION
Step 2 of the live view round-two blueprint (docs/drafts/live-stage-blueprint.md): the persistent node registry and the sprite contract.

- src/window-client/stage-nodes.ts (pure helpers) and src/window-client/program/42-stage-nodes.ts (ensure, retire, reconcile) keyed by record id: a record present before and after a paint keeps its identical node; one that leaves the drawn set (overflow, absorption, departure) is retired; a new one is created once; the census gate detaches nodes without retiring them and the same nodes return
- 27-live-render.ts reconciles #live-plates by transform instead of replaceChildren
- one stage animation-frame loop, running only while Live is visible and the tab is not hidden
- sprites carry a facing factor and never a rotation; a source scan forbids rotate( on stage rules

Assertions deleted or rewritten, as the step requires:

Assertions deleted or rewritten:

1. `redraw gate schedules changed visible input and stays idle when identical or hidden` became `stage loop keeps scheduling while visible and stops when hidden or inactive`.

2. `new change rows replay once in recorded order and leave truthful residue` now asserts registry survival for `thing:21`, retirement for departed `thing:9` and `resident:5`, and the correct `+3` drawn-set count. Its moving-label assertions moved to `a moving resident returning to readable ground receives a bounded label refresh`. (superseded by the review rounds below: the focused flow keeps thing:9 and resident:5 drawn as on main and proves registry survival; the separate unpinned absorption case proves their retirement.)

3. `sixty-four simultaneous walks complete in one painted batch` became `sixty-four simultaneous walks complete in one paint without rebuilding stable nodes`; the child-list mutation assertion was replaced by render-count and surviving-node identity assertions.

4. `eight legal change pages settle 1,600 actors without rebuilding crowd membership` now reads `--stage-x`/`--stage-y` and requires identical registry markers before, during, and after the replay.

5. `proof: one popover carries what the chips carried, for one resident, one thing, and one place` now polls guarded rectangles and prints both operands; the proof-scene test also verifies node and sprite identities through 64 active replays.

Next action: run `git diff --stat` to inspect the uncommitted handoff.

Review rounds (after the two Opus reviews of 28b1db0):

- Restored the settled-walker poll and the `Math.hypot(...) > 10` assertion, proving a recorded walk finishes at a new stage position.
- Restored the settled plate portrait checks immediately after the `Earlier line` bubble: it names `map-walker` and excludes `/Earlier|L{10}/` speech text.
- Restored the 750 ms moving-resident label bound and removed the inserted Pause/Resume detour.
- Replaced the false departure claims for `thing:9` and `resident:5`: the focused flow keeps them drawn as on main, while a separate unpinned flow proves all eight things as 5 drawn + 3 overflow and all eight residents as 4 drawn + 4 overflow on the badges.
- Added exact 4-walker, 1-specimen and 221-node preconditions to the 1,600-actor case; a resident-census gate detach-and-reattach identity case; null-safe `page.evaluate` polls where two poll bodies could throw; and key-sorted repaint samples.
- Product: an explicit `retireAllStageNodes()` for the three terminal gates instead of a bare finish; a portrait image that fails to load is retried on the next paint; a settled walker drops its replay key; camera visibility no longer affects whether a mover is attached or registered (a round-10 gate that had retained but not attached off-camera movers is gone).
- Tests made timing-proof: the proof scene pauses the held clock only after its 64 replays are scheduled and samples the whole plate at one instant (152 shells, 88 walkers, 64 replays, 7 things); the frame-time readout advances exactly the held time its sampler needs; the label-refresh case waits for the walker to stop under the ordinary timeout and only then applies main's two visibility assertions within 750 ms; the 1,600-actor case asserts the fixture's exact counts (4 walkers, 1 specimen, 221 registered nodes); the gate-identity case samples each place card's own portrait, not a nested walker's; the absorption case advances the 25 s of held timers the fixture chains.

Confirm round (a2c337c): the code confirm approved 1ed58f9 with two lows, both applied: the retainStageNode mechanism from round 10, shipped with no call site, is deleted with its state and its test, so a full paint can only keep nodes both ensured and attached; the motion frame skips its whole-plate census when no reconcile is open (stageNodeReconcileOpen), keeping the post-throw recovery.

Final gate (orchestrator, round 13): typecheck clean; door:check clean; `npm test` with only the four known Windows-only #183 failures; seven named cases green under --repeat-each=5 (35 of 35); three sequential full runs of e2e/public-window-live.spec.ts green (100 of 100 each), rerun after round 13 with the same result.

Gates (orchestrator, five rounds): round 1 drew 151 walkers where the contract allows 88 (no retirement); round 2 retired survivors and lost their identity markers; round 3 fixed both; round 4 settled one mid-gate identity sample in the 1,600-actor test; round 5 found the last path back to 151, a full paint whose DOM census replaced its begin/ensure intent so stale attached nodes counted as current, and reconciliation now keeps only keys both ensured and attached (motion-only redraws keep the DOM census; gates keep detached identity). Final: typecheck clean; npm test with only the four known Windows-only #183 failures; the three identity cases and the proof scene green under --repeat-each=5; three sequential full runs of e2e/public-window-live.spec.ts green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


