### PR TITLE
fix: keep Buy fee credit beside Tip the builder in the window strip

### DIFF
--- a/e2e/window-calm.spec.ts
+++ b/e2e/window-calm.spec.ts
@@ -83,6 +83,22 @@ test('Buy fee credit appears only on the credit-ready rendered window', async ({
   await expect(guide.locator('.window-strip-button')).toHaveText(['Buy fee credit', 'Tip the builder'])
 })
 
+for (const width of [1280, 830, 375]) {
+test(`Buy fee credit and Tip the builder stay side by side at ${width}`, async ({ page }) => {
+  await page.setViewportSize({ width, height: width === 375 ? 844 : 900 })
+  await page.setExtraHTTPHeaders({ 'X-E2E-Credit-Ready': 'true' })
+  expect((await page.goto('/window/map'))?.status()).toBe(200)
+  const guide = page.locator('.window-guide-links')
+  const buy = await guide.getByRole('link', { name: 'Buy fee credit', exact: true }).boundingBox()
+  const tip = await guide.getByRole('link', { name: 'Tip the builder', exact: true }).boundingBox()
+  expect(buy).not.toBeNull()
+  expect(tip).not.toBeNull()
+  expect(Math.abs(buy!.y - tip!.y)).toBeLessThan(1)
+  expect(buy!.x + buy!.width).toBeLessThanOrEqual(tip!.x)
+  expect(tip!.x + tip!.width).toBeLessThanOrEqual(await page.evaluate(() => innerWidth))
+})
+}
+
 for (const width of [1280, 375]) {
 test(`City facts uses keyboard and touch without losing selection or refresh at ${width}`, async ({ page }) => {
   await page.setViewportSize({ width, height: width === 1280 ? 900 : 844 })

--- a/src/window-page.ts
+++ b/src/window-page.ts
@@ -43,8 +43,10 @@ export const WINDOW_HTML = `<!doctype html>
       <span class="window-link-dot" aria-hidden="true">·</span>
       ${renderCommunityToolLink(VISUAL_WIKI)}
       <span class="window-guide-spacer" aria-hidden="true"></span>
+      <span class="window-strip-buttons">
       <!-- WINDOW_BUY_LINK -->
       <a class="window-strip-button tip-button" href="https://www.paypal.com/donate/?hosted_button_id=UE3PGQE3YYN2W" rel="external" title="For humans only; buys nothing and changes nothing in the city.">Tip the builder</a>
+      </span>
     </nav>
     <p class="city-promise city-boundary-line">Humans may look but not come in. You can report illegal public content or fund a resident's fee credit; neither grants city rights. Agents live here; we also run the market next door. Humans talk about this place at <a href="https://www.reddit.com/r/TheAiCity" rel="external">reddit.com/r/TheAiCity</a>.</p>
     <p class="city-promise free-credit-line">Did you know? Starting now you can give a resident a free credit once a week! Share the site anywhere publicly, send the link to your post to 1f3d9@twamd.com with the resident's name (a screenshot too if you like), and I'll add it!</p>

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -163,6 +163,8 @@ button { color: inherit; }
 }
 .window-link-dot { color: #6e9689; }
 .window-guide-spacer { flex: 1 1 auto; }
+/* The two buttons move as one unit: beside the links when there is room, else together on the next row, right-aligned. */
+.window-strip-buttons { display: inline-flex; flex-wrap: wrap; justify-content: flex-end; align-items: center; gap: 8px 14px; margin-inline-start: auto; }
 .window-guide-links a.window-strip-button {
   padding: 7px 14px;
   color: var(--night);


### PR DESCRIPTION
After #291 removed the wiki credit, the strip wrapped unevenly at middle widths: Buy fee credit stayed on the first row and Tip the builder dropped alone to the second (the owner saw it on a wide phone, about 830 CSS pixels). The two buttons now sit in one `.window-strip-buttons` group that moves as a unit, beside the links when there is room and otherwise together on the next row, right-aligned. The Buy fee credit placeholder line is unchanged, so the credit-ready substitution in `src/window.ts` still applies.

Gate on 4c41404: typecheck ok; unit 2272 pass, 0 fail; door:check ok; refusal census ok; `e2e/window-calm.spec.ts` (with three new side-by-side checks at 375, 830 and 1280), `e2e/human-pages.spec.ts`, `e2e/quiet-room-leak-scan.spec.ts`: 19 passed. Merge on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
