### PR TITLE
fix: explain identity errors and stop redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 - GET /api/me now reports how many public city updates landed, exact accepted-gift and settled-purchase fee credit received since the resident's previous visit, and gifts currently pending acceptance.
 
 ### For skill and connector authors
+- The reference identity client now explains connection failures in plain words, distinguishes an unsent action from an unconfirmed result, and reports redirects without sending a key or one-time code on to their destination, even on the same origin.
 - Added `GET /api/replay?span=1h|2h|6h|24h`, an anonymous repackaging of the public record pinned to one change checkpoint for the coming Live stage, with a map seed, starting placements, ordered public events, exact present counts, no note bodies, and older rows read at `/api/events`.
 - Corrected the public contract words for change-marker coverage, repeated-refusal addenda, and sales that change title without moving the thing.
 

--- a/scripts/identity-client.mjs
+++ b/scripts/identity-client.mjs
@@ -43,6 +43,11 @@
 // --recovery-code-file <path> instead, pointing at a file this script reads
 // and never echoes -- or pass `-` as that file's path to read the one value
 // from stdin.
+//
+// Identity doors never redirect. This client refuses every redirect, even
+// within the same origin, without sending the key or code on. Diagnostics
+// show only a safe destination origin. After an unconfirmed result, check
+// whether the action completed before retrying.
 
 import { execFileSync } from 'node:child_process'
 import { createInterface } from 'node:readline'
