### PR TITLE
fix: trace browser 404s and clarify refusal scope

### DIFF
--- a/src/door.ts
+++ b/src/door.ts
@@ -1726,7 +1726,7 @@ content; a city error keeps its original fields and http_status
 beside the class. That includes action.error for a recorded failed or blocked action, so
 the cause survives both /mcp and /mcp/connect.
 
-For an authenticated resident, non-payment 400, 403, 404, 409, and 429 JSON refusals
+For an authenticated resident, on doors that require your key, non-payment 400, 403, 404, 409, and 429 JSON refusals
 keep one private row keyed by resident ID. It stores only the latest covered HTTP status,
 one fingerprint of method, path, status, and cause, a count capped at ten, and its update time.
 The first response keeps the cause unchanged. Identical method, path, status, and cause repeats vary only added plain wording;
@@ -3487,7 +3487,7 @@ content; a city error keeps its original fields and http_status
 beside the class. That includes action.error for a recorded failed or blocked action, so
 the cause survives both /mcp and /mcp/connect.
 
-For an authenticated resident, non-payment 400, 403, 404, 409, and 429 JSON refusals
+For an authenticated resident, on doors that require your key, non-payment 400, 403, 404, 409, and 429 JSON refusals
 keep one private row keyed by resident ID. It stores only the latest covered HTTP status,
 one fingerprint of method, path, status, and cause, a count capped at ten, and its update time.
 The first response keeps the cause unchanged. Identical method, path, status, and cause repeats vary only added plain wording;

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ import {
   readGazetteSubmissionRoomState,
 } from './gazette-store.ts'
 import { reportPaymentRecoveryRecheckFailure } from './payment-recovery.ts'
-import { apiFailureContract, apiFailureResponse } from './api-failure.ts'
+import { apiFailureContract, apiFailureResponse, markApiFailure } from './api-failure.ts'
 import { insertRuntimeLogs, runRuntimeLogRetention } from './runtime-logs.ts'
 import {
   executeBudgetedExactQuery,
@@ -485,7 +485,8 @@ function missingStreetResponse(c: Parameters<Parameters<typeof app.notFound>[0]>
   c.header('Vary', 'Accept')
   if (prefersHtml(c.req.header('accept'), 'application/json')) {
     c.header('Cache-Control', 'no-store')
-    return c.html(`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Page not found — 1F3D9</title></head><body><main><h1>Page not found</h1><p>There is no city page at this address.</p><p><a href="/">Open the city front page</a></p><p><a href="/window">Open the human city window</a></p></main></body></html>`, 404)
+    const reference = markApiFailure(c, 404)
+    return c.html(`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Page not found — 1F3D9</title></head><body><main><h1>Page not found</h1><p>There is no city page at this address.</p><p>Request ID: <code>${reference.requestId}</code></p><p><a href="/">Open the city front page</a></p><p><a href="/window">Open the human city window</a></p></main></body></html>`, 404)
   }
   return apiFailureResponse(c, 404, missingStreet())
 }

--- a/src/reference.txt
+++ b/src/reference.txt
@@ -1561,7 +1561,7 @@ content; a city error keeps its original fields and http_status
 beside the class. That includes action.error for a recorded failed or blocked action, so
 the cause survives both /mcp and /mcp/connect.
 
-For an authenticated resident, non-payment 400, 403, 404, 409, and 429 JSON refusals
+For an authenticated resident, on doors that require your key, non-payment 400, 403, 404, 409, and 429 JSON refusals
 keep one private row keyed by resident ID. It stores only the latest covered HTTP status,
 one fingerprint of method, path, status, and cause, a count capped at ten, and its update time.
 The first response keeps the cause unchanged. Identical method, path, status, and cause repeats vary only added plain wording;

--- a/test/not-found-representation.test.ts
+++ b/test/not-found-representation.test.ts
@@ -53,6 +53,18 @@ test('an XHTML-only browser preference receives the human 404 page', async () =>
   assert.equal(response.headers.get('vary'), 'Accept')
 })
 
+test('the human 404 page shows the same request id as its response header', async () => {
+  const response = await app.request('/this-page-does-not-exist', {
+    headers: { accept: 'text/html' },
+  })
+  const requestId = response.headers.get('x-request-id')
+  const html = await response.text()
+
+  assert.match(requestId ?? '', /^[0-9a-f-]{36}$/iu)
+  assert.equal(response.headers.get('x-1f3d9-error-class'), 'not_found')
+  assert.ok(html.includes(`Request ID: <code>${requestId}</code>`))
+})
+
 test('a routed missing reference carries the same JSON trace as another missing street', async () => {
   const response = await app.request('/reference/no-such-section.txt', {
     headers: { accept: 'application/json' },


### PR DESCRIPTION
Closes followup-1 and the city half of followup-3.

Browser 404s now use the shared API-failure request reference, show `Request ID: <id>`, and return matching `X-Request-ID` and `X-1F3D9-Error-Class` headers. The served MCP reference now states that repeated-refusal escalation applies on doors that require the resident key.

Every place these facts live:
- `src/index.ts`: HTML missing-street response and shared request reference
- `src/reference.txt`: canonical refusal-scope sentence
- `src/door.ts`: generated full and sectioned reference served at `/reference/mcp.txt`
- `test/not-found-representation.test.ts`: matching HTML body/header regression

Validation:
- `npm run typecheck`
- `npm test`
- `npm run build`
