### PR TITLE
fix: drop the wiki independence note from the window strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Plain-language notes about what changed on 1F3D9, for anyone who does not read code. Entries are grouped by date, then by who the change is mainly for. One sentence per change. This file is also served at [/changelog](https://1f3d9.com/changelog), as a web page and as plain text.
 
+## 2026-09-09
+
+### For humans watching
+- The window header is one short strip now: the help links in a line, Buy fee credit and Tip the builder as the only buttons, the boundary sentence, the free-credit note, and a City facts control beside the pickers, while the wiki independence note stays on the Tools page.
+
 ## 2026-09-08
 
 ### For residents

--- a/docs/window-calm-plan.md
+++ b/docs/window-calm-plan.md
@@ -130,7 +130,7 @@ The owner reviewed this looking pass and approved a much smaller change than the
 
 ### One calm strip beneath the unchanged title and status box
 
-Replace the button row and four green boxes with a single compact strip. Its first row has plain links for What is this?, How do I connect?, Tools, and Solward's Visual Wiki, with `(independent, not run by us)` beside the wiki. Buy fee credit and Tip the builder are the only button-styled links, aligned right on desktop and wrapping as shown on the phone. Buy fee credit retains its existing availability gate. Keep every destination, including Reddit inside the boundary band and the original PayPal tip destination. The tip's humans-only, buys-nothing, changes-nothing meaning stays in its link description and the unchanged footer.
+Replace the button row and four green boxes with a single compact strip. Its first row has plain links for What is this?, How do I connect?, Tools, and Solward's Visual Wiki. The wiki's independence note stays on the Tools page, not in the strip. Buy fee credit and Tip the builder are the only button-styled links, aligned right on desktop and wrapping as shown on the phone. Buy fee credit retains its existing availability gate. Keep every destination, including Reddit inside the boundary band and the original PayPal tip destination. The tip's humans-only, buys-nothing, changes-nothing meaning stays in its link description and the unchanged footer.
 
 The second band uses normal-weight text and the mock's boundary sentence:
 

--- a/e2e/window-calm.spec.ts
+++ b/e2e/window-calm.spec.ts
@@ -58,7 +58,8 @@ test('header links have exact destinations and only money actions look like butt
       return { background: style.backgroundColor, border: style.borderTopWidth }
     })).toEqual({ background: 'rgba(0, 0, 0, 0)', border: '0px' })
   }
-  await expect(guide).toContainText("Solward's Visual Wiki (independent, not run by us)")
+  await expect(guide).toContainText("Solward's Visual Wiki")
+  await expect(guide).not.toContainText('independent, not run by us')
 
   const tip = guide.getByRole('link', { name: 'Tip the builder', exact: true })
   await expect(tip).toHaveAttribute(

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -3,6 +3,11 @@ export const CHANGELOG_MARKDOWN = `# Changelog
 
 Plain-language notes about what changed on 1F3D9, for anyone who does not read code. Entries are grouped by date, then by who the change is mainly for. One sentence per change. This file is also served at [/changelog](https://1f3d9.com/changelog), as a web page and as plain text.
 
+## 2026-09-09
+
+### For humans watching
+- The window header is one short strip now: the help links in a line, Buy fee credit and Tip the builder as the only buttons, the boundary sentence, the free-credit note, and a City facts control beside the pickers, while the wiki independence note stays on the Tools page.
+
 ## 2026-09-08
 
 ### For residents

--- a/src/window-page.ts
+++ b/src/window-page.ts
@@ -41,7 +41,7 @@ export const WINDOW_HTML = `<!doctype html>
       <span class="window-link-dot" aria-hidden="true">·</span>
       <a href="/tools">Tools</a>
       <span class="window-link-dot" aria-hidden="true">·</span>
-      ${renderCommunityToolLink(VISUAL_WIKI)} <span class="wiki-credit">(independent, not run by us)</span>
+      ${renderCommunityToolLink(VISUAL_WIKI)}
       <span class="window-guide-spacer" aria-hidden="true"></span>
       <!-- WINDOW_BUY_LINK -->
       <a class="window-strip-button tip-button" href="https://www.paypal.com/donate/?hosted_button_id=UE3PGQE3YYN2W" rel="external" title="For humans only; buys nothing and changes nothing in the city.">Tip the builder</a>

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -161,8 +161,7 @@ button { color: inherit; }
   text-underline-offset: 3px;
   white-space: nowrap;
 }
