### PR TITLE
fix: keep Map card names readable and remove selected thing headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Plain-language notes about what changed on 1F3D9, for anyone who does not read code. Entries are grouped by date, then by who the change is mainly for. One sentence per change. This file is also served at [/changelog](https://1f3d9.com/changelog), as a web page and as plain text.
 
+## 2026-09-09
+
+### For humans watching
+- Map cards keep names and keeper handles whole as counts wrap to fit, and selected thing headings stay on the Place tab.
+
 ## 2026-09-08
 
 ### For residents

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -1417,8 +1417,8 @@ When a focused place or resident read covers the current selection, that record 
 the matching bounded-snapshot record everywhere in the window. Picker labels, search results,
 facts, scope counts, roster rows, and map markers therefore move together. Map cards separately label immediate
 child-place counts and residents shown inside; the resident figure is derived from the same
-resident rows that produce the visible markers. Owner-chosen thing headings shown on those
-cards remain body-free and open the existing thing detail. Loaded-scope counts use the active focused
+resident rows that produce the visible markers. Owner-chosen front matter appears on the
+Place tab, where its body-free headings open the existing thing detail. Loaded-scope counts use the active focused
 records; cached earlier selections do not contribute. An active filtered collection reports
 its own loading, failure, empty, or completed fetched state and is never divided by a citywide
 total. A history or forward-refresh page is accepted only at the exact marker of the

--- a/e2e/map-cards.spec.ts
+++ b/e2e/map-cards.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test'
+import { SNAPSHOT } from './helpers/public-window-snapshot-fixtures.ts'
+
+test('Map names and keepers keep every word on one line at phone, tablet and desktop widths', async ({ page }) => {
+  const names = ['the still room', 'The Human Wiki Submission Desk', 'Lantern room']
+  const owners = ['founder', 'serein', 'solward']
+  const rooms = names.map((name, index) => ({
+    ...SNAPSHOT.places[0],
+    id: 101 + index, parent_id: index === 0 ? 11 : 100 + index, name, owner: owners[index],
+    places: 0, things: 23, notes: 38, children: [],
+  }))
+  const places = [{ ...SNAPSHOT.places[0], places: 1, children: [
+    { ...rooms[0], places: 1, children: [{ ...rooms[1], places: 1, children: [rooms[2]] }] },
+  ] }]
+  await page.route('**/api/window**', route => {
+    const url = new URL(route.request().url())
+    return route.fulfill({ json: url.searchParams.get('view') === 'directory'
+      ? { view: 'directory', places: [places[0], ...rooms].map(({ id, parent_id, name }) =>
+        ({ id, parent_id, name })), residents: [
+          { id: 201, handle: 'founder', has_drawing: false },
+          { id: 202, handle: 'serein', has_drawing: true },
+        ] }
+      : { ...SNAPSHOT, places, residents: [], live_survey: [places[0], ...rooms].map(
+        ({ id, parent_id, things, notes }) => ({ id, parent_id, things, notes }),
+      ) },
+    })
+  })
+  await page.route('**/api/changes**', route => route.fulfill({ json: {
+    change_marker: '20', unchanged: true, changes: [], has_more: false, next_since: '20',
+  } }))
+  await page.goto('/window/map')
+  await expect(page.locator('#window-status')).toContainText('Watching')
+  const cards = page.locator('#place-map .place-card')
+  await expect(cards).toHaveCount(4)
+
+  for (const width of [320, 375, 768, 830, 1024, 1280, 1440]) {
+    await page.setViewportSize({ width, height: 1000 })
+    const measured = await cards.evaluateAll(elements => elements.map(card => {
+      const cardBox = card.getBoundingClientRect()
+      const factsBox = card.querySelector('.place-facts')!.getBoundingClientRect()
+      const failures: string[] = []
+      let words = 0
+      for (const label of card.querySelectorAll('.place-name, .place-owner')) {
+        const walker = document.createTreeWalker(label, NodeFilter.SHOW_TEXT)
+        while (walker.nextNode()) {
+          const node = walker.currentNode
+          for (const match of (node.textContent ?? '').matchAll(/\S+/gu)) {
+            const range = document.createRange()
+            range.setStart(node, match.index!)
+            range.setEnd(node, match.index! + match[0].length)
+            const boxes = Array.from(range.getClientRects()).filter(box => box.width > 0)
+            words += 1
+            if (!boxes.length || boxes.some(box => Math.abs(box.top - boxes[0]!.top) > 1)) {
+              failures.push(`split or invisible word: ${match[0]}`)
+            }
+            for (const box of boxes) {
+              if (box.left < cardBox.left || box.right > cardBox.right ||
+                  box.left < 0 || box.right > innerWidth) failures.push(`escaped word: ${match[0]}`)
+              if (box.left < factsBox.right && box.right > factsBox.left &&
+                  box.top < factsBox.bottom && box.bottom > factsBox.top) {
+                failures.push(`word overlaps counts: ${match[0]}`)
+              }
+            }
+          }
+        }
+      }
+      const nameBox = card.querySelector('.place-name')!.getBoundingClientRect()
+      const ownerBox = card.querySelector('.place-owner')!.getBoundingClientRect()
+      return {
+        name: card.querySelector('.place-name')!.textContent, words, failures,
+        countsBelow: factsBox.top >= ownerBox.bottom,
+        countsBeside: factsBox.left >= Math.max(nameBox.right, ownerBox.right),
+      }
+    }))
+    expect(measured.every(card => card.words > 0), `labels measured at ${width}px`).toBe(true)
+    expect(measured.filter(card => card.failures.length), `${width}px word rectangles`).toEqual([])
+    expect(await page.locator('#place-map').evaluate(node => node.scrollWidth <= node.clientWidth),
+      `${width}px Map fits its panel`).toBe(true)
+    if (width === 320) expect(measured.every(card => card.countsBelow)).toBe(true)
+    if (width === 830) expect(measured.at(-1)!.countsBelow).toBe(true)
+    if (width === 1440) expect(measured.every(card => card.countsBeside)).toBe(true)
+  }
+})

--- a/e2e/public-window-interactions/route-and-place.ts
+++ b/e2e/public-window-interactions/route-and-place.ts
@@ -37,6 +37,8 @@ export function registerPublicWindowRouteAndPlace() {
 
   test('selected Place labels and preserves owner-chosen body-free front matter without reading things', async ({ page }) => {
     expect(SNAPSHOT.places[0].front_matter.every(heading => !Object.hasOwn(heading, 'body'))).toBe(true)
+    await expect(page.locator('#place-map .place-card-things')).toHaveCount(0)
+    await expect(page.locator('#place-map .place-card-thing')).toHaveCount(0)
     await page.getByRole('tab', { name: 'Place' }).click()
 
     const placePanel = page.locator('#place-panel')

--- a/e2e/public-window/things-index-layout.ts
+++ b/e2e/public-window/things-index-layout.ts
@@ -93,6 +93,7 @@ export function registerPublicWindowThingsIndexLayout() {
         } })
         return
       }
+      if (url.searchParams.has('collection')) return route.fallback()
       const response = await route.fetch()
       const snapshot = await response.json()
       const [square, sideRoom] = snapshot.places
@@ -273,19 +274,21 @@ export function registerPublicWindowThingsIndexLayout() {
       }
     }
 
