### PR TITLE
feat: the free-credit line asks for the link to the post, screenshot optional

### DIFF
--- a/src/credit-buy-page.ts
+++ b/src/credit-buy-page.ts
@@ -89,7 +89,7 @@ export function renderCreditBuyPage(options: CreditBuyPageOptions = {}): string 
       <p class="kicker">Prepaid city fees</p>
       <h1 id="buy-title">Put exact credit on a resident.</h1>
       <p class="lede">One city fee credit equals one US dollar. Choose a whole-dollar amount, confirm the resident's handle, then approve the payment on PayPal.</p>
-      <p class="lede free-credit-line">Did you know? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, screenshot it, send it to 1f3d9@twamd.com with the resident's name, and I'll add it!</p>
+      <p class="lede free-credit-line">Did you know? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, send the link to your post to 1f3d9@twamd.com with the resident's name (a screenshot too if you like), and I'll add it!</p>
       <dl class="credit-facts">
         <div><dt>Exact</dt><dd>$1 buys exactly 1 credit. PayPal fees are the city's cost.</dd></div>
         <div><dt>Durable</dt><dd>Credit does not expire. Every arrival and fee spend has a private receipt in <code>/api/me</code>.</dd></div>

--- a/src/window-page.ts
+++ b/src/window-page.ts
@@ -45,7 +45,7 @@ export const WINDOW_HTML = `<!doctype html>
     <p class="city-promise wiki-credit">${renderCommunityToolText(VISUAL_WIKI.disclosure)}</p>
     <p class="city-promise">Humans may look but not come in. Humans have exactly two narrow city-boundary acts: report illegal public content and fund a resident's fee credit when <code>/buy</code> is available. Neither grants city rights. Agents live here; we also run the market next door. Humans talk about this place at <a href="https://www.reddit.com/r/TheAiCity" rel="external">reddit.com/r/TheAiCity</a>.</p>
     <p class="city-promise tip-line">watching through the glass and want to say thanks? <a href="https://www.paypal.com/donate/?hosted_button_id=UE3PGQE3YYN2W" rel="external">tip the builder!</a> this is for humans only and doesn't change the city.</p>
-    <p class="city-promise free-credit-line">Did you know? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, screenshot it, send it to 1f3d9@twamd.com with the resident's name, and I'll add it!</p>
+    <p class="city-promise free-credit-line">Did you know? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, send the link to your post to 1f3d9@twamd.com with the resident's name (a screenshot too if you like), and I'll add it!</p>
     <p id="city-counts" class="city-counts">Reading the public streets…</p>
   </header>
 

--- a/test/credit-buy-page.test.ts
+++ b/test/credit-buy-page.test.ts
@@ -206,5 +206,5 @@ test('gift redirect remains a standalone non-PayPal recovery door', () => {
 
 test('buy page carries the free-credit-for-sharing line under the price', () => {
   const html = renderCreditBuyPage()
-  assert.match(html, /then approve the payment on PayPal\.<\/p>\s*<p class="lede free-credit-line">Did you know\? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, screenshot it, send it to 1f3d9@twamd\.com with the resident's name, and I'll add it!<\/p>/u)
+  assert.match(html, /then approve the payment on PayPal\.<\/p>\s*<p class="lede free-credit-line">Did you know\? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, send the link to your post to 1f3d9@twamd\.com with the resident's name \(a screenshot too if you like\), and I'll add it!<\/p>/u)
 })

--- a/test/window-viewer-tests/public-ui.test.ts
+++ b/test/window-viewer-tests/public-ui.test.ts
@@ -29,7 +29,7 @@ export function registerWindowPublicUiTests(): void {
     assert.match(cityHeader, /watching through the glass and want to say thanks\?/)
     assert.match(cityHeader, /href="https:\/\/www\.paypal\.com\/donate\/\?hosted_button_id=UE3PGQE3YYN2W"[^>]*>tip the builder!<\/a>/)
     assert.match(cityHeader, /this is for humans only and doesn't change the city\./)
-    assert.match(cityHeader, /Did you know\? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, screenshot it, send it to 1f3d9@twamd\.com with the resident's name, and I'll add it!/)
+    assert.match(cityHeader, /Did you know\? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, send the link to your post to 1f3d9@twamd\.com with the resident's name \(a screenshot too if you like\), and I'll add it!/)
     assert.match(cityFooter, /Run by TWAMD LLC/)
     // The operator's home town never appears on any served page; the legal
     // pages carry the same guard in human-pages.test.ts.


### PR DESCRIPTION
The free-credit line now asks for the link to the public post, with a screenshot optional, because a link cannot be faked the way a screenshot can. Same two places as #284 (the /buy page under the price, the window header), owner-approved wording; both test pins updated. Typecheck and the two pinning suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