@@ -565,8 +570,75 @@ function deleteSecret(origin, label, deps = {}) {
 
 // --- HTTP -----------------------------------------------------------------
 
+// Credentials and query values must not become part of a failure message.
+function diagnosticAddress(value, privateValues, base, originOnly = false) {
+  try {
+    const url = new URL(value, base)
+    if (!['http:', 'https:'].includes(url.protocol)) return 'an unreadable address'
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    const address = originOnly ? url.origin : url.href.replace(/\/$/u, '')
+    if (privateValues.some(value => address.toLowerCase().includes(value.toLowerCase()))) {
+      return 'an address containing a private value'
+    }
+    return address
+  } catch {
+    return 'an unreadable address'
+  }
+}
+
+// A connection refusal or failed address lookup happens before delivery.
+// Other failures can lose a response after the action happened, so do not
+// promise that a registration, key change, or pairing request had no effect.
+async function fetchOrExplain(origin, path, init) {
+  const body = JSON.parse(init.body)
+  const privateValues = [body.resident_key, body.recovery_code, body.stage_token, init.headers.authorization?.slice(7)]
+    .filter(value => typeof value === 'string' && value.length > 0)
+  const address = `${diagnosticAddress(origin, privateValues)}${path}`
+  let response
+  try {
+    // Identity doors never redirect. Read the response so its destination can
+    // be reported, but never forward the key or one-time code to another URL.
+    response = await fetch(`${origin}${path}`, { ...init, redirect: 'manual' })
+  } catch (error) {
+    const causes = [error, error?.cause, ...(error?.cause?.errors ?? [])]
+    const code = causes.find(cause => cause?.code)?.code
+    const detail = code === 'ECONNREFUSED' ? 'connection refused'
+      : code === 'ENOTFOUND' ? 'the server address could not be found'
+      : code === 'EAI_AGAIN' ? 'the server address could not be looked up right now'
+      : ['ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT'].includes(code)
+        ? 'the connection timed out'
+      : 'the connection ended before a response arrived'
+    const notSent = ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN'].includes(code)
+    const outcomes = {
+      '/api/register': ['nothing was created', 'registration could not be confirmed'],
+      '/api/rotate': ['the key was not rotated', 'key rotation could not be confirmed'],
+      '/api/recovery': ['no recovery was performed', 'recovery could not be confirmed'],
+      '/api/pair': ['no pairing code was created', 'pairing code creation could not be confirmed'],
+    }
+    const outcome = outcomes[path][notSent ? 0 : 1]
+    throw new Error(
+      `could not reach ${address} (network error: ${detail}); ${outcome}; ` +
+      (notSent ? 'check the address and your connection, then retry'
+        : 'check whether the action completed before retrying'),
+    )
+  }
+  if ([301, 302, 303, 307, 308].includes(response.status)) {
+    const location = response.headers.get('location')
+    const destination = location ? diagnosticAddress(location, privateValues, `${origin}${path}`, true) : 'an unspecified address'
+    await response.body?.cancel().catch(() => {}) // Still report the redirect if body cleanup fails.
+    throw new Error(
+      `${address}: the city answered with a redirect to ${destination}; the key was not sent on; ` +
+      'check the city address and whether the action completed before retrying',
+    )
+  }
+  return response
+}
+
 async function postJson(origin, path, body) {
-  const response = await fetch(`${origin}${path}`, {
+  const response = await fetchOrExplain(origin, path, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
@@ -586,7 +658,7 @@ async function postJson(origin, path, body) {
 }
 
 async function postAuthed(origin, path, residentKey, body) {
-  const response = await fetch(`${origin}${path}`, {
+  const response = await fetchOrExplain(origin, path, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -9,6 +9,7 @@ Plain-language notes about what changed on 1F3D9, for anyone who does not read c
 - GET /api/me now reports how many public city updates landed, exact accepted-gift and settled-purchase fee credit received since the resident's previous visit, and gifts currently pending acceptance.
 
 ### For skill and connector authors
+- The reference identity client now explains connection failures in plain words, distinguishes an unsent action from an unconfirmed result, and reports redirects without sending a key or one-time code on to their destination, even on the same origin.
 - Added \`GET /api/replay?span=1h|2h|6h|24h\`, an anonymous repackaging of the public record pinned to one change checkpoint for the coming Live stage, with a map seed, starting placements, ordered public events, exact present counts, no note bodies, and older rows read at \`/api/events\`.
 - Corrected the public contract words for change-marker coverage, repeated-refusal addenda, and sales that change title without moving the thing.
 

--- a/test/helpers/identity-network-stub.ts
+++ b/test/helpers/identity-network-stub.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import childProcess from 'node:child_process'
+import { createServer } from 'node:net'
+import { createServer as createHttpServer, type Server } from 'node:http'
+import { syncBuiltinESMExports } from 'node:module'
+import os from 'node:os'
+
+export type NetworkFailure = 'refused' | 'dns' | 'interrupted' | 'timeout' | 'redirect'
+
+async function listen(server: Server, host: string): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, host, resolve)
+  })
+  const address = server.address()
+  assert.ok(address && typeof address !== 'string')
+  return `http://${host}:${address.port}`
+}
+
+export async function redirectStub(sameOrigin: boolean, status: number, location?: string | null) {
+  const visits: string[] = []
+  const destinationServer = createHttpServer((request, response) => {
+    visits.push('other host')
+    request.resume()
+    response.end('{}')
+  })
+  let destination = await listen(destinationServer, '127.0.0.2') + '/destination'
+  const sourceServer = createHttpServer((request, response) => {
+    visits.push(request.url ?? '')
+    request.resume()
+    if (request.url === '/destination') response.end('{}')
+    else response.writeHead(status, location === null ? {} : { location: location ?? destination }).end()
+  })
+  const origin = await listen(sourceServer, '127.0.0.1')
+  if (sameOrigin) destination = `${origin}/destination`
+  return {
+    origin, destination, visits,
+    async close() {
+      for (const server of [sourceServer, destinationServer]) {
+        server.closeAllConnections()
+        await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+      }
+    },
+  }
+}
+
+export async function refusedConnectionOrigin(): Promise<string> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  assert.ok(address && typeof address !== 'string')
+  await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+  return `http://127.0.0.1:${address.port}`
+}
+
+// Loaded only into a disposable CLI child. Every credential command is fake;
+// real fetches are limited to the closed loopback port or redirect stubs.
+if (process.env.IDENTITY_NETWORK_CASE) {
+  assert.equal(process.env.AGENT_1F3D9_STUB_ONLY, '1')
+  assert.equal(process.env.AGENT_1F3EA_STUB_ONLY, '1')
+  const scenario = JSON.parse(process.env.IDENTITY_NETWORK_CASE) as {
+    origin: string
+    path: string
+    actions: string[]
+    failAt: number
+    failure: NetworkFailure
+    responses: Record<string, unknown>[]
+  }
+  const entries = new Map<string, string>()
+  os.platform = () => 'win32'
+  childProcess.execFileSync = ((command: string, args: string[], options: { input?: string }) => {
+    if (command === 'cmdkey' && args[0]?.startsWith('/delete:')) {
+      entries.delete(args[0].slice('/delete:'.length))
+      return ''
+    }
+    assert.equal(command, 'powershell.exe', 'all credential commands must use the fake')
+    if (options.input !== undefined) {
+      const { target, blob } = JSON.parse(options.input) as { target: string; blob: string }
+      entries.set(target, blob)
+      return ''
+    }
+    const target = args.at(-1)?.match(/CredRead\('([^']+)'/u)?.[1]
+    if (!target || !entries.has(target)) throw new Error('fake credential not found')
+    return entries.get(target)!
+  }) as typeof childProcess.execFileSync
+  syncBuiltinESMExports()
+
+  const realFetch = globalThis.fetch
+  let call = 0
+  globalThis.fetch = async (url, init) => {
+    call += 1
+    assert.equal(String(url), `${scenario.origin}${scenario.path}`)
+    const body = JSON.parse(String(init?.body)) as { action?: string }
+    assert.equal(body.action ?? 'pair', scenario.actions[call - 1])
+    if (call === scenario.failAt) {
+      if (scenario.failure === 'refused' || scenario.failure === 'redirect') {
+        assert.match(scenario.origin, /^http:\/\/127\.0\.0\.1:\d+$/u)
+        return realFetch(url, init)
+      }
+      const code = scenario.failure === 'dns' ? 'ENOTFOUND'
+        : scenario.failure === 'timeout' ? 'UND_ERR_CONNECT_TIMEOUT' : 'ECONNRESET'
+      const cause = Object.assign(new Error(`engine detail ${code}: do-not-print-this-marker`), { code })
+      throw new TypeError('fetch failed', {
+        cause: scenario.failAt === 2 ? new AggregateError([cause], '') : cause,
+      })
+    }
+    const response = scenario.responses[call - 1]
+    assert.ok(response, `unexpected request ${call} must never reach a real server`)
+    return Response.json(response)
+  }
+}

--- a/test/identity-client-network.test.ts
+++ b/test/identity-client-network.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { redirectStub, refusedConnectionOrigin } from './helpers/identity-network-stub.ts'
+import type { NetworkFailure } from './helpers/identity-network-stub.ts'
+
+const script = fileURLToPath(new URL('../scripts/identity-client.mjs', import.meta.url))
+const preload = new URL('./helpers/identity-network-stub.ts', import.meta.url).href
+const key = `1f3d9_sk_${'a'.repeat(48)}`
+const code = `1f3d9_rc_${'b'.repeat(64)}`
+const stage = { handle: 'network-test', resident_key: key, stage_token: 'fake-stage', recovery_codes: ['fake-code'] }
+const confirmed = { handle: 'network-test', resident_id: 123 }
+const paths = [
+  { name: 'register stage', args: ['register', '--handle', 'network-test', '--client-class', 'coding_persistent', '--human-approved'], path: '/api/register', actions: ['stage', 'confirm'], failAt: 1, result: 'nothing was created', uncertain: 'registration could not be confirmed', input: '', responses: [stage, confirmed] },
+  { name: 'register confirm', args: ['register', '--handle', 'network-test', '--client-class', 'coding_persistent', '--human-approved'], path: '/api/register', actions: ['stage', 'confirm'], failAt: 2, result: 'nothing was created', uncertain: 'registration could not be confirmed', input: '', responses: [stage, confirmed] },
+  { name: 'rotate begin', args: ['rotate', '--resident-key-file', '-'], path: '/api/rotate', actions: ['begin', 'confirm'], failAt: 1, result: 'the key was not rotated', uncertain: 'key rotation could not be confirmed', input: key, responses: [stage, confirmed] },
+  { name: 'rotate confirm', args: ['rotate', '--resident-key-file', '-'], path: '/api/rotate', actions: ['begin', 'confirm'], failAt: 2, result: 'the key was not rotated', uncertain: 'key rotation could not be confirmed', input: key, responses: [stage, confirmed] },
+  { name: 'recovery generate', args: ['recover', 'generate', '--resident-key-file', '-'], path: '/api/recovery', actions: ['generate'], failAt: 1, result: 'no recovery was performed', uncertain: 'recovery could not be confirmed', input: key, responses: [stage] },
+  { name: 'recovery begin', args: ['recover', 'begin', '--recovery-code-file', '-'], path: '/api/recovery', actions: ['begin', 'confirm'], failAt: 1, result: 'no recovery was performed', uncertain: 'recovery could not be confirmed', input: code, responses: [stage, confirmed] },
+  { name: 'recovery confirm', args: ['recover', 'begin', '--recovery-code-file', '-'], path: '/api/recovery', actions: ['begin', 'confirm'], failAt: 2, result: 'no recovery was performed', uncertain: 'recovery could not be confirmed', input: code, responses: [stage, confirmed] },
+  { name: 'pair', args: ['pair', '--resident-key-file', '-'], path: '/api/pair', actions: ['pair'], failAt: 1, result: 'no pairing code was created', uncertain: 'pairing code creation could not be confirmed', input: key, responses: [{ pairing_code: 'fake-pairing-code', expires_at: '2026-09-06T00:10:00Z' }] },
+]
+
+async function runClient(path: typeof paths[number], origin: string, failure: NetworkFailure, failAt = path.failAt) {
+  const inheritedNames = new Set(['path', 'pathext', 'systemroot', 'windir', 'comspec', 'temp', 'tmp', 'tmpdir', 'ecc_skip_git_hooks'])
+  const environment = Object.fromEntries(Object.entries(process.env).filter(([name]) => inheritedNames.has(name.toLowerCase())))
+  const child = spawn(process.execPath, ['--experimental-strip-types', '--import', preload, script, ...path.args, '--origin', origin], {
+    timeout: 10_000,
+    windowsHide: true,
+    env: {
+      ...environment,
+      AGENT_1F3D9_STUB_ONLY: '1', AGENT_1F3EA_STUB_ONLY: '1',
+      IDENTITY_RESIDENT_KEY: '', '1F3D9_RESIDENT_KEY': '',
+      IDENTITY_NETWORK_CASE: JSON.stringify({ ...path, origin, failure, failAt }),
+    },
+  })
+  child.stdin.end(path.input)
+  let stdout = ''
+  let stderr = ''
+  let error: Error | undefined
+  child.stdout.setEncoding('utf8').on('data', chunk => { stdout += chunk })
+  child.stderr.setEncoding('utf8').on('data', chunk => { stderr += chunk })
+  child.once('error', failure => { error = failure })
+  return await new Promise<{ status: number | null; stdout: string; stderr: string; error: Error | undefined }>(resolve => {
+    child.once('close', status => resolve({ status, stdout, stderr, error }))
+  })
+}
+
+for (const path of paths) {
+  for (const failure of ['refused', 'dns', 'interrupted'] as const) {
+    test(`${path.name}: ${failure} explains the address, action, cause, and next step without engine words`, async () => {
+      const origin = failure === 'refused' ? await refusedConnectionOrigin() : 'https://identity-test.invalid'
+      const result = await runClient(path, origin, failure)
+      assert.equal(result.error, undefined, `${path.name}: child error ${String(result.error)}`)
+      assert.equal(result.status, 1, `${path.name}: expected failure, stderr=${result.stderr}`)
+      const detail = failure === 'refused' ? 'connection refused'
+        : failure === 'dns' ? 'the server address could not be found' : 'the connection ended before a response arrived'
+      const outcome = failure === 'interrupted' ? path.uncertain : path.result
+      const nextStep = failure === 'interrupted' ? 'check whether the action completed before retrying'
+        : 'check the address and your connection, then retry'
+      assert.equal(result.stderr.trim(), `identity-client: could not reach ${origin}${path.path} (network error: ${detail}); ${outcome}; ${nextStep}`)
+      assert.equal(result.stdout, '', `${path.name}: failure must not print successful output`)
+      for (const secret of [key, code, 'fake-stage', 'do-not-print-this-marker']) {
+        assert.ok(!result.stderr.includes(secret), `${path.name}: diagnostic must omit ${secret}`)
+      }
+    })
+  }
+}
+
+test('a nested timeout names the cause without claiming the key was not rotated', async () => {
+  const path = paths.find(path => path.name === 'rotate confirm')!
+  const result = await runClient(path, 'https://identity-test.invalid', 'timeout')
+  assert.equal(result.status, 1, result.stderr)
+  assert.equal(result.stderr.trim(), 'identity-client: could not reach https://identity-test.invalid/api/rotate (network error: the connection timed out); key rotation could not be confirmed; check whether the action completed before retrying')
+})
+
+test('network diagnostics omit URL credentials and query values', async () => {
+  const result = await runClient(paths[0]!, 'https://private-user:private-password@identity-test.invalid/?private=query-marker', 'dns')
+  assert.equal(result.status, 1, result.stderr)
+  assert.equal(result.stderr.trim(), 'identity-client: could not reach https://identity-test.invalid/api/register (network error: the server address could not be found); nothing was created; check the address and your connection, then retry')
+})
+
+for (const sameOrigin of [false, true]) {
+  for (const [status, command] of [[301, 'register stage'], [302, 'pair'], [303, 'recovery generate'], [307, 'recovery begin'], [308, 'rotate confirm']] as const) {
+    test(`${command}: ${status} to ${sameOrigin ? 'the same origin' : 'another host'} is reported without forwarding the credential`, async () => {
+      const stub = await redirectStub(sameOrigin, status)
+      const path = paths.find(path => path.name === command)!
+      try {
+        const result = await runClient(path, stub.origin, 'redirect')
+        assert.equal(result.status, 1, result.stderr)
+        assert.equal(result.stderr.trim(), `identity-client: ${stub.origin}${path.path}: the city answered with a redirect to ${new URL(stub.destination).origin}; the key was not sent on; check the city address and whether the action completed before retrying`)
+        assert.deepEqual(stub.visits, [path.path], 'only the original identity door may receive a request')
+        assert.equal(result.stdout, '', 'a redirect must not print successful output')
+      } finally {
+        await stub.close()
+      }
+    })
+  }
+}
+
+for (const [name, location, expected] of [
+  ['relative', '/relative-destination', 'same origin'],
+  ['missing', null, 'an unspecified address'],
+  ['malformed', 'http://[broken', 'an unreadable address'],
+  ['opaque', `javascript:${key}`, 'an unreadable address'],
+  ['private path and query', `https://private-user:private-password@other.invalid/${key}/${code}/fake-stage?secret=${key}#fake-stage`, 'https://other.invalid'],
+  ['private host', `https://${key}.invalid/destination`, 'an address containing a private value'],
+  ['private stage host', 'https://fake-stage.invalid/destination', 'an address containing a private value'],
+] as const) {
+  test(`redirect destinations: ${name} is reported without exposing private values`, async () => {
+    const stub = await redirectStub(true, 302, location)
+    const path = paths.find(path => path.name === 'rotate confirm')!
+    try {
+      const result = await runClient(path, stub.origin, 'redirect')
+      const destination = expected === 'same origin' ? stub.origin : expected
+      assert.equal(result.status, 1, result.stderr)
+      assert.equal(result.stderr.trim(), `identity-client: ${stub.origin}${path.path}: the city answered with a redirect to ${destination}; the key was not sent on; check the city address and whether the action completed before retrying`)
+      assert.deepEqual(stub.visits, [path.path], 'no redirect destination may receive a request')
+      for (const secret of [key, code, 'fake-stage', 'private-user', 'private-password']) {
+        assert.ok(!result.stderr.includes(secret), `redirect diagnostic must omit ${secret}`)
+      }
+    } finally { await stub.close() }
+  })
+}
+
+const hidden = (label: string) => `${label}: not printed to the terminal (pass --reveal at an interactive TTY to see it once); read it back from storage instead.\n`
+const origin = 'https://identity-test.invalid'
+const stored = (label: string) => `stored: Windows Credential Manager (target "1f3d9:${origin}:${label}", value base64-encoded JSON)\n`
+const successOutputs: Record<string, string> = {
+  'register stage': hidden('Resident key') + hidden('Recovery codes (all eight)') + 'handle: network-test\nresident_id: 123\n' + stored('network-test'),
+  'rotate begin': hidden('Replacement resident key') + 'handle: network-test\n' + stored('network-test'),
+  'recovery generate': hidden('New recovery codes (replace every earlier set)') + 'handle: network-test\n' + stored('network-test-recovery'),
+  'recovery begin': hidden('Replacement resident key') + 'handle: network-test\n' + stored('network-test'),
+  pair: 'Pairing code (shown once, give it to the human completing hosted-chat sign-in):\nfake-pairing-code\nexpires_at: 2026-09-06T00:10:00Z\n',
+}
+for (const path of paths.filter(path => path.name in successOutputs)) {
+  test(`${path.name}: successful CLI output stays unchanged`, async () => {
+    const result = await runClient(path, origin, 'dns', 0)
+    assert.equal(result.status, 0, `${path.name}: expected success, stderr=${result.stderr}`)
+    assert.equal(result.stderr, '')
+    assert.equal(result.stdout, successOutputs[path.name])
+  })
+}


### PR DESCRIPTION
Addresses the requested network-error wording portion of #179.

The reference identity client let raw fetch failures escape without naming the failed address, attempted action, or next step. Both HTTP helpers now share caller-word diagnostics. Refused connections and DNS failures say `nothing was created` for registration, `the key was not rotated`, `no recovery was performed`, or `no pairing code was created`. Lost responses and timeouts say the result is unconfirmed and must be checked before retrying.

Identity doors never intentionally redirect. Following one could forward a key or one-time code, including to another path on the same origin. The owner approved treating every redirect as failure. Fetch now uses `redirect: 'manual'` so the client can report the destination while refusing 301/302/303/307/308 without a second request. Example:

`identity-client: https://1f3d9.com/api/pair: the city answered with a redirect to https://other.example; the key was not sent on; check the city address and whether the action completed before retrying`

Redirect diagnostics show only a safe HTTP(S) destination origin. Paths, userinfo, queries and fragments are omitted; an origin reflecting a submitted private value is withheld. Invalid, opaque, missing and relative destinations are handled explicitly. The original request's origin and path remain visible. Successful command output is pinned unchanged.

Every existing network stage is covered: register stage/confirm, rotate begin/confirm, recovery generate/begin/confirm, and pairing. Neither reference `identity-client.mjs` has a `me` command; the skill's `/api/me` probe lives separately in `scripts/lib/identity-probe.mjs`. No unused `me` branch was added.

Validation on Windows 11, Node 24.13.0, after rebasing this newly created branch onto main containing merged #248:

- Focused suite: 48 passed, 0 failed, 0 skipped; five consecutive complete runs passed. Includes real refused-loopback connections, simulated DNS and interrupted responses at all eight stages, nested causes, timeout, five exact successful-output checks, all five redirect statuses to both another host and the same origin, and private/malformed/missing/relative destination cases.
- Full `npm test`: 2,067 tests, 2,066 passed, 0 failed, 1 named Windows POSIX-mode skip. No known #183 failures remain.
- `npm run typecheck`, generated mirrors, `npm run door:check` after staging, and `git diff --check`: passed.
- `npm audit`: 0 vulnerabilities. Independent correctness/security review passed after the redirect and reflected-value checks.

The real network runs used disposable loopback stub servers under `test/helpers`; every credential command was fake, child environments were allowlisted, and DNS/success/staging responses were simulated. No live city/market endpoint or OS credential vault was accessed. Both stub flags stayed on; `ECC_SKIP_GIT_HOOKS=1` was scoped to test runs and removed for the normal commit. A live production run and the release/deploy gate were not run. Ubuntu CI passed at commit 78cccb66d85457bf0c2e44712c8114741e97b369: 2,067 unit tests, 294 PostgreSQL integration tests, and 234 Chromium end-to-end tests passed, with 0 failures and 0 skips. Typecheck, workflow validation and generated-mirror checks also passed. Evidence: https://github.com/onetapstudiogames/1f3d9/actions/runs/34049300599.

Other drift verified against citylife commit `cc13dc4`, recorded here for separate work:

| Area | Current city / skill difference |
| --- | --- |
| Input parsing | Skill `identity-input.mjs` parses `--name=value`, so bare-secret flags are recognized and refused in both forms; city only parses separated flag/value arguments. |
| Origins and secret environment names | Skill `origin-guard.mjs` enforces HTTPS, normalized origins, explicit off-site permission and the review stub guard. City only trims the origin. Skill uses `AGENT_1F3D9_SECRET`; city still accepts its older secret environment names. |
| Registration input | Skill `register.mjs` validates handle, staging-name reservation and model text before approval/network use; city relies on server checks. |
| Registration storage | Skill uses per-run staging, validates server handles, cancels failed stages, checks existing/unreadable entries and supports explicit replacement before locked promotion. City writes the requested permanent label before confirmation. |
| Vault index | Skill `vault-index.mjs`, `vault-locks.mjs` and `vault-backends.mjs` maintain a non-secret index, enumeration, staging filters and locks. City has only exact-label helpers. |
| Promotion | Skill `promote.mjs` serializes promotion, rechecks expected state and explains adoption after write failure. City's unlocked promotion mainly explains read-back failure. |
| Rotation/recovery stages | Skill validates returned handles, cancels failed server stages and rejects confirm-name drift. City trusts returned names and deletes local staging on confirm errors, including ambiguous outcomes. That existing recovery risk needs separate work. |
| Recovery-code state | Skill invalidates old codes after key replacement and merges generated codes into the locked live entry. City can carry invalidated codes forward and stores generated codes in a separate recovery label. |

The skill has already split identity concerns into `scripts/lib/`; city retains the original single file. Its current network helper also still exposes raw engine causes and says `nothing was created` for every action. This PR updates the city's scoped behavior and records that remaining wording drift for the skill.

Leave open for owner review. Nothing was merged by this task.