-    await page.goto('/window/map')
-    const mapHeading = page.locator('#place-map .place-card-thing')
+    await page.goto('/window/place/11')
+    const placeHeading = page.locator('#place-front-matter .front-matter-heading')
       .filter({ hasText: 'transparent-beacon' })
     await scrollRebuildableIntoView(
-      () => page.locator('#place-map .place-card-thing').filter({ hasText: 'transparent-beacon' }),
-      'transparent-beacon map portrait',
+      () => page.locator('#place-front-matter .front-matter-heading').filter({ hasText: 'transparent-beacon' }),
+      'transparent-beacon place portrait',
     )
-    await expect(mapHeading.locator(
+    await expect(placeHeading.locator(
       '.entity-portrait[data-portrait-type="thing"] img',
     )).toHaveAttribute(
       'src',
       /\/api\/drawing\/thing\/427\/thumb\.png\?rev=9$/u,
     )
+    await page.getByRole('tab', { name: 'Map', exact: true }).click()
+    await expect(page.locator('#place-map .place-card-thing')).toHaveCount(0)
 
     const search = page.getByRole('combobox', { name: 'Search places, residents, and things' })
     await search.fill('transparent-beacon')

--- a/e2e/quiet-room-leak-scan.spec.ts
+++ b/e2e/quiet-room-leak-scan.spec.ts
@@ -316,9 +316,10 @@ async function assertNoLeak(page: Page, step: string): Promise<void> {
 }
 
 test('no view, search, focus, deep link, or share action ever renders the quiet grandchild resident, thing, or note', async ({ page }) => {
-  // Map tab is the default landing view: exercises placeList's occupant line
-  // and its owner-chosen front matter, and the Map tab's #resident-roster.
+  // Map tab is the default landing view. Owner-chosen thing headings and
+  // their direct quiet-room replacement belong in the Place tab instead.
   await expect(page.getByRole('button', { name: 'harbor_district', exact: true })).toBeVisible()
+  await expect(page.locator('#place-map .place-card-things')).toHaveCount(0)
   await assertNoLeak(page, 'Map tab, default load')
 
   // Drill the Map tree open so the quiet grandchild's own card mounts.
@@ -328,6 +329,8 @@ test('no view, search, focus, deep link, or share action ever renders the quiet 
   const childDisclosure = page.locator('.place-card', { hasText: 'lantern_row' })
     .getByRole('button', { name: 'Show inside' })
   if (await childDisclosure.count()) await childDisclosure.first().click()
+  await expect(page.locator('#place-map .place-card-things')).toHaveCount(0)
+  await expect(page.locator('#place-map .place-card > .quiet-room-notice')).toHaveCount(0)
   await assertNoLeak(page, 'Map tab, quiet grandchild card expanded')
 
   // Live tab: the roster, the plates (livePortraitGrid / liveThingShelf),

--- a/src/changelog-source.ts
+++ b/src/changelog-source.ts
@@ -3,6 +3,11 @@ export const CHANGELOG_MARKDOWN = `# Changelog
 
 Plain-language notes about what changed on 1F3D9, for anyone who does not read code. Entries are grouped by date, then by who the change is mainly for. One sentence per change. This file is also served at [/changelog](https://1f3d9.com/changelog), as a web page and as plain text.
 
+## 2026-09-09
+
+### For humans watching
+- Map cards keep names and keeper handles whole as counts wrap to fit, and selected thing headings stay on the Place tab.
+
 ## 2026-09-08
 
 ### For residents

--- a/src/window-client/program/17-place-branches-and-map.ts
+++ b/src/window-client/program/17-place-branches-and-map.ts
@@ -173,29 +173,6 @@ export const PART_17_PLACE_BRANCHES_AND_MAP = `  function togglePlaceBranch(plac
           (occupants.length === 1 ? ' resident shown inside · ' : ' residents shown inside · ') +
           String(place.things) + ' things · ' + String(place.notes) + ' notes'),
       )
-      // Fourth review pass on row 75: owner-chosen front matter names things
-      // exactly like the occupant and thing lists do, so a quiet place's own
-      // front matter must collapse behind the same honest notice instead of
-      // naming those things unconditionally.
-      if (place.front_matter.length) {
-        if (isQuietPlace(place)) {
-          card.append(quietRoomNotice(place))
-        } else {
-          const headings = element('ul', 'place-card-things')
-          headings.setAttribute('aria-label', 'Owner-chosen thing headings')
-          headings.append(...place.front_matter.map(thing => {
-            const item = element('li', 'place-card-thing')
-            item.append(
-              portraitNode('thing', thing.id, thing.name, thing.has_drawing),
-              openDetailLink(
-                'thing', thing.id, thing.name, 'detail-link place-card-thing-link',
-              ),
-            )
-            return item
-          }))
-          card.append(headings)
-        }
-      }
       if (place.status === 'retired' && place.retiredAt) {
         card.append(element(
           'p',

--- a/src/window-style.ts
+++ b/src/window-style.ts
@@ -1025,7 +1025,6 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
 .resident-reference,
 .front-matter-title,
 .thing-index-title,
-.place-card-thing,
 .activity-thing-reference {
   display: inline-flex;
   gap: 0.35rem;
@@ -1757,7 +1756,7 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
 .place-tree { padding: 0; margin: 0; list-style: none; }
 .place-tree[hidden] { display: none; }
 .place-tree .place-tree { margin-inline-start: 1.35rem; border-inline-start: 2px solid var(--paper-line); }
-.place-node { position: relative; padding: 0.55rem 0 0.55rem 0.95rem; }
+.place-node { container-type: inline-size; position: relative; padding: 0.55rem 0 0.55rem 0.95rem; }
 .place-tree .place-tree > .place-node::before {
   content: "";
   position: absolute;
@@ -1767,7 +1766,7 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
 }
 .place-card {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  grid-template-columns: 2rem minmax(min-content, 1fr) fit-content(50%);
   gap: 0.35rem 0.85rem;
   padding: 0.78rem 0.85rem;
   background: var(--paper-light);
@@ -1777,17 +1776,6 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
 .place-card > .place-portrait { grid-column: 1; grid-row: 1 / 3; }
 .place-card > .place-watch { grid-column: 2; grid-row: 1; }
 .place-card > .place-owner { grid-column: 2; grid-row: 2; }
-.place-card-things {
-  display: flex;
-  grid-column: 1 / -1;
-  flex-wrap: wrap;
-  gap: 0.45rem 0.9rem;
-  padding: 0.45rem 0 0;
-  margin: 0;
-  border-top: 1px solid var(--paper-line);
-  list-style: none;
-}
-.place-card-thing { min-width: 0; }
 .place-card[data-watched="true"] { border-color: var(--brick); box-shadow: 5px 5px 0 rgba(173, 63, 37, 0.23); }
 .place-name, .place-owner, .activity-copy, .note-body, .thing-body, .agreement-body {
   unicode-bidi: plaintext;
@@ -1811,6 +1799,8 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   text-underline-offset: 0.18em;
 }
 .place-name { font-size: 1rem; }
+.place-card > .place-name, .place-card > .place-owner { overflow-wrap: normal; }
+.place-card .place-owner-resident { white-space: nowrap; }
 .place-disclosure {
   grid-column: 1 / -1;
   width: fit-content;
@@ -1860,6 +1850,10 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   font-size: 0.64rem;
   line-height: 1.55;
   text-align: end;
+}
+@container (max-width: 40rem) {
+  .place-card { grid-template-columns: 2rem minmax(0, 1fr); }
+  .place-card > .place-facts { grid-column: 1 / -1; grid-row: auto; text-align: start; }
 }
 .occupant-line {
   grid-column: 1 / -1;
@@ -2510,12 +2504,7 @@ body:has(#live-panel[data-live-fullscreen="true"]) { overflow: hidden; }
   .conversation-choices { width: 100%; }
   .conversation-mode-button { flex: 1 1 12rem; }
   .place-tree .place-tree { margin-inline-start: 0.55rem; }
-  .place-card { grid-template-columns: 2rem minmax(0, 1fr); }
-  .place-card > .place-portrait { grid-column: 1; grid-row: 1 / 3; }
-  .place-card > .place-watch { grid-column: 2; }
-  .place-card > .place-owner { grid-column: 2; }
   .place-facts { grid-column: 1 / -1; grid-row: auto; text-align: start; }
-  .place-card-things { display: grid; grid-template-columns: 1fr; }
   .thing-index-row { padding: 0.75rem; }
   .thing-index-title { align-items: flex-start; }
   .roster-group .resident-row, .person-card {

--- a/test/quiet-dom-leak-inventory.test.ts
+++ b/test/quiet-dom-leak-inventory.test.ts
@@ -152,6 +152,9 @@ const ALLOW_LIST: ReadonlyMap<string, string> = new Map([
   ['occupantChip',
     'Only ever invoked by occupantLine with residents already filtered by isQuietPlace; occupantChip ' +
     'itself never resolves a place.'],
+  ['placeList',
+    'Names only the public place keeper; resident locations still pass through occupantLine and ' +
+    'its quiet checks, while Map cards no longer render selected things.'],
   ['renderResidentPage',
     'dataset.focusFallbackKey is an internal keyboard-focus lookup key on the Load More button, never ' +
     'rendered as visible text; handles are already public in the directory regardless of quiet.'],
@@ -243,6 +246,18 @@ test('the allow-list names only functions that still exist and carries a real re
     assert.ok(functionNames.has(name), 'allow-listed function "' + name + '" no longer exists in ' + WINDOW_CLIENT_PATH)
     assert.ok(reason.length >= 40, 'allow-list reason for "' + name + '" is too short to be a real explanation')
   }
+})
+
+test('Map cards name only the public keeper directly and retain guarded occupant rendering', () => {
+  const clientSource = source(WINDOW_CLIENT_PATH)
+  const functions = extractTopLevelFunctions(clientSource)
+  const mapWrites = findIdentityDomWrites(clientSource, functions)
+    .filter(flag => flag.functionName === 'placeList')
+  assert.deepEqual(mapWrites.map(flag => flag.text), [
+    "residentNode(place.owner, 'place-owner-resident',",
+  ])
+  const mapFunction = functions.find(fn => fn.name === 'placeList')!
+  assert.match(functionBody(clientSource, mapFunction), /occupantLine\(place, occupants,/u)
 })
 
 test('the allow-list carries no stale entries: every listed function still has a flagged DOM write', () => {

--- a/test/window-viewer-tests/directory-and-place.test.ts
+++ b/test/window-viewer-tests/directory-and-place.test.ts
@@ -179,7 +179,13 @@ export function registerWindowDirectoryAndPlaceTests(): void {
     assert.match(WINDOW_JS, /rawPlace\.front_matter/)
     assert.match(WINDOW_JS, /place\.purpose/)
     assert.match(WINDOW_JS, /place\.front_matter/)
-    assert.match(WINDOW_JS, /place\.front_matter\.map\(/)
+    assert.equal(WINDOW_JS.match(/place\.front_matter\.map\(/gu)?.length, 1)
+    const mapRenderer = WINDOW_JS.slice(
+      WINDOW_JS.indexOf('function placeList('),
+      WINDOW_JS.indexOf('function mapRoots('),
+    )
+    assert.doesNotMatch(mapRenderer, /front_matter|quietRoomNotice/u)
+    assert.match(mapRenderer, /occupantLine\(/u)
     assert.match(WINDOW_JS, /link\.href\s*=\s*['"]\/window\/['"]\s*\+\s*kind\s*\+\s*['"]\/['"]\s*\+\s*String\(id\)/)
     assert.match(WINDOW_JS, /made by[\s\S]{0,600}currently owned by[\s\S]{0,600}UTF-8 bytes/iu)
     assert.doesNotMatch(WINDOW_JS, /front_matter\.(?:sort|toSorted|reverse|splice)\(/)


### PR DESCRIPTION

Map count summaries could squeeze place names and keeper handles until words split across lines. Keep words intact, let counts wrap, and move counts below the name and keeper when each card is narrow, including nested branches. Wide cards retain the existing arrangement.

Remove selected thing headings and their quiet-room replacement from Map cards. Resident chips, sleeper controls, resident quiet notices, Place-tab front matter, Live, Things, and API payloads remain unchanged. Remove the unused Map thing styles, correct one window sentence in SYSTEM_DESIGN, and add the 2026-09-09 human changelog sentence with its generated mirror.

Validation:

- `npm run typecheck`, `npm run door:check`, and `node --experimental-strip-types scripts/check-refusal-census.ts`: passed; `node scripts/embed-changelog.mjs` completed and `git diff --check` passed.
- `npm test`: 2,272 passed, 1 failed, 1 skipped out of 2,274. The failure is `test/embed-door.test.ts:151`: its nested Git read rejects this checkout as owned by `Owner` while the test runs as `CodexSandboxOffline`. The existing skip is the POSIX permission test on Windows. Git configuration was not changed.
- `npx playwright test e2e/map-cards.spec.ts e2e/public-window.spec.ts e2e/public-window-interactions.spec.ts e2e/window-calm.spec.ts e2e/quiet-room-leak-scan.spec.ts`: 113 passed, 0 failed, 0 skipped, using `E2E_PORT=41747`. Windows server teardown hung after all tests; only this run's verified server process was stopped, and Playwright then returned exit 0.
- The new geometry regression measures each rendered word's Range rectangles at 320, 375, 768, 830, 1024, 1280, and 1440 pixels, including nested cards and both plain and followable keepers. It detects word splitting, overlap with counts, and overflow; it also checks counts below on cramped cards and beside names at 1440. It reproduced the original split in “Submission” at 1024 before the fix. Visual checks at 320, 830, and 1440 also passed.
- Independent review found no remaining issues. Existing Place front-matter and resident/sleeper behavior checks remain; the quiet DOM inventory now explicitly pins the public keeper as Map's only direct identity write and retains occupant filtering.

Local evidence: `map-cards-npm-test-final.log`, `map-cards-playwright-final.log`, and `map-cards-320.png`, `map-cards-830.png`, `map-cards-1440.png` sit beside this file. The earlier unrelated redirect-test timeout passed both an isolated retry and the final full suite.

Changes remain in the working tree. No commit, push, deployment, or production verification was performed. The unchanged Live spec and shared snapshot fixture contained no Map-heading expectation requiring edits. API front matter and decision rows were not changed.

NOT done: the required full local suite is still red because of the Git ownership restriction; rerun it from the authorized checkout environment before release.


---

Orchestrator: built by the Astra lane from two owner screenshots of the Map tab on a wide phone (2026-09-09): names and handles breaking inside words, and things showing on some cards only. The things were owner-chosen front matter; per the owner they leave the Map tab and stay on the Place tab and in the API. Resident chips stay (the map is who is standing where). Gate on 5132881: typecheck ok; unit ℹ pass 2273 ℹ fail 0 ; door:check ok; refusal census ok; window specs 261passed(6.5m). Merge on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Merge note (orchestrator, 2026-09-09 11:50Z): GitHub Actions created no run for this pull request (neither the opened event nor the empty-commit synchronize b7d59bd; the check suite for the head has no github-actions entry, while the live repo triggered normally minutes later). As the substitute, the full end-to-end suite ran locally on this head: 279 passed, 2 flaky (passed on retry), plus the unit gate above. The push-to-main run after merge is the next CI signal.