-.window-link-dot, .window-guide-links .wiki-credit { color: #6e9689; }
-.window-guide-links .wiki-credit { white-space: nowrap; }
+.window-link-dot { color: #6e9689; }
 .window-guide-spacer { flex: 1 1 auto; }
 .window-guide-links a.window-strip-button {
   padding: 7px 14px;

--- a/test/human-pages.test.ts
+++ b/test/human-pages.test.ts
@@ -357,9 +357,9 @@ test('the window and tools page share the canonical Visual Wiki link and disclos
   assert.match(toolsHtml, new RegExp(sharedLink, 'u'))
   assert.match(windowHtml, new RegExp(sharedLink, 'u'))
   assert.equal(toolsHtml.includes(wiki.disclosure), true)
-  assert.equal(windowHtml.includes(
-    sharedLink + ' <span class="wiki-credit">(independent, not run by us)</span>',
-  ), true)
+  assert.equal(windowHtml.includes(sharedLink), true)
+  assert.equal(windowHtml.includes('wiki-credit'), false)
+  assert.equal(windowHtml.includes('(independent, not run by us)'), false)
   assert.match(toolsHtml, /<a href="\/window">Window<\/a>/iu)
   assert.match(windowHtml, /<a href="\/tools">Tools<\/a>/iu)
 })

--- a/test/window-viewer-tests/public-ui.test.ts
+++ b/test/window-viewer-tests/public-ui.test.ts
@@ -35,7 +35,8 @@ export function registerWindowPublicUiTests(): void {
     assert.match(cityHeader, /href="https:\/\/www\.paypal\.com\/donate\/\?hosted_button_id=UE3PGQE3YYN2W"[^>]*>Tip the builder<\/a>/)
     assert.match(cityHeader, /title="[^"]*humans only[^"]*buys nothing[^"]*changes nothing[^"]*"/iu)
     assert.match(cityHeader, /Did you know\? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, send the link to your post to 1f3d9@twamd\.com with the resident's name \(a screenshot too if you like\), and I'll add it!/)
-    assert.match(cityHeader, /Solward&#39;s Visual Wiki[\s\S]{0,120}\(independent, not run by us\)/u)
+    assert.match(cityHeader, /Solward&#39;s Visual Wiki/u)
+    assert.doesNotMatch(cityHeader, /independent, not run by us/u)
     assert.match(WINDOW_CSS, /#share-status:empty\s*\{\s*display:\s*none/u)
     assert.match(cityFooter, /Run by TWAMD LLC/)
     // The operator's home town never appears on any served page; the legal


### PR DESCRIPTION
The owner saw the wiki credit "(independent, not run by us)" wrap onto its own line under the help links on a wide phone (1f3d9.com/window, 2026-09-09) and asked for it to go. The strip now shows only the wiki link; the full disclosure (made by resident Solward, independent, not run by us) stays on the Tools page, where the community tool entry carries it.

Changes: `src/window-page.ts` drops the span, `src/window-style.ts` drops its dead rule, the three tests that pinned the old text (`test/human-pages.test.ts`, `test/window-viewer-tests/public-ui.test.ts`, `e2e/window-calm.spec.ts`) now pin its absence, `docs/window-calm-plan.md` says where the note lives, and `CHANGELOG.md` gets the strip line that #288 did not add (embedded into `src/changelog-source.ts` by the script).

Gate on 96a44c4: typecheck ok; unit 2272 pass, 0 fail; door:check ok; refusal census ok; `e2e/window-calm.spec.ts`, `e2e/human-pages.spec.ts`, `e2e/quiet-room-leak-scan.spec.ts` 16 passed. Merge on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
