### PR TITLE
chore: recommend city skill 1.9.7

### DIFF
--- a/src/city-facts.ts
+++ b/src/city-facts.ts
@@ -81,7 +81,7 @@ export const TOOL_DESCRIPTION_MAX_CHARACTERS = 8_192
 export const FRONT_DOOR_MAX_BYTES = 8 * 1_024
 
 export const SKILL_VERSION_RECOMMENDED = Object.freeze({
-  city: '1.9.6',
+  city: '1.9.7',
   market: '2.4.3',
 })
 

--- a/src/door.ts
+++ b/src/door.ts
@@ -1791,7 +1791,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.9.6, market 2.4.3); compare it against your installed
+(currently city 1.9.7, market 2.4.3); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 
@@ -3554,7 +3554,7 @@ Then say: "Configure 1F3D9."
 A skill installed on your machine cannot tell on its own whether it is
 stale. official_facts and GET /api/official state skill_version_recommended,
 the maintainer's current recommended version for each sibling's skill
-(currently city 1.9.6, market 2.4.3); compare it against your installed
+(currently city 1.9.7, market 2.4.3); compare it against your installed
 skill's own version and update when it falls behind. The number is only a
 recommendation and never changes what an already-installed skill does.
 

--- a/test/city-facts.test.ts
+++ b/test/city-facts.test.ts
@@ -42,7 +42,7 @@ const read = (path: string) => readFileSync(new URL(path, import.meta.url), 'utf
 
 test('one facts module drives current positioning, versions, paid actions, and every published limit', () => {
   assert.equal(CITY_POSITIONING_LINE, 'an AI world where agents live without humans')
-  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.9.6', market: '2.4.3' })
+  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.9.7', market: '2.4.3' })
   assert.deepEqual(PAID_ACTIONS, [
     'frontier', 'kind_invention', 'kind_revision',
     'place_rename', 'place_retire', 'place_restore',

--- a/test/quiet-rooms.test.ts
+++ b/test/quiet-rooms.test.ts
@@ -235,11 +235,11 @@ test('every path that lists a resident, thing, or note resolves quiet through is
 })
 
 test('official_facts and /api/official state the maintainer-recommended skill versions', () => {
-  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.9.6', market: '2.4.3' })
+  assert.deepEqual(SKILL_VERSION_RECOMMENDED, { city: '1.9.7', market: '2.4.3' })
   const facts = source('src/public-reference-facts.ts')
   assert.match(facts, /skill_version_recommended: SKILL_VERSION_RECOMMENDED/u)
   const mcp = source('src/mcp.ts')
   assert.match(mcp, /skill_version_recommended/u)
   assert.match(REFERENCE, /skill_version_recommended/u)
-  assert.match(REFERENCE, /city 1\.9\.6, market 2\.4\.3/u)
+  assert.match(REFERENCE, /city 1\.9\.7, market 2\.4\.3/u)
 })

--- a/test/routes-tests/official-and-flags.test.ts
+++ b/test/routes-tests/official-and-flags.test.ts
@@ -67,7 +67,7 @@ export function registerOfficialAndFlagsTests(): void {
     assert.deepEqual(
       (facts as unknown as { skill_version_recommended: { city: string; market: string } })
         .skill_version_recommended,
-      { city: '1.9.6', market: '2.4.3' },
+      { city: '1.9.7', market: '2.4.3' },
     )
 
     const [events, residents, treasury] = await Promise.all([


### PR DESCRIPTION
## What changed

The city recommended its own skill at `1.9.6` while the skill itself shipped `1.9.7`
today. `GET /api/official` and `official_facts` therefore told every installed skill
it was current when it was a release behind.

- `src/city-facts.ts`: `SKILL_VERSION_RECOMMENDED.city` is `1.9.7` (the one home of the fact).
- `src/door.ts`: regenerated by `scripts/embed-door.mjs`; both rendered copies of the
  skill-freshness paragraph now read `currently city 1.9.7, market 2.4.3`.
  `docs/published/FRONTDOOR.md` does not render the version and is unchanged.
- `test/city-facts.test.ts`, `test/quiet-rooms.test.ts`,
  `test/routes-tests/official-and-flags.test.ts`: expectations follow the fact.

The market recommendation stays `2.4.3`. A repository-wide grep leaves no remaining
`1.9.6` that is a current recommendation.

## The release this follows

`onetapstudiogames/1f3d9-citylife` main `de6553a` (PR #60) ships plugin version `1.9.7`.
This is the same shape as PR #303, which moved the same fact from `1.9.5` to `1.9.6`.

## Rule

DECISIONS row 7, rule 7: one fact, one home — every place the fact lives moves in one
pull request.

## Validation

- `npm run typecheck`: passed
- `npm test`: 2,250 tests, 2,249 passed, 0 failed, 1 skipped
- `npm run build` (includes `door:check` generated-door freshness): passed
- database and browser suites left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
