### PR TITLE
docs: the live view moves to its own Phaser repo

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -5,6 +5,15 @@ preserved in [archive/2026-08/RESOLVED_QUESTIONS.md](archive/2026-08/RESOLVED_QU
 
 ## Current follow-ups
 
+- [ ] The live view is being rebuilt as its own Phaser page in
+  [onetapstudiogames/1f3d9-live](https://github.com/onetapstudiogames/1f3d9-live) (owner
+  decision, 2026-09-07; plan in that repo's `docs/PLAN.md`). The current Live tab stays as it
+  is until that page is good. Then: point the Live tab at the new page, delete the old stage
+  code (`src/window-client/program/2*-live-*.ts`, `42-stage-nodes.ts`, `live-*.ts`) with
+  `e2e/public-window-live.spec.ts` and `test/window-live-client.test.ts`, and retire the
+  Live sentences the door and docs carry for it. Small public facts the page needs
+  (`asleep since`, `joined_at` on the replay's start block, a law summary per place) come
+  through ordinary PRs with door words.
 - [ ] After explicit release approval, apply the public-snapshot migration, provision
   the restricted export login, complete the manual dry run, and publish the first dated
   snapshot using [runbooks/PUBLIC_SNAPSHOTS.md](runbooks/PUBLIC_SNAPSHOTS.md).

--- a/docs/drafts/live-stage-blueprint.md
+++ b/docs/drafts/live-stage-blueprint.md
@@ -1,5 +1,11 @@
 # Live view round two: the stage
 
+> **Superseded on 2026-09-07.** Steps 1 to 3 shipped (#235, #237, #238) and step 4 was
+> closed unmerged (#253). The owner decided to rebuild the live view as its own Phaser page in
+> [onetapstudiogames/1f3d9-live](https://github.com/onetapstudiogames/1f3d9-live); its
+> `docs/PLAN.md` replaces steps 4 to 15 below. The replay file (step 3) and the pure ground
+> math from step 4 carried over. This document stays for the record.
+
 ## Pitch
 
 The Live tab today is a cartographic plate that redraws itself, and the owner watched it and rejected the feel: figures blink because the plate replaces its whole layer on every paint, arrivals appear as settled residue rather than as anything happening, and the tab spends its opening moments proving how much history it fetched. Round two replaces the plate's behaviour with a stage. Opening Live starts a replay of the last 24 hours of the public record, played in recorded order at a pace set by the actions themselves, and when the head reaches the present the stage simply keeps running live with no mode change. Every resident and thing on screen owns one DOM node keyed by its record id for as long as it is on screen, so a change animates a node instead of replacing it. The city serves the span as one pinned file so the watcher never sees a page-follow loop or the loading state it produces, and one small clock is the only device that explains anything, printing the stage time while replaying and `now` when live. Nothing about the record, the physics, or the resident-facing doors changes. The stage is a new way of reading facts the city already publishes, and every animated claim still traces to a record id.


### PR DESCRIPTION
Owner decision, 2026-09-07: the live view is rebuilt as its own Phaser page in https://github.com/onetapstudiogames/1f3d9-live. This PR only points docs/TASKS.md at it (with the later clean-up of the old stage code listed) and marks docs/drafts/live-stage-blueprint.md superseded from step 4 on. No code, no door words, no mirrors change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)