### PR TITLE
test: align happenings readiness wait with client timeout

### DIFF
--- a/e2e/public-window.spec.ts
+++ b/e2e/public-window.spec.ts
@@ -1333,7 +1333,13 @@ test('public window completes deliberate excerpts and loads older happenings wit
 
 test('unfiltered happenings still page older history on demand', async ({ page }) => {
   await page.goto('/window#view=happenings')
-  await expect(page.locator('#window-status')).toContainText('Watching')
+  await expect.poll(
+    async () => await page.locator('#window-status').textContent() ?? '<missing>',
+    {
+      message: 'observed window status while waiting for unfiltered happenings',
+      timeout: 10_000,
+    },
+  ).toContain('Watching')
 
   // No filter is active, so nothing fetches by itself; the snapshot slice
   // renders and the reader pages backward deliberately.


### PR DESCRIPTION
## Problem and result

The unfiltered Happenings E2E case could exhaust Playwright's default 5-second assertion budget while the window was still completing an initial read that the client deliberately allows 10 seconds. The readiness check now polls the actual status for that same 10-second budget, and a failure prints the last observed status text instead of leaving the state ambiguous.

The issue suggested that the preceding excerpt/history case left browser work in flight. The evidence did not support that hypothesis: Playwright awaits each test-scoped context close before starting the next test, the preceding case awaits its response and state reads, the stub routes are synchronous, and their persistent observation arrays do not influence later responses. Before the change, the ordered pair passed 40/40 across 20 repetitions and one complete spec run passed 22/22, so the historical intermittent failure did not reproduce locally.

No production code or Live file changed.

## Verification

- Isolated target: 20/20 passed under `--repeat-each=20`.
- Complete `e2e/public-window.spec.ts`: 440/440 passed, 22 cases across 20 complete repetitions, with zero retries.
- `npm run typecheck`: passed.
- `npm test`: 2,006/2,010 passed; the only failures were the four documented Windows-only `test/identity-client.test.ts` failures from #183. There were zero skips, cancellations, or todos.
- Independent source-only review: APPROVED digest `f59fa932239e27c455c9599bf85f89b21330aca48f852d12376d0a11550b4ce8`, with zero blocker, high, medium, or low findings.
- Change guard and receipt validation: only the claimed test file changed; no unexpected or post-seal paths.

Every test command set `ECC_SKIP_GIT_HOOKS=1`, `AGENT_1F3D9_STUB_ONLY=1`, and `AGENT_1F3EA_STUB_ONLY=1`. E2E used the local stub server on port 41740. No live city, market, credential-vault, PostgreSQL, deployment, or Vercel-preview check ran.

`scripts/deploy.sh --prepare` was not run because it requires explicit acknowledgements for production provider keys and migrations that this task did not verify. CI remains the release gate for this open PR.

Closes #236.
